### PR TITLE
fix: include character description in prompt

### DIFF
--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -5367,11 +5367,16 @@ class ChatService extends ChangeNotifier {
   /// When evolution exists, returns a layered block: original as foundation,
   /// evolved traits as additive growth. This prevents contradictions.
   String _getEffectivePersonality(CharacterCard card) {
-    if (!_storageService.characterEvolutionEnabled) return card.personality;
+    // Combine description (physical traits, background) with personality
+    final base = [
+      if (card.description.isNotEmpty) card.description,
+      if (card.personality.isNotEmpty) card.personality,
+    ].join('\n');
+    if (!_storageService.characterEvolutionEnabled) return base;
     final evolved = _evolvedPersonalities[_getCharacterIdFromCard(card)];
-    if (evolved == null || evolved.isEmpty) return card.personality;
+    if (evolved == null || evolved.isEmpty) return base;
     // Layered: original is ground truth, evolved is additive growth
-    return '${card.personality}\n\n'
+    return '$base\n\n'
         '[Character Growth — the following reflects how ${card.name} has changed through interactions. '
         'These traits build on the original personality above. If there is a contradiction, '
         'the growth represents genuine character development, not a replacement of core identity.]\n'


### PR DESCRIPTION
## Problem
Characters lose their physical appearance, background, and defining traits during conversation. The model doesn't know what the character looks like, their age, occupation, or other attributes defined on the card — leading to wildly inconsistent and out-of-character responses.

This happens because the character card `description` field is never included in the LLM prompt. Many cards (especially imports from SillyTavern/Backyard AI) put the core character definition in `description` rather than `personality`, so the model never sees it.

## Fix
Prepend the `description` field to the persona block via `_getEffectivePersonality()`. This is the single function all prompt assembly paths use (single chat, group chat, impersonate, story pipeline), so the fix covers everything.

When `description` is empty, nothing changes. When both `description` and `personality` are present, both appear in the persona block.

## Test plan
- [ ] Load a character card where traits are defined in `description` (not `personality`) — verify the model now reflects those traits
- [ ] Load a character with both `description` and `personality` filled — verify both appear in the persona block
- [ ] Load a character with empty `description` — verify no blank lines or changes in behavior
- [ ] Test with character evolution enabled — verify evolved traits still append correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)