### PR TITLE
feat(home): folder cards show a preview of the characters inside

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-06-12 (feat: folder character previews on the home screen)
+
+- **Files changed**: lib/ui/widgets/character_card_grid.dart, docs/Rawhide.md, .claude/changelog.md.
+- **Feature**: folder cards on the home grid render a 2×2 preview of the first up-to-4 member avatars instead of the generic folder icon. Empty folders still show the icon; folders with 1-3 members fill the remaining slots with subtle placeholders so the thumbnail stays square.
+- **Impl**: `_folderPreviewImages` maps the folder's filename references → matching library cards (by basename) → their real `imagePath`, resolved via the grid's existing `onResolveCharImage` (so characters stored in subdirs work too); `_buildFolderPreviewGrid` renders the 2×2. Preview size scales with card width (`maxWidth * 0.66`, clamped 56–170) so it tracks the grid-size setting. AppColors only; 2 new private helper methods, no dead code.
+- **Verification**: `flutter analyze` clean (full project); manual check on the home screen (empty / partial / full folders, varying grid sizes).
+- **Branch**: feat/folder-character-preview (off Rawhide).
+
 ## 2026-06-12 (fix: needs baseline sliders now respected on new chat)
 
 - **Files changed**: lib/services/chat/needs_simulation.dart (added `initializeFreshWithDefaults`), lib/services/chat_service.dart (3 call sites updated), test/services/chat/needs_simulation_test.dart (added test).

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -4,6 +4,8 @@ These notes feed the in-app "Update Available" dialog for Rawhide / cutting-edge
 
 ## Recent improvements
 
+- 📁 **Folder previews on the home screen** — folders now show a 2×2 thumbnail of the first few characters inside them instead of a plain folder icon, so you can tell at a glance what's in each one. The preview scales with your grid size; empty folders keep the classic folder icon.
+
 - 🔄 **Manual Needs Reprocessing** — you can now forcefully reprocess the Needs deltas of the latest AI message using the Director/Verifier. A new "Manual Reprocess" button sits below the Needs chips. Clicking it opens a dialog where you can enter a custom critique (e.g., "The character ate a granola bar and an energy drink"). The Realism Engine will then use your explicit feedback to reconstruct the scene's impacts on the character's Needs vector with the specified intensity scale. Look for the "✓ Director corrected (manual)" pill on the message once done!
 
 - 🐛 **Fixed missing Needs reactions from characters** — Needs levels (hunger, comfort, bladder, etc.) were no longer impacting the character's internal thoughts and roleplay due to a regression where the descriptive text prompts were accidentally abbreviated in the code. We've restored the full injection prompts so characters will now appropriately complain or struggle when their needs hit noticeable or critical levels.

--- a/lib/ui/widgets/character_card_grid.dart
+++ b/lib/ui/widgets/character_card_grid.dart
@@ -824,6 +824,71 @@ class CharacterCardGrid extends StatelessWidget {
     );
   }
 
+  /// Resolves up to [max] avatar image Files for the first characters in
+  /// [folder]. The folder stores filename references, so map each to the
+  /// matching library card to recover its real (possibly subdir'd) image path.
+  List<File> _folderPreviewImages(
+    BuildContext context,
+    CharacterFolder folder,
+    int max,
+  ) {
+    if (folder.characterPaths.isEmpty) return const [];
+    final repo = Provider.of<CharacterRepository>(context, listen: false);
+    final byFilename = <String, String>{};
+    for (final c in repo.characters) {
+      final p = c.imagePath;
+      if (p != null) byFilename.putIfAbsent(path.basename(p), () => p);
+    }
+    final files = <File>[];
+    for (final ref in folder.characterPaths) {
+      final full = byFilename[path.basename(ref)];
+      if (full != null) {
+        files.add(onResolveCharImage(full));
+        if (files.length >= max) break;
+      }
+    }
+    return files;
+  }
+
+  /// A 2x2 thumbnail grid of folder member avatars (iOS-style). Missing slots
+  /// render as subtle placeholders so the grid stays square for 1-3 members.
+  Widget _buildFolderPreviewGrid(
+    BuildContext context,
+    List<File> images,
+    double side,
+  ) {
+    const gap = 3.0;
+    final cell = (side - gap) / 2;
+    Widget tile(int i) {
+      final img = i < images.length ? images[i] : null;
+      return Container(
+        width: cell,
+        height: cell,
+        decoration: BoxDecoration(
+          color: AppColors.surfaceContainerOf(context),
+          borderRadius: BorderRadius.circular(6),
+          image: img != null
+              ? DecorationImage(image: FileImage(img), fit: BoxFit.cover)
+              : null,
+        ),
+      );
+    }
+
+    Widget row(int a, int b) => Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [tile(a), const SizedBox(width: gap), tile(b)],
+    );
+
+    return SizedBox(
+      width: side,
+      height: side,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [row(0, 1), const SizedBox(height: gap), row(2, 3)],
+      ),
+    );
+  }
+
   Widget _buildFolderCard(BuildContext context, CharacterFolder folder) {
     final charCount = folder.characterPaths.length;
 
@@ -856,18 +921,32 @@ class CharacterCardGrid extends StatelessWidget {
                 final isSmall = constraints.maxHeight < 200;
                 final isTiny = constraints.maxHeight < 140;
                 final iconSize = isTiny ? 32.0 : (isSmall ? 48.0 : 72.0);
+                // Scale the preview to the card width so it fills a real chunk
+                // of the card (and scales with the grid size) rather than a
+                // fixed thumbnail that looks tiny on larger cards.
+                final previewSide = (constraints.maxWidth * 0.66).clamp(
+                  56.0,
+                  170.0,
+                );
                 final fontSize = isTiny ? 11.0 : (isSmall ? 13.0 : 16.0);
+
+                // Preview the first few characters inside the folder (2x2).
+                // Empty folders fall back to the plain folder icon.
+                final previews = _folderPreviewImages(context, folder, 4);
 
                 return Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Icon(
-                      Icons.folder,
-                      size: iconSize,
-                      color: isHovering
-                          ? Colors.amber
-                          : AppColors.iconSecondary(context),
-                    ),
+                    if (previews.isEmpty)
+                      Icon(
+                        Icons.folder,
+                        size: iconSize,
+                        color: isHovering
+                            ? Colors.amber
+                            : AppColors.iconSecondary(context),
+                      )
+                    else
+                      _buildFolderPreviewGrid(context, previews, previewSide),
                     SizedBox(height: isTiny ? 4 : (isSmall ? 8 : 16)),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),


### PR DESCRIPTION
## Description
Folder cards on the home screen previously showed a generic folder icon, giving no hint of what's inside. They now render a **2×2 thumbnail of the first up-to-4 member avatars** (iOS-style), so you can recognize a folder at a glance.

- Maps the folder's stored filename references back to the matching library cards (by basename) to recover each member's real image path — so characters kept in avatar subfolders resolve correctly — and reuses the grid's existing image resolver.
- Folders with 1–3 members fill the remaining slots with subtle placeholders so the thumbnail stays square.
- **Empty folders** keep the plain folder icon.
- Preview size scales with the card width (so it tracks your grid-size setting rather than looking tiny on large cards).

Scoped entirely to `character_card_grid.dart`; no model, service, or schema changes.

**Note:** This PR targets `Rawhide` (the active development branch for all new features, per CLAUDE.md / AGENTS.md).

## Type of Change
- [x] New feature

## Testing
- [x] `flutter analyze` clean (0 issues)
- [x] Manual testing: empty folders (icon fallback), folders with 1–3 members (partial grid with placeholders), full 4-member previews, across different grid-size settings

## Checklist
- [x] Code follows style guidelines (matches surrounding style)
- [x] Linting passes (flutter analyze)
- [x] AppColors honored (no hardcoded colors)
- [x] Documentation updated (Rawhide.md "What's New")
- [x] No breaking changes
