### PR TITLE
fix(build): fpzip build broke on CMake 4 — unblocks the nightly macOS job

### DIFF
--- a/scripts/build-fpzip-macos.sh
+++ b/scripts/build-fpzip-macos.sh
@@ -25,10 +25,15 @@ echo "==> Cloning fpzip $FPZIP_TAG..."
 git clone --depth 1 --branch "$FPZIP_TAG" "$FPZIP_REPO" "$WORK/fpzip"
 
 echo "==> Building universal (arm64 + x86_64) shared library..."
+# CMAKE_POLICY_VERSION_MINIMUM: fpzip 1.3.0's CMakeLists declares a
+# cmake_minimum_required below 3.5, which CMake 4 (GitHub macOS runners)
+# refuses outright. The override tells modern CMake to configure anyway;
+# older CMakes ignore the unknown cache variable, so it is harmless there.
 cmake -S "$WORK/fpzip" -B "$WORK/build" \
   -DBUILD_SHARED_LIBS=ON \
   -DBUILD_UTILITIES=OFF \
   -DBUILD_TESTING=OFF \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" >/dev/null
 cmake --build "$WORK/build" --config Release -j"$(sysctl -n hw.ncpu)"


### PR DESCRIPTION
Last night's nightly macOS job died at the new libfpzip configure step: the GitHub runners now ship CMake 4, which refuses fpzip 1.3.0's ancient `cmake_minimum_required`. This adds CMake's documented override (`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`) to `scripts/build-fpzip-macos.sh`; older CMakes ignore it.

Verified locally on CMake 4.3.2 — the same generation that failed in CI — producing the universal arm64+x86_64 dylib.

No `nightly.yml` change and no main sync needed: the workflow executes this script from the Rawhide checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)