### PR TITLE
Release: promote Rawhide to main (objective regen-rollback fix)

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -5135,10 +5135,12 @@ re-appear as "added". Both jobs now skip when the PR head starts with
 `release/promote-` — Rawhide's incremental CI already gated every new line when it
 landed. Push/normal-PR behavior unchanged.
 
-## 2026-07-18 (UTC) — 1.0 hero screenshot refresh
-**Files:** `docs/screenshots/home_new.png`
-**Why:** The README hero still showed v0.9.6 (removed Cloud Sync item, open context
-menu, pre-warm-porch design). Replaced with the maintainer's staged 1.0 shot
-(~/Desktop/fpai-review/screens-1.0/home_screen.png, picked per maintainer request),
-resampled to 1920px (6.7MB→1.9MB). Committed on Rawhide so the promotion carries it
-to main — same single-source rule as the banner SVGs.
+## 2026-07-18 (UTC) — 1.0 hero screenshot refresh (correction: already done)
+**Files:** none (commit 1eeb5325 carried only this changelog entry)
+**Why:** Set out to replace the stale v0.9.6 README hero with the maintainer's staged
+1.0 shot (~/Desktop/fpai-review/screens-1.0/home_screen.png). Turned out Rawhide
+commit 374612e7 ("retake the four canonical screenshots on the 1.0 warm-porch UI")
+had already committed that exact capture at 1920px — the working tree matched, so
+nothing staged and 1eeb5325's message overstates itself (only this changelog rode
+in it). main still shows the old hero only until the promotion merge lands; no
+image action needed.

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -5144,3 +5144,24 @@ had already committed that exact capture at 1920px — the working tree matched,
 nothing staged and 1eeb5325's message overstates itself (only this changelog rode
 in it). main still shows the old hero only until the promotion merge lands; no
 image action needed.
+
+## 2026-07-18 (UTC) — Regen now rolls back the turn's objective mutations
+**Files:** `lib/services/chat/chat_service_objectives.dart`, `lib/services/chat_service.dart`, `lib/services/chat/chat_service_reprocess.dart`, `docs/Rawhide.md`
+**Why:** Maintainer report: regenerating a message left the invalidated turn's objective
+changes in place (eval-proposed quests stayed created, completion-check task ticks and
+quest retirements stayed applied). The realism engine has per-message delta revert;
+objectives had nothing. Fix mirrors that pattern: turn-attributable objective ops
+(created + demoted/evicted side effects, tasks_changed with pre-mutation JSON,
+deactivated) are recorded into _pendingRealismMetadata['objective_turn_ops'] (inherits
+the existing flush/reset lifecycle), and regenerateLastMessage inverts them reversed +
+id-addressed before the eval replay — 1:1/group parity by construction, guest regens
+skip. Recording is armed only for turn-path work: the eval setObjective cb passes
+recordTurnOps:true; check-driven sites gate on _objectiveTurnOpsArmed (armed via
+try/finally only in _maybeCheckTaskCompletionSync), so panel edits and manual "Check
+now" are never recorded. Grok review: demote-invert reconciliation guard added (skip
+isPrimary restore when the user promoted another primary in between, charId recorded
+on ops for it); swipe-back re-apply deliberately deferred (faithful 'created' re-apply
+impossible — task-gen fills tasks async post-flush; self-heals next turn) and
+documented in the turn-ops block comment. No god growth (logic in the objectives part
+file); 2 new privates (_recordObjectiveTurnOp, _revertObjectiveTurnOps) — justified,
+no existing method records into pending metadata or inverts ops.

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -4,6 +4,7 @@ These notes feed the in-app "Update Available" dialog for Rawhide / cutting-edge
 
 ## Recent improvements (unreleased — ships in the next build)
 
+- 🎯 **Regenerating a reply now rolls back its quest changes** — if a character proposed a new objective or checked off a quest step during a reply you then regenerated, those changes used to stick around even though the moment they came from was gone. Now they're undone along with the rejected reply, and the new reply earns its own — your hand-made objectives and manual "Check now" results are never touched.
 - 🎨 **Draw Things connection fixed for real** — connecting to Draw Things was a coin flip ("Test Connection" randomly failing) and image generation would show Draw Things rendering away while Front Porch never received the picture, then refuse to reconnect. One tiny byte-counting bug in how the app read Draw Things' replies caused all of it. Connection tests, model listing, single images, and expression packs now come through reliably.
 - 🧠 **Memory (RAG) setup fixed on Windows** — the new built-in memory engine failed its self-test on every Windows machine ("Setup Failed" in the memory setup dialog) because of a Windows-only quirk in how the AI runtime is handed the model's file path. The engine now loads correctly on Windows — and the same fix also repairs character expressions and photo captions there, which were quietly affected by the same bug. If setup does fail, the dialog now shows the actual reason instead of a generic message.
 - 🔧 Under-the-hood fixes and polish.

--- a/lib/services/chat/chat_service_objectives.dart
+++ b/lib/services/chat/chat_service_objectives.dart
@@ -85,6 +85,7 @@ extension ChatServiceObjectives on ChatService {
     bool isPrimary = true,
     CharacterCard? targetCharacter,
     bool autoGenerateTasks = false,
+    bool recordTurnOps = false,
   }) async {
     if (goal.trim().isEmpty) return;
     if (_currentSessionId == null) return;
@@ -128,6 +129,14 @@ extension ChatServiceObjectives on ChatService {
               isPrimary: const drift.Value(false),
             ),
           );
+          if (recordTurnOps) {
+            // charId enables the invert's primary-reconciliation guard.
+            _recordObjectiveTurnOp({
+              'op': 'demoted',
+              'id': obj.id,
+              'charId': charId,
+            });
+          }
         }
       }
     } else {
@@ -140,6 +149,12 @@ extension ChatServiceObjectives on ChatService {
               active: const drift.Value(false),
             ),
           );
+          if (recordTurnOps) {
+            _recordObjectiveTurnOp({
+              'op': 'evicted',
+              'id': currentSecondaries[i].id,
+            });
+          }
         }
       }
     }
@@ -155,6 +170,9 @@ extension ChatServiceObjectives on ChatService {
         isPrimary: drift.Value(isPrimary),
       ),
     );
+    if (recordTurnOps) {
+      _recordObjectiveTurnOp({'op': 'created', 'id': newId, 'charId': charId});
+    }
 
     await _loadActiveObjectives();
     _messagesSinceLastCheck = 0;
@@ -237,6 +255,16 @@ extension ChatServiceObjectives on ChatService {
       (t) => (t['description'] as String) == taskDesc && t['completed'] != true,
     );
     if (idx < 0) return;
+    // Turn-op for regen rollback: obj.tasks is still the pre-mutation JSON here,
+    // so the inverse is a plain write-back of that string. Armed-gated: manual
+    // "Check now" completions are user actions, not turn ops.
+    if (_objectiveTurnOpsArmed) {
+      _recordObjectiveTurnOp({
+        'op': 'tasks_changed',
+        'id': obj.id,
+        'prev': obj.tasks,
+      });
+    }
     tasks[idx]['completed'] = true;
     await _db.updateObjective(
       ObjectivesCompanion(
@@ -368,7 +396,15 @@ extension ChatServiceObjectives on ChatService {
     if (_messagesSinceLastCheck < freq) return;
     _messagesSinceLastCheck = 0;
 
-    await _checkTaskCompletionInBackground(); // step 11 thin (full in objective_proposal)
+    // Arm turn-op recording only for THIS turn-path check (see field doc):
+    // its completions/retirements belong to the turn being generated and must
+    // roll back on regen; manual "Check now" runs the same check unarmed.
+    _objectiveTurnOpsArmed = true;
+    try {
+      await _checkTaskCompletionInBackground(); // step 11 thin (full in objective_proposal)
+    } finally {
+      _objectiveTurnOpsArmed = false;
+    }
   }
 
   // Thin delegation (full _checkTaskCompletionInBackground + 2000 budget + central strip in
@@ -377,4 +413,113 @@ extension ChatServiceObjectives on ChatService {
   // proposal in step 11").
   Future<void> _checkTaskCompletionInBackground() =>
       _objectiveProposal.checkTaskCompletionInBackground();
+
+  // ── Objective turn-ops: regen rollback (mirrors the realism delta-revert) ──
+  //
+  // Objective mutations attributable to a turn (eval-proposed creations with
+  // their demotion/eviction side effects, check-driven task completions and
+  // quest retirements) are recorded here and ride
+  // _pendingRealismMetadata['objective_turn_ops'], so they attach to the bot
+  // message the turn produced via the exact flush/reset machinery the realism
+  // metadata already uses. regenerateLastMessage inverts them (reversed, by
+  // objective id — character-agnostic, so 1:1 and group behave identically)
+  // before replaying the evals, which may then legitimately re-propose for the
+  // new turn. Nothing user-initiated ever records: panel setObjective,
+  // toggleTask, clearObjective have no recording path, and the check-driven
+  // sites are gated on _objectiveTurnOpsArmed, which only the turn-path
+  // check in _maybeCheckTaskCompletionSync arms — so a manual "Check now"
+  // (forceCheckCompletion) runs the same check unrecorded and regen can
+  // never undo a user action.
+  //
+  // Known follow-up (deliberate, reviewed): swiping BACK to a rejected swipe
+  // does not re-apply its inverted ops (faithful 'created' re-apply is
+  // impossible from this op log — auto task-gen fills tasks async after the
+  // metadata flush). Accepting an old swipe and continuing self-heals at the
+  // next turn's check/eval, which re-derives completions and can re-propose;
+  // until that turn the panel reflects the newest swipe's objective state.
+
+  /// Append one turn op to the pending realism metadata (created on demand;
+  /// leaves always start from getPendingRealismMetadata(), so the list
+  /// survives their read-mutate-set pattern).
+  void _recordObjectiveTurnOp(Map<String, dynamic> op) {
+    _pendingRealismMetadata ??= {};
+    final list =
+        (_pendingRealismMetadata!['objective_turn_ops'] ??= <dynamic>[])
+            as List;
+    list.add(op);
+  }
+
+  /// Invert the rejected message's recorded objective ops (reverse order):
+  /// created → deleted, tasks_changed → pre-mutation JSON restored,
+  /// deactivated/evicted → reactivated, demoted → primary restored. Blind
+  /// id-addressed updates: a row deleted since (e.g. chat cleanup) no-ops.
+  Future<void> _revertObjectiveTurnOps(ChatMessage rejectedMsg) async {
+    final raw = rejectedMsg.activeMetadata?['objective_turn_ops'];
+    if (raw is! List || raw.isEmpty) return;
+    for (final entry in raw.reversed) {
+      if (entry is! Map) continue;
+      final id = entry['id'] as String?;
+      if (id == null || id.isEmpty) continue;
+      try {
+        switch (entry['op']) {
+          case 'created':
+            await _db.deleteObjective(id);
+          case 'tasks_changed':
+            final prev = entry['prev'];
+            if (prev is String) {
+              await _db.updateObjective(
+                ObjectivesCompanion(
+                  id: drift.Value(id),
+                  tasks: drift.Value(prev),
+                ),
+              );
+            }
+          case 'deactivated' || 'evicted':
+            await _db.updateObjective(
+              ObjectivesCompanion(
+                id: drift.Value(id),
+                active: const drift.Value(true),
+              ),
+            );
+          case 'demoted':
+            // Reconciliation guard (review finding): if the user promoted a
+            // DIFFERENT objective to primary between the turn and this regen,
+            // blindly restoring this one would leave two active primaries.
+            // The user's later choice wins — skip the restore then.
+            final charId = entry['charId'] as String?;
+            var otherPrimaryExists = false;
+            if (charId != null && charId.isNotEmpty) {
+              final current = await _db.getObjectivesForCharacter(
+                charId,
+                chatId: _currentSessionId,
+              );
+              otherPrimaryExists = current.any(
+                (o) => o.active && o.isPrimary && o.id != id,
+              );
+            }
+            if (!otherPrimaryExists) {
+              await _db.updateObjective(
+                ObjectivesCompanion(
+                  id: drift.Value(id),
+                  isPrimary: const drift.Value(true),
+                ),
+              );
+            }
+        }
+      } catch (e) {
+        debugPrint('[Objective] Regen revert op failed (${entry['op']}): $e');
+      }
+    }
+    debugPrint(
+      '[Objective] Regen reverted ${raw.length} turn op(s) from rejected message',
+    );
+    // Refresh the in-memory list the UI/injection reads. In group mode the
+    // turn manager has already been forced back to the rejected speaker, so
+    // the speaker loader targets the right member.
+    if (_activeGroup != null) {
+      await _loadObjectivesForCurrentSpeaker();
+    } else {
+      await _loadActiveObjectives();
+    }
+  }
 }

--- a/lib/services/chat/chat_service_reprocess.dart
+++ b/lib/services/chat/chat_service_reprocess.dart
@@ -454,6 +454,17 @@ extension ChatServiceReprocess on ChatService {
         _groupManager?.setNextSpeaker(regenSpeakerCard);
       }
 
+      // Roll back objective mutations recorded for the rejected turn (eval
+      // proposals + completion-check side effects) BEFORE the eval replay, so
+      // the new turn re-derives objectives from a clean baseline instead of
+      // stacking on the invalidated turn's (and dedup can't suppress a fresh
+      // proposal because the rejected turn's copy still exists). Runs with or
+      // without realism (completion checks also run realism-off); id-addressed
+      // ops keep 1:1 and group identical. Guest turns never touch objectives.
+      if (regenGuest == null) {
+        await _revertObjectiveTurnOps(lastMsg);
+      }
+
       // Revert realism state from the rejected swipe and re-evaluate.
       // Guest messages carry no Realism/Needs state (regenGuest != null skips).
       //

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -182,6 +182,13 @@ class ChatService extends ChangeNotifier {
   // purpose — NOT persisted, so NSFW tasks default OFF on a fresh launch.
   bool objectiveNsfwTasks = false;
   int objectiveTaskCount = 5;
+
+  /// Armed only while the TURN-path completion check runs (see
+  /// _maybeCheckTaskCompletionSync try/finally): check-driven objective
+  /// mutations record regen turn-ops only when armed, so the UI's manual
+  /// "Check now" (forceCheckCompletion) never records — a regen must not
+  /// undo a user-triggered check. Scoped by try/finally; no reset needed.
+  bool _objectiveTurnOpsArmed = false;
   int _messagesSinceLastCheck = 0;
   bool _isCheckingCompletion =
       false; // god-side secondary runtime flag for objective_proposal leaf's get/setIsChecking (early guard in check); must be defensively zeroed on *all* reset/new-chat/0-session/group/setActive/load/delete paths (like _activeObjectives + _messagesSinceLastCheck) to prevent permanent skip of future task checks after in-flight reset; see CLAUDE.md "keep reset blocks in sync" + "incomplete zeroing..." (leaves incl fact/evo/verif + needs_impact etc) + " ; no extra mutable scalar; live read from frontPorch under impersonation)" + "needsSimulation. (reason support kept for Director chips) ; cleared via sim initializeFresh/clearVector/resetBuffers on all paths; now complete)").
@@ -1951,6 +1958,10 @@ class ChatService extends ChangeNotifier {
           text,
           isPrimary: isPrimary,
           autoGenerateTasks: autoGenerateTasks,
+          // Eval-proposed objectives belong to the turn being generated —
+          // record them so regen can roll them back (turn-ops; the UI's
+          // direct setObjective calls stay unrecorded).
+          recordTurnOps: true,
         ),
     verifyRealismOutput: _realismVerifier.verify,
   );
@@ -1995,6 +2006,13 @@ class ChatService extends ChangeNotifier {
       );
     },
     deactivateObjective: (id) async {
+      // Only the completion check retires through this cb (the UI's
+      // clearObjective has its own db call) — record the turn-op so regen
+      // can reactivate a quest the invalidated turn retired. Armed-gated:
+      // manual "Check now" retirements are user actions, not turn ops.
+      if (_objectiveTurnOpsArmed) {
+        _recordObjectiveTurnOp({'op': 'deactivated', 'id': id});
+      }
       await _db.updateObjective(
         ObjectivesCompanion(
           id: drift.Value(id),


### PR DESCRIPTION
Follow-up promotion after the 1.0 promotion (#148): brings the objective regen-rollback fix (37747787) + changelog/docs onto main before tagging. Same script-built Rawhide-wins candidate, all 7 gates green, guards (README.md, docs/main.md) kept from main. Merge will be --ff-only after CI.