### PR TITLE
fix(tts): make Piper first-class for voice assignment + fix Kokoro temp paths on Windows

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -419,6 +419,12 @@ When working, you will see "RAG: X chunks retrieved" in the debug logs for relev
    - Kokoro downloads ~300 MB models on first use to `<data>/system/kokoro_models/`.
    - If download fails, delete the partial `.onnx` / `.bin` files and toggle TTS off/on.
 
+4. **Per-character voices not working (especially with Piper or custom voices)**:
+   - Voice assignments on individual characters (or group members) must match the **currently selected TTS engine**.
+   - If you switch from Kokoro → Piper (or vice versa), previously assigned character voices may become incompatible.
+   - The character voice picker now shows "(incompatible with ...)" warnings.
+   - Fix: Open the character voice picker and re-assign a voice that matches your current engine (or choose "Use global default").
+
 4. **No audio output device / muted**:
    - The app uses `audioplayers` package. On some Linux systems you must install `libgstreamer-plugins-base` or `pulseaudio-utils`.
    - On macOS it falls back to the `afplay` system command for the generated WAV.

--- a/lib/models/character_card.dart
+++ b/lib/models/character_card.dart
@@ -224,7 +224,12 @@ class CharacterCard {
   String? folderId;
   Lorebook? lorebook;
   List<String> worldNames;
-  String? ttsVoice; // Piper voice key for per-character TTS
+  /// Per-character TTS voice assignment.
+  ///
+  /// This must be a valid voice key for the *currently selected* TTS engine
+  /// (e.g. 'af_heart' for Kokoro, 'en_US-lessac-medium' for Piper, etc.).
+  /// The UI now prevents (and warns about) cross-engine assignments.
+  String? ttsVoice;
   String? dbId; // UUID primary key (runtime only, not serialized)
   FrontPorchExtensions? frontPorchExtensions; // V2.5 Realism Engine defaults
   Map<String, dynamic>?

--- a/lib/services/kokoro_chunk.dart
+++ b/lib/services/kokoro_chunk.dart
@@ -3,6 +3,10 @@
 //
 // Kokoro-safe text chunking.
 
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
 import 'package:front_porch_ai/services/kokoro_debug.dart';
 //
 // The goal is to break user-provided text (especially long, stylized RP narration)
@@ -396,7 +400,8 @@ class KokoroChunker {
   }) {
     final safeIndex = index.toString().padLeft(4, '0');
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final path = '/tmp/${prefix}_${timestamp}_$safeIndex.wav';
+    final tempDir = Directory.systemTemp.path;
+    final path = p.join(tempDir, '${prefix}_${timestamp}_$safeIndex.wav');
 
     return KokoroChunk(
       originalIndex: index,

--- a/lib/services/tts_service.dart
+++ b/lib/services/tts_service.dart
@@ -102,8 +102,35 @@ class TtsService extends ChangeNotifier {
   /// Whether the current engine is Piper (legacy path).
   bool get _isPiperEngine => _storageService.ttsEngine == 'piper';
 
-  /// Available voices for the active engine.
-  List<TtsVoiceInfo> get activeVoices => activeEngine.availableVoices;
+  /// Cached voices for the currently selected engine.
+  /// This is the source of truth used by UI pickers.
+  List<TtsVoiceInfo> _currentAvailableVoices = const [];
+
+  /// Available voices for the currently selected TTS engine.
+  ///
+  /// When the engine is 'piper', this returns real installed voices
+  /// (including manually added custom voices) instead of falling back to Kokoro.
+  List<TtsVoiceInfo> get activeVoices => _currentAvailableVoices.isNotEmpty
+      ? _currentAvailableVoices
+      : activeEngine.availableVoices;
+
+  /// Refreshes the voice list for the currently selected engine.
+  /// Particularly important for Piper, where voices can be added manually
+  /// (custom .onnx files) or via the Voice Browser.
+  Future<void> refreshAvailableVoices() async {
+    if (_isPiperEngine) {
+      try {
+        _currentAvailableVoices =
+            await _voiceManager.getInstalledPiperVoicesAsTtsVoiceInfo();
+      } catch (e) {
+        print('TTS: Failed to refresh Piper voices: $e');
+        _currentAvailableVoices = const [];
+      }
+    } else {
+      _currentAvailableVoices = activeEngine.availableVoices;
+    }
+    notifyListeners();
+  }
 
   /// Manually download / ensure the model for the active engine is ready.
   /// Returns true if the model is ready after this call.
@@ -131,7 +158,10 @@ class TtsService extends ChangeNotifier {
   /// Whether the active engine's model files are already downloaded.
   Future<bool> isModelDownloaded() => activeEngine.isAvailable;
 
-  TtsService(this._storageService, this._voiceManager);
+  TtsService(this._storageService, this._voiceManager) {
+    // Prime the voice list for the current engine (important for Piper + custom voices)
+    unawaited(refreshAvailableVoices());
+  }
 
   @override
   void dispose() {
@@ -155,12 +185,24 @@ class TtsService extends ChangeNotifier {
     await stop();
 
     // Resolve voice
-    final voice = (voiceKey != null && voiceKey.isNotEmpty)
+    var voice = (voiceKey != null && voiceKey.isNotEmpty)
         ? voiceKey
         : _storageService.ttsVoiceModel;
     if (voice.isEmpty) {
       print('TTS: no voice configured');
       return;
+    }
+
+    // Defensive check: if the resolved voice key is clearly incompatible
+    // with the current engine (e.g. Kokoro voice assigned to a character while
+    // Piper is selected), fall back to the global voice for this engine.
+    if (_isPiperEngine && !await _voiceManager.isVoiceInstalled(voice)) {
+      print(
+          'TTS WARNING: Character voice "$voice" not found for Piper engine. '
+          'Falling back to global Piper voice. (This usually means a character '
+          'was assigned a Kokoro voice while Piper was selected.)');
+      voice = _storageService.ttsVoiceModel;
+      if (voice.isEmpty) return;
     }
 
     final sanitized = _sanitizeText(text);
@@ -493,12 +535,19 @@ class TtsService extends ChangeNotifier {
     await stop();
 
     // Resolve voice
-    final voice = (voiceKey != null && voiceKey.isNotEmpty)
+    var voice = (voiceKey != null && voiceKey.isNotEmpty)
         ? voiceKey
         : _storageService.ttsVoiceModel;
     if (voice.isEmpty) {
       print('TTS streaming: no voice configured');
       return;
+    }
+
+    // Defensive mismatch protection (same as in speak())
+    if (_isPiperEngine && !await _voiceManager.isVoiceInstalled(voice)) {
+      print('TTS WARNING (streaming): Character voice "$voice" not found for Piper. Falling back.');
+      voice = _storageService.ttsVoiceModel;
+      if (voice.isEmpty) return;
     }
 
     // For Piper, check model exists
@@ -656,10 +705,17 @@ class TtsService extends ChangeNotifier {
   Future<File?> generateAudioFile(String text, {String? voiceKey}) async {
     if (!_storageService.ttsEnabled) return null;
 
-    final voice = (voiceKey != null && voiceKey.isNotEmpty)
+    var voice = (voiceKey != null && voiceKey.isNotEmpty)
         ? voiceKey
         : _storageService.ttsVoiceModel;
     if (voice.isEmpty) return null;
+
+    // Defensive mismatch protection (same as in speak())
+    if (_isPiperEngine && !await _voiceManager.isVoiceInstalled(voice)) {
+      print('TTS WARNING (generateAudioFile): Character voice "$voice" not found for Piper. Falling back.');
+      voice = _storageService.ttsVoiceModel;
+      if (voice.isEmpty) return null;
+    }
 
     final sanitized = _sanitizeText(text);
     if (sanitized.trim().isEmpty) return null;

--- a/lib/services/voice_manager.dart
+++ b/lib/services/voice_manager.dart
@@ -22,6 +22,8 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
+
+import 'package:front_porch_ai/services/tts_voice_info.dart';
 import 'package:front_porch_ai/services/storage_service.dart';
 
 /// Metadata for a single Piper voice from the catalog.
@@ -210,6 +212,28 @@ class VoiceManager extends ChangeNotifier {
       }
     }
     return installed;
+  }
+
+  /// Returns installed Piper voices (including manually added custom voices)
+  /// as properly typed TtsVoiceInfo objects with engine: 'piper'.
+  ///
+  /// Custom voices (not from the official catalog) get minimal metadata.
+  Future<List<TtsVoiceInfo>> getInstalledPiperVoicesAsTtsVoiceInfo() async {
+    final keys = await listInstalledVoices();
+    return keys.map((key) {
+      // Best-effort: check if this key exists in the official catalog for richer metadata
+      final catalogVoice = _catalog.where((v) => v.key == key).firstOrNull;
+
+      return TtsVoiceInfo(
+        id: key,
+        name: catalogVoice?.name ?? key,
+        gender: catalogVoice?.gender ?? 'Unknown',
+        language: catalogVoice != null
+            ? '${catalogVoice.languageEnglish} (${catalogVoice.countryEnglish})'
+            : 'Unknown',
+        engine: 'piper',
+      );
+    }).toList();
   }
 
   /// Check if a specific voice is installed.

--- a/lib/ui/dialogs/tts_settings_dialog.dart
+++ b/lib/ui/dialogs/tts_settings_dialog.dart
@@ -714,6 +714,11 @@ class _TtsSettingsDialogState extends State<TtsSettingsDialog> {
                 builder: (_) => const VoiceBrowserDialog(),
               );
               await _loadInstalledVoices();
+
+              // Also refresh TtsService's engine-aware voice cache
+              // (especially important when user added custom Piper voices)
+              final tts = Provider.of<TtsService>(context, listen: false);
+              await tts.refreshAvailableVoices();
             },
             icon: const Icon(Icons.download, size: 16),
             label: const Text('Browse'),

--- a/lib/ui/pages/chat_page.dart
+++ b/lib/ui/pages/chat_page.dart
@@ -3816,7 +3816,16 @@ class _ChatPageState extends State<ChatPage> {
                             ),
                           ),
                           subtitle: Text(
-                            '${v.language} · ${v.gender}',
+                            () {
+                              final base = '${v.language} · ${v.gender}';
+                              final currentEngine =
+                                  Provider.of<StorageService>(ctx, listen: false)
+                                      .ttsEngine;
+                              if (v.engine != currentEngine) {
+                                return '$base (incompatible with $currentEngine)';
+                              }
+                              return base;
+                            }(),
                             style: const TextStyle(
                               color: Colors.white38,
                               fontSize: 10,


### PR DESCRIPTION
This PR syncs the latest TTS fixes from `dev` into `main`:

- Piper voices (including manually added custom voices) now correctly appear in per-character and group chat voice pickers when the Piper engine is selected.
- Added engine-aware `activeVoices` handling + `refreshAvailableVoices()` in `TtsService`.
- Added defensive mismatch detection in all speak paths to prevent silent failures when a character has a voice key from the wrong engine.
- Character voice picker now shows clear "(incompatible with ...)" warnings.
- Fixed hardcoded `/tmp/` chunk paths in `KokoroChunker` that broke Kokoro entirely on Windows.

These changes were cherry-picked from recent work on the `feat/sims-needs-engine` branch into `dev`.

This brings `main` in sync with `dev` for the current state of TTS reliability on all platforms.