### PR TITLE
fix(group): forkToGroupChat created an empty group with no members

### DIFF
--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -2780,6 +2780,14 @@ class ChatService extends ChangeNotifier {
     );
     await groupRepo.save(group);
 
+    // Decoupled model: a group has no members until group_members rows exist.
+    // Create them for the original 1:1 character and every added character, or
+    // the group loads empty (and turn selection throws "No active group").
+    await _createGroupMember(group.id, _activeCharacter!);
+    for (final c in additionalCharacters) {
+      await _createGroupMember(group.id, c);
+    }
+
     // Create a new session for the group and copy all messages
     final newSessionId = DateTime.now().millisecondsSinceEpoch.toString();
     final copiedMessages = <MessagesCompanion>[];
@@ -2843,20 +2851,17 @@ class ChatService extends ChangeNotifier {
     return group;
   }
 
-  /// Add a character to the currently active group chat.
-  Future<bool> addCharacterToGroup(
+  /// Create a group member (decoupled model): copy the character's avatar into
+  /// the group's private storage and insert a group_members row.
+  /// Shared by [addCharacterToGroup] (live add) and [forkToGroupChat] (initial
+  /// membership when forking a 1:1 chat into a group).
+  Future<void> _createGroupMember(
+    String groupId,
     CharacterCard character,
-    GroupChatRepository groupRepo,
   ) async {
-    if (_activeGroup == null || _characterRepository == null) return false;
-    if (_isGenerating) return false;
-
-    // Live add for decoupled model (extends this existing addCharacterToGroup).
-    // Generalized duplicate for private avatar + AppDatabase insert for row (UUID).
-    // Reload from members + refresh. No new private methods.
     final mid = const Uuid().v4();
     final avDir = Directory(
-      path.join(_storageService.groupsDir.path, _activeGroup!.id, 'avatars'),
+      path.join(_storageService.groupsDir.path, groupId, 'avatars'),
     );
     await avDir.create(recursive: true);
 
@@ -2871,7 +2876,7 @@ class ChatService extends ChangeNotifier {
     await db.insertGroupMember(
       GroupMembersCompanion(
         id: drift.Value(mid),
-        groupId: drift.Value(_activeGroup!.id),
+        groupId: drift.Value(groupId),
         name: drift.Value(character.name),
         description: drift.Value(character.description),
         personality: drift.Value(character.personality),
@@ -2905,6 +2910,19 @@ class ChatService extends ChangeNotifier {
         memberState: drift.Value('{}'),
       ),
     );
+  }
+
+  /// Add a character to the currently active group chat.
+  Future<bool> addCharacterToGroup(
+    CharacterCard character,
+    GroupChatRepository groupRepo,
+  ) async {
+    if (_activeGroup == null || _characterRepository == null) return false;
+    if (_isGenerating) return false;
+
+    // Decoupled model: copy the character's avatar into the group's private
+    // storage and insert a group_members row. Shared with forkToGroupChat.
+    await _createGroupMember(_activeGroup!.id, character);
 
     await groupRepo.save(_activeGroup!);
 


### PR DESCRIPTION
## Description
Fixes "Fork to Group Chat" creating an empty group with no characters on Rawhide.

The decoupling refactor moved group membership to the `group_members` table (UUID rows + private avatar storage). `addCharacterToGroup` was updated for this, but `forkToGroupChat` was not — it created the GroupChat row, copied messages, and inserted the session, yet never created any `group_members`. So forking produced a memberless group; `setActiveGroup` loaded zero members and turn selection then threw "Bad state: No active group".

Fix: extract the member-creation logic (avatar duplication into the group's private storage + `insertGroupMember`) from `addCharacterToGroup` into a shared `_createGroupMember(groupId, card)` helper, and call it from `forkToGroupChat` for the original 1:1 character and every added character before `setActiveGroup`. `addCharacterToGroup` now delegates to the same helper — no parallel implementations.

## Type of Change
- [x] Bug fix

## Testing
- [x] `flutter analyze` clean
- [x] `flutter test` — no new failures (pre-existing Rawhide failures unchanged)
- [x] Manual: forked 1:1 -> group with 1 and 2 added characters; members + avatars populate, group loads and chats
- [ ] No unit test added: member creation is DB + filesystem bound (needs in-memory DB, character repo, temp storage) and this path is currently untested in the repo; verified manually instead.

## Checklist
- [x] Code follows style guidelines (matches surrounding style)
- [x] Linting passes
- [x] No new test failures
- [x] No breaking changes (refactor keeps addCharacterToGroup behavior identical)