### PR TITLE
fix: safe double-to-int coercion in story model fromJson methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local dev tools
+build_and_deploy.ps1
+
 # Miscellaneous
 *.class
 *.log

--- a/lib/models/story_project.dart
+++ b/lib/models/story_project.dart
@@ -108,8 +108,8 @@ class StoryLoreEntry {
     topic: json['topic'] ?? '',
     detail: json['detail'] ?? '',
     relatedTo: (json['related_to'] as List?)?.map((e) => e.toString()).toList() ?? [],
-    validFromAct: json['valid_from_act'] ?? 1,
-    validFromScene: json['valid_from_scene'] ?? 1,
+    validFromAct: (json['valid_from_act'] as num?)?.toInt() ?? 1,
+    validFromScene: (json['valid_from_scene'] as num?)?.toInt() ?? 1,
   );
 }
 
@@ -174,7 +174,7 @@ class StoryAct {
   };
 
   factory StoryAct.fromJson(Map<String, dynamic> json) => StoryAct(
-    number: json['number'] ?? 1,
+    number: (json['number'] as num?)?.toInt() ?? 1,
     title: json['title'] ?? '',
     description: json['description'] ?? '',
     focusThreadIds: (json['focus_thread_ids'] as List?)?.map((e) => e.toString()).toList() ?? [],
@@ -234,13 +234,13 @@ class StoryScene {
   };
 
   factory StoryScene.fromJson(Map<String, dynamic> json) => StoryScene(
-    number: json['number'] ?? 1,
+    number: (json['number'] as num?)?.toInt() ?? 1,
     title: json['title'] ?? '',
     description: json['description'] ?? '',
     activeThreadIds: (json['active_thread_ids'] as List?)?.map((e) => e.toString()).toList() ?? [],
     location: json['location'] ?? '',
     castNames: (json['cast_names'] as List?)?.map((e) => e.toString()).toList() ?? [],
-    valence: json['valence'] ?? 0,
+    valence: (json['valence'] as num?)?.toInt() ?? 0,
     causality: json['causality'] != null
         ? SceneCausality.fromJson(json['causality'])
         : SceneCausality(),
@@ -275,12 +275,12 @@ class StoryBeat {
   };
 
   factory StoryBeat.fromJson(Map<String, dynamic> json) => StoryBeat(
-    number: json['number'] ?? 1,
+    number: (json['number'] as num?)?.toInt() ?? 1,
     type: json['type'] ?? 'Action',
     description: json['description'] ?? '',
     emotionalShift: json['emotional_shift'] ?? '',
-    valence: json['valence'] ?? 0,
-    pacing: json['pacing'] ?? 1,
+    valence: (json['valence'] as num?)?.toInt() ?? 0,
+    pacing: (json['pacing'] as num?)?.toInt() ?? 1,
   );
 }
 


### PR DESCRIPTION
## Description

LLMs sometimes return numeric fields as doubles (e.g. `1.0`) instead of ints. Dart's type system rejects a direct `double` assignment to an `int` field, causing a runtime crash:

```
type 'double' is not a subtype of type 'int'
```

This was reproducible when generating beats within a story act.

## Changes

Updated `fromJson` methods in `lib/models/story_project.dart` to use `(json['field'] as num?)?.toInt() ?? default` instead of `json['field'] ?? default` for all integer fields:

- `StoryBeat`: `number`, `valence`, `pacing`
- `StoryScene`: `number`, `valence`
- `StoryAct`: `number`
- `StoryLoreEntry`: `valid_from_act`, `valid_from_scene`

## Type of Change
- [x] Bug fix

## Testing
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests passed
- [x] Manual testing: beat and act generation confirmed working after fix

## Checklist
- [x] Code follows style guidelines
- [x] Linting passes
- [x] Tests pass
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)