### PR TITLE
fix(dt): native Draw Things generation in signed builds (bundle libfpzip) + DT Engine Status row

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -309,6 +309,27 @@ jobs:
             /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.linux4life1.frontPorchAi.nightly" FrontPorchAI-Rawhide.app/Contents/Info.plist 2>/dev/null || true
           fi
 
+      - name: Bundle libfpzip for the native Draw Things client (macOS)
+        if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          # The pure-Dart Draw Things client decodes generated images through
+          # a tiny fpzip FFI dylib (dt_fpzip.dart looks in Contents/Frameworks/).
+          # Without it here, signed builds silently fell back to the Python
+          # sidecar for image generation — dev and release diverged. Built
+          # fresh (LLNL fpzip 1.3.0, universal arm64+x86_64) and signed by the
+          # codesign pass below like every other Frameworks dylib. Draw Things
+          # is macOS-only software, so no Windows/Linux counterpart exists.
+          ./scripts/build-fpzip-macos.sh
+          APP_PATH=$(find build/macos/Build/Products/Release -maxdepth 1 -name "*.app" | head -1)
+          if [ -z "$APP_PATH" ]; then
+            echo "No .app bundle found for libfpzip bundling" >&2
+            exit 1
+          fi
+          mkdir -p "$APP_PATH/Contents/Frameworks"
+          cp tools/fpzip/libfpzip.dylib "$APP_PATH/Contents/Frameworks/"
+          echo "Bundled libfpzip into $APP_PATH/Contents/Frameworks/"
+
       - name: Bundle ML Engines (Kokoro TTS, Piper TTS, Whisper STT, ONNX Embeddings)
         shell: bash
         run: |

--- a/lib/services/engine_health.dart
+++ b/lib/services/engine_health.dart
@@ -49,8 +49,15 @@ class EngineHealth extends ChangeNotifier {
   static const String kokoro = 'Kokoro voice';
   static const String piper = 'Piper voice';
   static const String whisper = 'Voice input';
+  static const String drawThings = 'Draw Things';
 
-  static const List<String> _order = [expressions, kokoro, piper, whisper];
+  static const List<String> _order = [
+    expressions,
+    kokoro,
+    piper,
+    whisper,
+    drawThings,
+  ];
 
   final Map<String, EngineHealthEntry> _entries = {
     for (final name in _order) name: EngineHealthEntry(name),

--- a/lib/services/grpc/draw_things_grpc_service.dart
+++ b/lib/services/grpc/draw_things_grpc_service.dart
@@ -9,6 +9,8 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import 'package:front_porch_ai/services/engine_health.dart';
+
 import 'dt_native/draw_things_native_client.dart';
 import 'dt_native/dt_fpzip.dart';
 
@@ -422,11 +424,24 @@ class DrawThingsGrpcService {
       // tensors, so without libfpzip the native path would only fail AFTER a
       // full (possibly minutes-long) generation. Skip straight to the sidecar
       // in that case rather than paying for the generation twice.
-      if (!_sidecarForced) {
+      if (_sidecarForced) {
+        EngineHealth.instance.reportFallback(
+          EngineHealth.drawThings,
+          'FP_DT_SIDECAR=1 (legacy forced by environment)',
+          expected: true,
+        );
+      } else {
         if (!DtFpzip.instance.isAvailable) {
           debugPrint(
             '[DT-Native] libfpzip not found — using sidecar for generate '
             '(build it with scripts/build-fpzip-macos.sh for native decode)',
+          );
+          // Releases bundle libfpzip in Contents/Frameworks/ — missing means
+          // broken packaging (or an unbuilt dev checkout), so it counts as a
+          // real fallback, not a documented path.
+          EngineHealth.instance.reportFallback(
+            EngineHealth.drawThings,
+            'libfpzip not found — image generation on the legacy sidecar',
           );
         } else {
           final native = DrawThingsNativeClient(host: host, port: port);
@@ -441,9 +456,14 @@ class DrawThingsGrpcService {
                   : (step) => onProgress(step, steps),
             );
             debugPrint('[DT-Native] Generated ${bytes.length} bytes');
+            EngineHealth.instance.reportNative(EngineHealth.drawThings);
             return bytes;
           } catch (e) {
             debugPrint('[DT-Native] generate failed, trying sidecar: $e');
+            EngineHealth.instance.reportFallback(
+              EngineHealth.drawThings,
+              'native generation failed: $e',
+            );
           } finally {
             unawaited(native.shutdown());
           }

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -322,6 +322,21 @@ if [ "$DO_ML" -eq 1 ]; then
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
+# libfpzip for the native Draw Things client (macOS-only feature)
+# ─────────────────────────────────────────────────────────────────────────────
+# The pure-Dart DT client decodes generated images through a tiny fpzip FFI
+# dylib (lib/services/grpc/dt_native/dt_fpzip.dart looks in
+# Contents/Frameworks/). Without it, signed builds silently fall back to the
+# Python sidecar for image generation — dev and release would diverge. The
+# dylib is signed by the codesign pass below like every other framework.
+echo "==> Bundling libfpzip (native Draw Things tensor decode)..."
+if [ ! -f "$ROOT/tools/fpzip/libfpzip.dylib" ]; then
+  "$ROOT/scripts/build-fpzip-macos.sh"
+fi
+mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+cp "$ROOT/tools/fpzip/libfpzip.dylib" "$APP_BUNDLE/Contents/Frameworks/"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # xattr clean (MUST be before any codesigning)
 # ─────────────────────────────────────────────────────────────────────────────
 echo "==> Cleaning xattrs (critical before codesign/notarization)..."

--- a/test/services/engine_health_test.dart
+++ b/test/services/engine_health_test.dart
@@ -32,6 +32,7 @@ void main() {
       EngineHealth.kokoro,
       EngineHealth.piper,
       EngineHealth.whisper,
+      EngineHealth.drawThings,
     ]);
     expect(health.hasFallbacks, isFalse);
     for (final e in health.entries) {
@@ -110,7 +111,7 @@ void main() {
     health.reportFallback(EngineHealth.expressions, 'model files not found');
     final snap = health.snapshot();
     final engines = (snap['engines'] as List).cast<Map<String, dynamic>>();
-    expect(engines, hasLength(4));
+    expect(engines, hasLength(5));
     final expr = engines.firstWhere(
       (e) => e['name'] == EngineHealth.expressions,
     );


### PR DESCRIPTION
Closes the open phase-1 TODO from docs/design/sidecar-retirement.md.

## The problem
The pure-Dart Draw Things client needs one tiny C library (libfpzip) to decode generated images. Its loader already searches the app's `Contents/Frameworks/`, but nothing put the dylib there — it lived in a gitignored dev folder. Result: `flutter run` generated images natively while **every signed/notarized build silently fell back to the Python sidecar** for generation. Test connection / model lists were native either way (pure Dart).

## The fix
- Both macOS release paths (nightly.yml macOS job + `scripts/build-macos.sh`) build LLNL fpzip 1.3.0 fresh (universal) and copy it into `Contents/Frameworks/` **before** the codesign pass — sealed with the bundle, no new entitlements. Draw Things is macOS-only software, so there is no Windows/Linux counterpart.
- Draw Things gets an Engine Status row: native generation shows green; a missing dylib or native failure reports an **unexpected** fallback (visible during soak instead of silent); `FP_DT_SIDECAR=1` counts as expected. Desktop and web panels pick the row up automatically.

## Note for after merge
nightly.yml's cron executes **main's copy** of the workflow — the nightly.yml change must be synced to main after this merges (same as the 2026-07-12 skip-gate sync).

## Verification
flutter analyze clean; engine_health suite green (7 tests, row order + snapshot updated); build-macos.sh syntax-checked; workflow step gated `matrix.platform == 'macos'` with an explicit failure if no .app is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)