### PR TITLE
test(realism): fix stale bond assertion left by the #47 port

### DIFF
--- a/test/services/chat_service_realism_engine_test.dart
+++ b/test/services/chat_service_realism_engine_test.dart
@@ -270,9 +270,11 @@ void main() {
           await chat.startNewChat();
 
           expect(chat.realismEnabled, isTrue);
-          // V2.5 seed path: shortTermBond 55 (<=150) migrates *2 via seedFromV2OrExt -> 110.
-          // (Trust 11 unaffected by bond migrate; longTerm would also *2 if present.)
-          expect(chat.relationshipService.affectionScore, 110);
+          // V2.5 card seed path: shortTermBond 55 is authored on the ±300 scale and
+          // seeds as-is (plain clamp, no *2). The legacy ±150→±300 migration only
+          // applies to persisted session loads, not fresh card seeds.
+          // (Trust 11 likewise seeds unchanged.)
+          expect(chat.relationshipService.affectionScore, 55);
           expect(chat.relationshipService.trustLevel, 11);
           if (chat.needsSimEnabled) {
             expect(chat.needsSimulation.vector, isNotEmpty);


### PR DESCRIPTION
## Description
A follow-up to the bond-doubling fix ported from #47 (`fe91830`): the full test suite is red on Rawhide because of one stale assertion the port missed.

The fix made V2.5 card-seeded bond seed as-is via plain clamp — card `shortTermBond` 55 now seeds as **55**, not the old doubled **110**. The port added a dedicated `relationship_service_test` asserting 55, but `chat_service_realism_engine_test` still asserted the pre-fix doubled value (110), so `flutter test` fails.

This realigns that expectation to 55 (matching production and the new dedicated test) and corrects the stale comment describing the old `*2` migration.

## Type of Change
- [x] Bug fix (test-only)

## Testing
- [x] `flutter analyze` clean
- [x] Full `flutter test` suite green across **3 consecutive runs** (`+1127`), confirming both the deterministic fix and no recurrence of the prior teardown-race flake (post dispose-guard)
- [x] Production behavior unchanged — test-only change

## Checklist
- [x] Code follows style guidelines
- [x] Linting passes
- [x] Tests pass (full suite green, repeated runs)
- [x] No breaking changes