### PR TITLE
fix(dt): accept gzip-compressed Draw Things responses (second stacked connect bug)

### DIFF
--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -4,7 +4,7 @@ These notes feed the in-app "Update Available" dialog for Rawhide / cutting-edge
 
 ## Recent improvements (unreleased — ships in the next build)
 
-- 🖼️ **Draw Things connects in the installed app now** — the new built-in connection had a certificate bug that only showed up outside development, so installed builds couldn't reach Draw Things at all. Fixed and verified against a live Draw Things server; connection tests and generations both show up in the Engine Status panel.
+- 🖼️ **Draw Things connects in the installed app now** — the new built-in connection had two stacked bugs (a certificate check that could never pass, and Draw Things' compressed replies being rejected), so installed builds couldn't reach Draw Things at all. Both fixed and verified against a live Draw Things server; connection tests and generations show up in the Engine Status panel.
 - ⭐ **Starring an avatar now really changes the card — everywhere** — the ★ in the Avatar Gallery updates the character's face across the whole app: library card, folder previews, open chats (sidebar, header, message bubbles, character pickers), the web app, and exports. One face per character. You can also finally delete the original portrait: the starred avatar steps up as the new portrait in its place. Bonus: star clicks no longer repaint the home screen behind the gallery.
 - 🚩 **The "NSFW Tasks" switch stays on** — the objectives panel's NSFW toggle (and the task count) quietly reset after every message; they now hold for your whole session. (They still start OFF on each app launch, on purpose.)
 - 🔧 Under-the-hood fixes and polish.

--- a/lib/services/grpc/dt_native/draw_things_native_client.dart
+++ b/lib/services/grpc/dt_native/draw_things_native_client.dart
@@ -119,6 +119,15 @@ class DrawThingsNativeClient {
           onBadCertificate: (cert, host) =>
               sha256.convert(cert.der).toString() == _pinnedDerSha256,
         ),
+        // Draw Things gzip-compresses responses. Python gRPC negotiates that
+        // automatically; grpc-dart only accepts compressed messages when a
+        // codec registry says so — without this, every reply died as
+        // DATA_LOSS 'Error parsing response' (field report from the first
+        // signed nightly, reproduced + verified fixed with tool-probe
+        // against a live server).
+        codecRegistry: CodecRegistry(
+          codecs: const [GzipCodec(), IdentityCodec()],
+        ),
       ),
     );
   }


### PR DESCRIPTION
The TLS fix exposed the next bug in the stack: DT gzip-compresses responses; Python gRPC auto-negotiates (sidecar worked), grpc-dart needs an explicit codec registry (native client had none) → every reply died as DATA_LOSS 'Error parsing response'. Reproduced with a live-server probe in dev JIT (not release-specific), fixed with CodecRegistry(gzip+identity), verified via the FP_DT_LIVE gated test against real Draw Things.

Notable: the maintainer's bug report WAS an Engine Status panel copy-paste — the observability feature caught its first real bug within hours of shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)