### PR TITLE
Fix: chat > model settings-related cascading RSOD

### DIFF
--- a/lib/services/storage/settings/backend_settings.dart
+++ b/lib/services/storage/settings/backend_settings.dart
@@ -117,8 +117,10 @@ class BackendSettings with SettingsBase {
     final parsed = PresetSettings.parseKcppsFile(_activeKcppsPath);
     _kcppsHasModel =
         parsed != null &&
-        parsed['model'] is String &&
-        (parsed['model'] as String).trim().isNotEmpty;
+        ((parsed['model_param'] is String &&
+                (parsed['model_param'] as String).trim().isNotEmpty) ||
+            (parsed['model'] is String &&
+                (parsed['model'] as String).trim().isNotEmpty));
     if (parsed != null && parsed['contextsize'] is int) {
       _contextSize = parsed['contextsize'] as int;
     }

--- a/lib/ui/dialogs/model_settings_dialog.dart
+++ b/lib/ui/dialogs/model_settings_dialog.dart
@@ -74,7 +74,10 @@ class _ModelSettingsDialogState extends State<ModelSettingsDialog> {
     _apiKeyController.text = storage.remoteApiKey;
     _modelNameController.text = storage.remoteModelName;
 
-    _scanLocalPresets();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _scanLocalPresets();
+    });
   }
 
   void _scanLocalPresets() {

--- a/lib/ui/widgets/kcpps_selector.dart
+++ b/lib/ui/widgets/kcpps_selector.dart
@@ -95,7 +95,9 @@ class _KcppsSelectorState extends State<KcppsSelector> {
         widget.storage.kcppsHasModel && widget.storage.kcppsModelFileExists;
     if (valid != _lastValidModel) {
       _lastValidModel = valid;
-      widget.onModelStatusChanged?.call(valid);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onModelStatusChanged?.call(valid);
+      });
     }
   }
 


### PR DESCRIPTION
Addresses two problems:
- on opening chat > model settings and selecting the .kcpps file, any attempt to switch backend tabs result in RSOD - first in model settings, and on closing it - app-wide RSOD.
- model status indicator was not initialized correctly on kcpps file that was selected in previous sessions

Also some minor changes following the main Settings page pattern (minus one unnecessary widget rebuild).
