### PR TITLE
test: realign stale assertions to green Rawhide CI

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-06-06 (Realign stale test assertions to green Rawhide CI — Tier 1)
+- Problem: Rawhide CI was red on every push. 4 of the 6 failures were stale tests asserting behavior that production code intentionally changed, not real regressions.
+- Root causes:
+  - `avatar_repository_test.dart`: asserted DB `schemaVersion == 29`; schema is now 32 (bumped 3× without updating the test).
+  - `chat_message_test.dart` (3 tests): the `ChatMessage` constructor now clamps an out-of-range `swipeIndex` to 0 (guards against corrupted DB rows, see chat_service.dart:188). The tests predated the clamp — they set `swipeIndex` beyond the `swipes` list and expected either a RangeError throw or metadata at the (now-clamped-away) index.
+- Changes (test-only, no production code):
+  - Schema assertion 29 → 32.
+  - "swipeIndex out of range" test rewritten to assert the new clamp-to-0 + no-throw behavior.
+  - "activeMetadata at current index" and "pads with nulls" tests given a `swipes` list long enough that their `swipeIndex` survives the clamp, preserving each test's original intent rather than weakening assertions.
+- Impact: 4 of 6 Rawhide failures fixed. The 2 remaining (Realism Engine seed 55→110 and one-shot delta false) are deliberately left for a separate branch — they may be real regressions in a parity-sensitive area.
+- Verification: `flutter test` on both files (50 pass); `flutter analyze` clean on both.
+- Files: `test/services/avatar_repository_test.dart`, `test/services/chat_message_test.dart`, `.claude/changelog.md`
+- Hygiene: New private methods: 0. Methods deleted: 0. Production code touched: none.
+
 ## 2026-06-03 (Thinking models: increase objective/task generation limits + robust stripping)
 - User report: "most models think way more than 600 tokens" for subtask generation. The previous 600 maxLength (and 1024 for completion checks) was insufficient once <think> reasoning is emitted before the final "Output ONLY a numbered list..." or "Answer only YES or NO".
 - Changes:

--- a/test/services/avatar_repository_test.dart
+++ b/test/services/avatar_repository_test.dart
@@ -50,8 +50,8 @@ void main() {
       await db.close();
     });
 
-    test('schema version is 29', () {
-      expect(db.schemaVersion, 29);
+    test('schema version is 32', () {
+      expect(db.schemaVersion, 32);
     });
 
     test('characters table has prime_avatar_index column', () async {

--- a/test/services/chat_message_test.dart
+++ b/test/services/chat_message_test.dart
@@ -64,7 +64,9 @@ void main() {
       expect(msg.swipes, isEmpty);
     });
 
-    test('swipeIndex out of range throws RangeError', () {
+    test('swipeIndex out of range is clamped to 0 instead of throwing', () {
+      // The constructor clamps an out-of-range swipeIndex to 0 to prevent
+      // RangeError crashes from corrupted DB rows or previous buggy state.
       final msg = ChatMessage(
         text: 'Hello',
         sender: 'Luna',
@@ -73,7 +75,8 @@ void main() {
         swipeIndex: 99,
       );
 
-      expect(() => msg.text, throwsRangeError);
+      expect(msg.swipeIndex, 0);
+      expect(msg.text, 'Hello');
     });
   });
 
@@ -277,6 +280,7 @@ void main() {
         text: 'Hello',
         sender: 'Luna',
         isUser: false,
+        swipes: ['Hello', 'Hi'],
         swipeMetadata: [
           null,
           {'swipeKey': 'swipeValue'},
@@ -313,6 +317,7 @@ void main() {
         text: 'Hello',
         sender: 'Luna',
         isUser: false,
+        swipes: ['Hello', 'Hi', 'Hey'],
         swipeMetadata: [null, null, null],
         swipeIndex: 2,
       );


### PR DESCRIPTION
## Summary

Rawhide CI is red on every push. Of the 6 failing tests, **4 were stale assertions** — tests asserting old behavior that production code intentionally changed, not real regressions. This PR realigns those 4. Test-only change; no production code touched.

## What was stale

- `avatar_repository_test.dart` — asserted Drift `schemaVersion == 29`; the schema is now **32** (three migrations landed without the test being updated). Bumped to 32.
- `chat_message_test.dart` (3 tests) — the `ChatMessage` constructor now clamps an out-of-range `swipeIndex` to 0 (guards against corrupted DB rows, `chat_service.dart:188`). The tests predated the clamp:
  - "swipeIndex out of range throws RangeError" → rewritten to assert the new safe contract (clamps to 0, resolves to `swipes[0]`, no throw).
  - "activeMetadata at current index" / "pads with nulls" → given a `swipes` list long enough that their `swipeIndex` stays valid, preserving the original test intent rather than weakening assertions.

## ⚠️ CI will still show 2 failures after this merge — expected

These two are **pre-existing on Rawhide** (not introduced here) and are **out of scope** for this PR. They live in the parity-sensitive Realism Engine and may be real regressions needing code fixes, so they're being tracked and fixed separately:

- `chat_service_realism_engine_test.dart` — V2.5 seeding (`expected 55, got 110`)
- `chat_service_realism_engine_test.dart` — one-shot dynamic deltas (`expected true, got false`)

Splitting keeps this safe, mechanical fix from being held hostage to that investigation.

## Verification
- `flutter test test/services/chat_message_test.dart test/services/avatar_repository_test.dart` → 50 pass
- `flutter analyze` → clean