### PR TITLE
Fix: broken chat side panel

### DIFF
--- a/lib/models/character_card.dart
+++ b/lib/models/character_card.dart
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
 
-import 'package:front_porch_ai/database/database.dart' show AvatarImage;
+import 'package:front_porch_ai/models/avatar_image.dart';
 import 'package:front_porch_ai/models/lorebook.dart';
 
 import 'package:flutter/material.dart';

--- a/lib/services/character_repository.dart
+++ b/lib/services/character_repository.dart
@@ -29,7 +29,8 @@ import 'package:front_porch_ai/services/v2_card_service.dart';
 import 'package:front_porch_ai/services/world_repository.dart';
 import 'package:front_porch_ai/services/cloud_sync_service.dart';
 import 'package:front_porch_ai/services/storage_service.dart';
-import 'package:front_porch_ai/database/database.dart';
+import 'package:front_porch_ai/models/avatar_image.dart';
+import 'package:front_porch_ai/database/database.dart' hide AvatarImage;
 import 'package:image/image.dart' as img;
 
 class CharacterRepository extends ChangeNotifier {
@@ -147,11 +148,21 @@ class CharacterRepository extends ChangeNotifier {
         // Load avatar images from DB so they survive hot reloads
         if (card.dbId != null) {
           try {
-            final avatars = await _db.getAvatarImagesByCharacterId(card.dbId!);
-            if (avatars.isNotEmpty) {
-              card.avatarImages = avatars;
+            final driftAvatars =
+                await _db.getAvatarImagesByCharacterId(card.dbId!);
+            if (driftAvatars.isNotEmpty) {
+              card.avatarImages = driftAvatars
+                  .map((a) => AvatarImage(
+                        id: a.id,
+                        characterId: a.characterId,
+                        filename: a.filename,
+                        label: a.label,
+                        displayOrder: a.displayOrder,
+                        createdAt: a.createdAt,
+                      ))
+                  .toList();
               debugPrint(
-                '[CharacterRepository] Loaded ${avatars.length} avatar images for ${card.name}',
+                '[CharacterRepository] Loaded ${card.avatarImages!.length} avatar images for ${card.name}',
               );
             }
           } catch (e) {
@@ -756,7 +767,18 @@ class CharacterRepository extends ChangeNotifier {
   /// Get all avatar images for a character from the database.
   Future<List<AvatarImage>> getAvatarImages(String characterId) async {
     try {
-      return await _db.getAvatarImagesByCharacterId(characterId);
+      final driftAvatars =
+          await _db.getAvatarImagesByCharacterId(characterId);
+      return driftAvatars
+          .map((a) => AvatarImage(
+                id: a.id,
+                characterId: a.characterId,
+                filename: a.filename,
+                label: a.label,
+                displayOrder: a.displayOrder,
+                createdAt: a.createdAt,
+              ))
+          .toList();
     } catch (e) {
       debugPrint('[CharacterRepository] Failed to get avatar images: $e');
       return [];

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -36,7 +36,7 @@ import 'package:front_porch_ai/services/group_chat_repository.dart';
 import 'package:front_porch_ai/models/character_card.dart';
 import 'package:front_porch_ai/models/chat_generation_settings.dart';
 import 'package:front_porch_ai/models/group_chat.dart';
-import 'package:front_porch_ai/models/avatar_image.dart' show AvatarImage;
+import 'package:front_porch_ai/models/avatar_image.dart';
 import 'package:front_porch_ai/services/group_turn_manager.dart';
 import 'package:front_porch_ai/models/lorebook.dart';
 import 'package:front_porch_ai/services/world_repository.dart';
@@ -2010,13 +2010,13 @@ class ChatService extends ChangeNotifier {
 
     final label = currentExpressionLabel;
     if (label == null) {
-      return (avatars
+      return avatars
               .where((a) => a.displayOrder + 1 == character.primeAvatarIndex)
               .isEmpty
           ? avatars.first
           : avatars.firstWhere(
               (a) => a.displayOrder + 1 == character.primeAvatarIndex,
-            )) as AvatarImage?;
+            );
     }
 
     // Find all avatars matching the current emotion label
@@ -2030,19 +2030,19 @@ class ChatService extends ChangeNotifier {
           .where((a) => a.label?.toLowerCase() == 'neutral')
           .toList();
       if (neutral.isNotEmpty) {
-        return neutral.first as AvatarImage?;
+        return neutral.first;
       }
-      return (avatars
+      return avatars
               .where((a) => a.displayOrder + 1 == character.primeAvatarIndex)
               .isEmpty
           ? avatars.first
           : avatars.firstWhere(
               (a) => a.displayOrder + 1 == character.primeAvatarIndex,
-            )) as AvatarImage?;
+            );
     }
 
     if (matches.length == 1) {
-      return matches.first as AvatarImage?;
+      return matches.first;
     }
 
     // Multiple matches — pick randomly, optionally avoiding the last one shown
@@ -2053,13 +2053,13 @@ class ChatService extends ChangeNotifier {
       if (different.isNotEmpty) {
         final picked = different[_expressionRandom.nextInt(different.length)];
         _lastExpressionAvatarId = picked.id;
-        return picked as AvatarImage?;
+        return picked;
       }
     }
 
     final picked = matches[_expressionRandom.nextInt(matches.length)];
     _lastExpressionAvatarId = picked.id;
-    return picked as AvatarImage?;
+    return picked;
   }
 
   /// Manually set an expression label (e.g., from /expression-set command).

--- a/lib/ui/dialogs/character_avatars_dialog.dart
+++ b/lib/ui/dialogs/character_avatars_dialog.dart
@@ -21,7 +21,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:archive/archive_io.dart';
-import 'package:front_porch_ai/database/database.dart' show AvatarImage;
+import 'package:front_porch_ai/models/avatar_image.dart';
 import 'package:front_porch_ai/models/character_card.dart';
 import 'package:front_porch_ai/services/character_repository.dart';
 import 'package:front_porch_ai/services/storage_service.dart';


### PR DESCRIPTION
- Chat side panel was shown as empty white  due to name collision/type mismatch bug (barrels import more than before, and tree-shaker only removes what is not used, not what used by mistake)