### PR TITLE
Release: promote Rawhide to main (site docs de-staled)

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -5174,3 +5174,18 @@ embed assets/images/front_porch_ai_icon.png as a base64 data URI in a rounded ti
 (GitHub's camo proxy strips external/relative resources inside <img>-rendered SVGs,
 so embedding is the only rendering option). Verified via qlmanage renders (previews
 in ~/Desktop/fpai-review/).
+
+## 2026-07-18 (UTC) — Pre-launch sweep: README build docs + contributors; GO verdict
+**Files:** `README.md` (Rawhide's dev copy; main's guarded 1.0 copy fixed directly on main @ 3a137023), `.claude/changelog.md`
+**Why:** Final lockdown before the v1.0.0 tag. Maintainer caught the Build from Source
+sections (both READMEs) still instructing Rust toolchain + cargo-building the deleted
+embed_server; rewritten for the in-process world with CI's proven Linux dep list
+(libsecret + gstreamer were missing). main's README also gained the Contributors
+section (S-A-M-F, willie, MisterLotto, dazpants1, bigsombar, FrozenKangaroo) and lost
+a stale screenshot TODO. Joint Claude+Grok audit verdict: GO — updater contract for
+0.9.9.1.3→1.0.0 verified against the OLD binary's frozen code (zero-padded compare,
+channel isolation, exact asset names), fresh-install boot tested in docker (v37 DB,
+no fatals). Operational notes recorded in the release-promotion memory: tag must be
+v1.0.0 (never v1.0 — 2-segment tag breaks pubspec), release must not be marked
+pre-release, don't re-publish older stable releases afterward (updater picks stable
+by publish date).

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -5189,3 +5189,13 @@ no fatals). Operational notes recorded in the release-promotion memory: tag must
 v1.0.0 (never v1.0 — 2-segment tag breaks pubspec), release must not be marked
 pre-release, don't re-publish older stable releases afterward (updater picks stable
 by publish date).
+
+## 2026-07-18 (UTC) — Site docs de-staled for the 1.0 website refresh
+**Files:** `docs/install.md`, `docs/faq.md`, `docs/troubleshooting.md`
+**Why:** These render on frontporchai.app (and GitHub). All three still documented the
+sidecar era and removed features: Rust/cargo embed_server build steps, Python voice
+sidecar pip installs, `pkill -f embed_server` advice, RAG described as a helper
+process, and the removed Chub/aicharactercards in-app browser (incl. its WPE WebKit
+Linux notes + a whole troubleshooting section). Rewritten for the in-process world;
+Linux build deps now match CI's proven set. Deployed to the droplet as part of the
+1.0 website refresh.

--- a/README.md
+++ b/README.md
@@ -412,14 +412,9 @@ flutter pub get
 flutter run
 ```
 
-**macOS release build** (signs, packages, and notarizes):
+**Release build:**
 ```bash
-./scripts/build-macos.sh
-```
-
-**Linux / Windows release build:**
-```bash
-flutter build linux    # or windows
+flutter build linux    # or windows, or macos
 ```
 That's it — the built bundle is self-contained.
 

--- a/README.md
+++ b/README.md
@@ -381,25 +381,26 @@ The app is **local-first**: using it offline collects nothing and sends us nothi
 
 ### Prerequisites
 - [Flutter SDK](https://docs.flutter.dev/get-started/install)
-- [Rust toolchain](https://rustup.rs/) (for the RAG embedding server)
 - Git
 - Windows, Linux, or macOS
+
+That's the whole list — every AI engine (TTS, STT, character expressions, RAG memory embeddings, the Draw Things client) runs **in-process** via ONNX/native libraries that ship with the app's packages. There are no sidecar binaries to build, no Rust, no Python.
 
 ### Linux Extra Dependencies
 
 **Ubuntu/Debian**
 ```bash
-sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev
+sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libsecret-1-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 ```
 
 **Arch Linux**
 ```bash
-sudo pacman -S clang cmake ninja pkgconf gtk3 xz
+sudo pacman -S clang cmake ninja pkgconf gtk3 xz libsecret gstreamer gst-plugins-base
 ```
 
 **Fedora**
 ```bash
-sudo dnf install clang cmake ninja-build pkgconf-pkg-config gtk3-devel xz-devel libstdc++-devel
+sudo dnf install clang cmake ninja-build pkgconf-pkg-config gtk3-devel xz-devel libsecret-devel gstreamer1-devel gstreamer1-plugins-base-devel libstdc++-devel
 ```
 
 ### Build & Run
@@ -411,17 +412,16 @@ flutter pub get
 flutter run
 ```
 
-**macOS release build** (includes RAG embedding server):
+**macOS release build** (signs, packages, and notarizes):
 ```bash
 ./scripts/build-macos.sh
 ```
 
 **Linux / Windows release build:**
 ```bash
-cargo build --release --manifest-path tools/embed_server/Cargo.toml
 flutter build linux    # or windows
 ```
-> On Linux/Windows, copy `tools/embed_server/target/release/embed_server` next to the built executable under `embed_server/embed_server`.
+That's it — the built bundle is self-contained.
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,7 +81,7 @@ See the [Installation Guide](install.md) for step-by-step instructions.
 
 Only for the initial setup: downloading the app, the AI engine, and a model. After that, everything core works fully offline — chatting, memory, local voices, image generation with a local backend, all of it.
 
-You need to be online for: remote AI APIs, cloud voices, The Stoop, downloading new models, and the built-in character site browsers.
+You need to be online for: remote AI APIs, cloud voices, The Stoop, and downloading new models.
 
 ### What's the difference between Stable and Nightly builds?
 
@@ -150,7 +150,7 @@ Usually fixable with settings:
 ### Where can I find characters?
 
 - **The Stoop** — the community hub built right into the app (currently in nightly builds): browse, follow creators, and download with one tap.
-- **The built-in browsers** — the app has embedded browsers for chub.ai and aicharactercards.com; download a card and it lands straight in your library.
+- **Import a card file** — download a card (PNG or JSON) from any character site in your normal browser, then use the **Import** button and it lands straight in your library.
 - **Anywhere character cards are shared** — Front Porch AI reads standard V2/V2.5 character card files (PNG or JSON), the same format the whole community uses.
 - **Make your own** — the AI Character Creator builds a complete character from a one-line concept, or use the step-by-step manual creator.
 - **The Discord** — people share cards and ideas in the [community Discord](https://discord.gg/e4tET6rpdv).
@@ -204,7 +204,6 @@ Never collected: your conversations, your characters (unless you upload them), o
 - **First use downloads voice files.** The default local engine (Kokoro) fetches its voice models (~300 MB) the first time you use it. Give it a minute and watch for the progress indicator.
 - **Wrong engine selected** — check Settings → Voice. Kokoro is the local default; ElevenLabs and OpenAI need an API key and internet.
 - **A character has a voice from a different engine.** If you switched engines, a character's assigned voice may no longer match — the voice picker warns you about incompatible ones. Re-assign or choose the default.
-- **Running from source code?** Only developers building from source need Python packages (`pip install kokoro-onnx soundfile faster-whisper`). The normal downloads bundle everything.
 
 More fixes in [Troubleshooting → Voice](troubleshooting.md#tts-not-producing-sound).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -111,7 +111,6 @@ Voice features (text-to-speech and voice input) are bundled with official builds
 ## Common Install Problems
 
 - **AMD graphics on Linux:** if the app can't see your GPU, make sure your user account is in the `render` and `video` groups, then log out and back in.
-- **Character browser won't open (Linux):** the built-in Chub.ai browser needs the WPE WebKit engine. It's bundled in the AppImage; on manual installs, install your distro's `wpewebkit` package.
 - **UI flicker on Linux (Wayland):** try launching with `GDK_BACKEND=x11`.
 - **Anything else:** the [Troubleshooting guide](troubleshooting.md) covers a lot more, and [Discord](https://discord.gg/e4tET6rpdv) is there for the rest.
 
@@ -124,25 +123,25 @@ Everything below is for people who want to hack on the app. Regular users can st
 **Prerequisites**
 
 - [Flutter SDK](https://docs.flutter.dev/get-started/install) 3.10.8 or later
-- [Rust toolchain](https://rustup.rs/) — builds the memory (RAG) embedding server
-- Python 3.8+ — only needed to run the voice sidecars in dev mode
 - Git
+
+That's the whole list — every AI engine (voice, speech-to-text, character expressions, memory embeddings) runs **in-process** via libraries that ship with the app's packages. No Rust, no Python, no helper programs.
 
 **Linux build dependencies**
 
 Ubuntu/Debian:
 ```bash
-sudo apt install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libwpewebkit-1.0-dev
+sudo apt install clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libsecret-1-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 ```
 
 Fedora:
 ```bash
-sudo dnf install clang cmake ninja-build pkgconf-pkg-config gtk3-devel xz-devel libstdc++-devel wpewebkit-devel
+sudo dnf install clang cmake ninja-build pkgconf-pkg-config gtk3-devel xz-devel libsecret-devel gstreamer1-devel gstreamer1-plugins-base-devel libstdc++-devel
 ```
 
 Arch:
 ```bash
-sudo pacman -S clang cmake ninja pkgconf gtk3 xz wpewebkit
+sudo pacman -S clang cmake ninja pkgconf gtk3 xz libsecret gstreamer gst-plugins-base
 ```
 
 **Clone and run**
@@ -157,23 +156,10 @@ flutter run
 **Release builds**
 
 ```bash
-# The embedding server (needed for memory/RAG)
-cargo build --release --manifest-path tools/embed_server/Cargo.toml
-
-# Then the app
-flutter build windows   # or: flutter build linux
-./scripts/build-macos.sh   # macOS — bundles the embedding server for you
+flutter build windows   # or: flutter build linux, flutter build macos
 ```
 
-On Windows and Linux, copy the built `embed_server` binary next to the app executable (under `embed_server/`) so memory features work.
-
-**Voice features in dev mode** run through Python directly, so install their packages:
-
-```bash
-pip install kokoro-onnx soundfile faster-whisper
-```
-
-(Official release builds bundle these — end users never need Python.)
+That's it — the built bundle is self-contained.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,7 +41,6 @@ When something goes wrong, this page is the fastest route back to chatting. Find
 - [Missing character images](#missing-character-images)
 
 ### Platform Notes
-- [Linux: character site browser won't open](#linux-character-site-browser-wont-open)
 - [Linux: flickering or visual glitches](#linux-flickering-or-visual-glitches)
 - [Linux: AMD GPU not being used](#linux-amd-gpu-not-being-used)
 - [macOS: "damaged" warning, and Intel Macs](#macos-damaged-warning-and-intel-macs)
@@ -75,8 +74,8 @@ When something goes wrong, this page is the fastest route back to chatting. Find
 
 - **Leftover processes from a previous run.** If the app was force-quit, the AI engine can be left running and block the next launch. Clean up:
   - Windows: Task Manager → end any `koboldcpp` or `front_porch` processes.
-  - macOS/Linux: `pkill -f koboldcpp` and `pkill -f embed_server`
-- **Linux — missing system libraries.** Run it from a terminal; if it complains about a missing `.so` file, install the library it names (the in-app browser needs WPE WebKit — see [the Linux note](#linux-character-site-browser-wont-open)). The **AppImage** bundles everything and is the easy way out.
+  - macOS/Linux: `pkill -f koboldcpp`
+- **Linux — missing system libraries.** Run it from a terminal; if it complains about a missing `.so` file, install the library it names (commonly GTK 3, libsecret, or GStreamer). The **AppImage** bundles everything and is the easy way out.
 - **macOS — blocked by Gatekeeper.** See the [macOS note](#macos-damaged-warning-and-intel-macs).
 - **Broken download/install.** Re-download the release and reinstall. Your data is safe — it lives in your Documents folder, not the install folder.
 
@@ -183,11 +182,11 @@ The conversation itself keeps working even when evaluations fail — you just lo
 
 ### Memory / RAG isn't working
 
-Long-term memory ("the character remembered something from last week!") runs on a small local helper program that converts text to searchable meaning. No internet, no Python, nothing to install — but a few things can trip it:
+Long-term memory ("the character remembered something from last week!") converts text to searchable meaning right inside the app — no internet, no helper programs, nothing extra to install. A few things can still trip it:
 
-- **Check its status** in Settings → Memory. It should say running/ready.
+- **Check its status** in Settings → Memory. It should say ready.
 - **First use downloads a small model** — give it a moment to finish.
-- **Helper stuck?** Toggle it off in Settings, run `pkill -f embed_server` (macOS/Linux) or end the process in Task Manager (Windows), then toggle it back on.
+- **Stuck?** Toggle memory off and back on in Settings; if it stays stuck, restart the app.
 - **Memories exist but aren't recalled:** memory retrieval needs *meaningful* content to match on — one-word messages don't give it much. Look for the re-index option in the memory settings to rebuild the index if it seems out of date.
 
 ---
@@ -200,7 +199,6 @@ Long-term memory ("the character remembered something from last week!") runs on 
 - **Check the engine and voice** in Settings → Voice. Cloud engines (ElevenLabs, OpenAI) need a valid API key and internet.
 - **Character voice mismatch:** if you switched engines (say Kokoro → Piper), a voice assigned to a character under the old engine won't play — the voice picker flags incompatible ones. Re-assign or use the global default.
 - **Linux audio:** if nothing in the app plays sound, your system may be missing GStreamer plugins — install your distro's `gstreamer` "good/base" plugin packages.
-- **Building from source?** Dev-mode voice features need Python packages: `pip install kokoro-onnx soundfile faster-whisper`. Normal downloads bundle everything — no Python required.
 
 ### Microphone / speech-to-text not working
 
@@ -267,10 +265,6 @@ If a character's portrait shows a placeholder silhouette, the image file moved o
 ---
 
 ## Platform Notes
-
-### Linux: character site browser won't open
-
-The in-app browser (for chub.ai and aicharactercards.com imports) needs **WPE WebKit**. If the browser fails to open, install your distro's `wpewebkit` package — or use the **AppImage**, which bundles it. You can always download cards in a normal browser and import the files instead.
 
 ### Linux: flickering or visual glitches
 


### PR DESCRIPTION
Docs-only promotion for the 1.0 website refresh: install/faq/troubleshooting rewritten for the no-sidecar app (removed Rust/Python build steps, embed_server pkill advice, and the removed Chub browser docs) + the two dev-README fixes. All 7 script gates green; guards kept. ff-only merge without CI wait (no code in the diff), full-project lint on the main push is the backstop.