### PR TITLE
feat(sanitizer): add * quantifier support + user-facing syntax docs

### DIFF
--- a/docs/design/session-load-refactor.md
+++ b/docs/design/session-load-refactor.md
@@ -1,11 +1,13 @@
 # Session Load Refactor
 
-**Status: IN PROGRESS (Step 1 of 2).** Output sanitizer PR introduced
-identical code in both `_loadLastSession` and `loadSession`. Step 1a
-extracts the shared message-hydration loop (done). Step 1b extracts the
-generation sliders from `chat_settings_dialog.dart` (done). Step 2
-(follow-up PR) will extract shared session-scalar loading and fix two
-pre-existing bugs.
+**Status: Steps 1a and 1b complete. Step 2 revised per code review —
+see updated plan below.**
+
+The output sanitizer PR introduced identical code in both
+`_loadLastSession` and `loadSession`. Step 1a extracted the shared
+message-hydration loop. Step 1b extracted the generation sliders from
+`chat_settings_dialog.dart`. Step 2 will extract shared session-scalar
+loading and fix three pre-existing bugs.
 
 ## Background
 
@@ -39,14 +41,25 @@ to both methods:
 1. **`loadSession` missing chaos mode load:** `_loadLastSession` calls
    `_chaosModeService.loadScalars(modeEnabled:, pressure:)` at load
    time; `loadSession` does not. Sessions loaded via the history picker
-   lose their chaos mode state. (Pre-existing, not introduced by this PR.)
+   lose their chaos mode state. (Pre-existing.)
 
 2. **Duplicate legacy migration call:** `_loadLastSession` calls
    `_relationshipService.applyLegacyShortTermMigrationIfNeeded()`
-   twice — once at line 156 and again at line 222. The second call is
+   twice — once at line 158 and again at line 224. The second call is
    redundant (no scores change between the two). (Pre-existing.)
 
-## Step 1a (this PR): Extract message hydration loop
+3. **Migration wrappers inflate scores on every chat open:**
+   `_migrateShortTermScore` (`relationship_service.dart:479`) doubles
+   any score with `|score| ≤ 150`, with no era flag or version guard.
+   `_loadLastSession` passes the wrapped values to `loadScalars` (lines
+   140-143), and `_doSaveChat` writes them back
+   (`chat_service_session_state.dart:327-334`). A bond of 40 inflates
+   to 80 on the second open, 160 on the third — up to 4× drift,
+   crossing several `_calculateTier` boundaries. `loadSession` passes
+   raw DB values and is the correct path. (Pre-existing. Promoted from
+   code review — see PR #162 discussion.)
+
+## Step 1a: Extract message hydration loop
 
 Extract a single private method `_hydrateMessagesFromRows(List<Message>)`
 that encapsulates the identical for-loop: decode swipes → apply retroactive
@@ -62,16 +75,16 @@ output sanitization → decode swipe durations → clamp swipe index → build
   (not needed by `_loadLastSession`)
 
 **Impact:** ~68 lines extracted per call site → one shared method.
-File: 671 → ~610 lines. One new private method.
+File: 641 → ~570 lines. One new private method.
 
-## Step 1b (this PR): Extract generation sliders from chat settings dialog
+## Step 1b: Extract generation sliders from chat settings dialog
 
-`chat_settings_dialog.dart` was 652 lines on Rawhide and grew to 734
-before this PR — 12 `SliderWithInput` calls, Kobold-only XTC/DRY
+`chat_settings_dialog.dart` was 734 lines at merge base (`45d7202`)
+— 12 `SliderWithInput` calls, Kobold-only XTC/DRY
 conditionals, dynamic temperature toggle, and Context Size with its
 `IgnorePointer` wrapper formed a 210-line inline block.
 
-Extracted `ChatSettingsGenerationSection` (281 lines) as a new
+Extracted `ChatSettingsGenerationSection` (277 lines) as a new
 `StatelessWidget` in `lib/ui/dialogs/`. The dialog passes its
 `_gen`, `storage`, `llmProvider`, `isRemote`, and an `onChanged`
 callback. The widget mutates `gen` directly and calls `onChanged`,
@@ -79,15 +92,15 @@ which the dialog uses to trigger `setState` + `_save()`.
 
 **Files changed:**
 
-- `lib/ui/dialogs/chat_settings_dialog.dart` — 652 → 407 lines
-- `lib/ui/dialogs/chat_settings_generation_section.dart` — new, 281 lines
+- `lib/ui/dialogs/chat_settings_dialog.dart` — 734 → 392 lines
+- `lib/ui/dialogs/chat_settings_generation_section.dart` — new, 277 lines
 
 **Verification:**
 
 - `flutter analyze` — zero warnings
-- `flutter test` — 2463 passed, 10 skipped, 3 pre-existing failures
+- `flutter test` — 2463 passed, 10 skipped, 2 pre-existing failures
 
-## Step 2 (follow-up PR): Extract session scalar loading
+## Step 2: Extract session scalar loading
 
 The session metadata load (authorNote, summary, name, fork), relationship
 `loadScalars`, time/nsfw/needs loading, and theme override fetch are
@@ -98,13 +111,23 @@ scalar fields from a `Session` object. This also fixes bug #1 (chaos mode)
 by construction — the shared method includes the chaos mode `loadScalars`
 call that `loadSession` was missing.
 
-Additionally, `_loadLastSession` applies relationship migration wrappers
-(`migrateShortTermScore`/`migrateLongTermScore`) while `loadSession`
-passes raw scores — the shared method should use the migration wrappers
-consistently to handle legacy pre-±300 sessions correctly.
+The shared method should pass raw scores to `loadScalars` — `loadSession`
+is already correct. The `migrateShortTermScore`/`migrateLongTermScore`
+wrappers in `_loadLastSession` (lines 140-143) should be removed. The
+legacy ±150→±300 rescale (bug #3) is a one-time operation that should
+run once behind a version marker and write the corrected value back,
+rather than re-running on every chat open.
+
+Bug #2 (duplicate `applyLegacyShortTermMigrationIfNeeded` call) is fixed
+by construction — the shared method calls it once, after `loadScalars`.
+
+**Asymmetry note:** `loadSession` calls
+`_userPersonaService.setActivePersona(session.userPersonaId)` (line 445);
+`_loadLastSession` does not. The shared method could unify this, but
+the call should be made optional or conditional on the caller's needs.
 
 **Impact:** ~80 lines extracted per call site → one shared method.
-File: ~610 → ~530 lines. One additional new private method (two total).
+File: 641 → ~560 lines. One additional new private method (two total).
 
 ## Verification
 
@@ -121,7 +144,19 @@ Step 1a (message hydration loop):
 Step 1b (generation sliders extraction):
 
 - `flutter analyze` — zero warnings
-- `flutter test` — 2463 passed, 10 skipped, 3 pre-existing failures
+- `flutter test` — 2463 passed, 10 skipped, 2 pre-existing failures
 - Manual: open chat settings → generation sliders work, dynamic temp
   toggle works, XTC/DRY show for Kobold only, Context Size greyed out
   when .kcpps active
+
+Step 2 (session scalar loading — planned):
+
+- `flutter analyze` — zero warnings
+- `flutter test` — all pass, plus new regression test for
+  per-chat generation-settings bleed (added in PR #169)
+- Manual: open chat A → change gen-settings → open chat B →
+  confirm B's own settings load (not A's)
+- Manual: open chat with legacy ±150 bond → confirm score is
+  rescaled once and written back, not re-doubled on subsequent opens
+- Grep for `migrateShortTermScore` in `chat_service_session_load.dart`
+  to confirm it is no longer called from either load path

--- a/docs/output-sanitizer-syntax.md
+++ b/docs/output-sanitizer-syntax.md
@@ -1,0 +1,237 @@
+# Output Sanitizer — Find & Replace Syntax
+
+The Output Sanitizer lets you automatically find text in AI responses and replace it with something else. Each rule has two fields:
+
+- **Find** — what to look for (supports simple wildcards)
+- **Replace** — what to put in its place (can reuse what was found)
+
+Rules run top to bottom. If a rule doesn't match anything, it's skipped.
+
+---
+
+## Plain text
+
+If you type `hello` in the find field, it matches the word "hello" exactly. Special characters like `(`, `)`, `+`, `*`, `[`, `]`, etc. are treated as normal text — they won't do anything fancy unless you use the wildcard syntax described below.
+
+---
+
+## Wildcards (masks)
+
+A wildcard is a short code that matches "any character of this type." Type a backslash `\` followed by a letter:
+
+| What you type | What it matches | Example |
+|---|---|---|
+| `\a` | Any printable character (letter, digit, punctuation, or space) | `\a` matches `A`, `3`, `!`, ` ` |
+| `\w` | Any letter or digit (a word character) | `\w` matches `a`, `Z`, `7` but not `!` or ` ` |
+| `\d` | Any digit | `\d` matches `0` through `9` |
+| `\l` | Any letter | `\l` matches `a` through `z` and `A` through `Z` |
+| `\p` | Any punctuation, symbol, or space | `\p` matches `!`, `.`, `@`, ` ` but not `a` or `5` |
+| `\\` | A literal backslash | `\\` matches `\` |
+
+**Example:** Find: `\d\d\d` matches any three digits in a row, like `427`.
+
+---
+
+## Repeating patterns (quantifiers)
+
+You can add a suffix to a wildcard to say how many times it should repeat:
+
+| Suffix | Meaning | Example |
+|---|---|---|
+| (none) | Exactly once | `\d` = one digit |
+| `?` | Zero or one (optional) | `\d?` = optional digit |
+| `+` | One or more | `\d+` = one or more digits |
+| `*` | Zero or more | `\d*` = zero or more digits |
+| `{n}` | Exactly n times | `\d{3}` = exactly 3 digits |
+| `{n,m}` | Between n and m times | `\d{2,4}` = 2 to 4 digits |
+| `{n,}` | n or more times | `\d{3,}` = 3 or more digits |
+
+**Example:** Find: `\l+` matches one or more letters — any word like `hello` or `A`.
+
+---
+
+## Capture groups — saving part of a match
+
+Sometimes you want to find a pattern but only replace *part* of it. For example: find `(hello)` and replace it with `[hello]` — you want to keep the word but change the brackets.
+
+Capture groups let you "save" part of what you match so you can use it in the replace field.
+
+### How to write a capture group
+
+Use `\(` to open the group and a bare `)` (without a backslash) to close it. Everything between them is the pattern to match and save.
+
+**Find:** `\(\d+)`
+**What it does:** Matches one or more digits and saves them.
+
+On the text `abc 123 def`, this:
+- `\(` opens the capture group (does not match any text)
+- `\d+` matches `123` and saves it
+- `)` closes the capture group (does not match any text)
+
+The saved part (`123`) can now be used in the replace field (see below).
+
+### `(` vs `\(` — this matters
+
+- `\(` (with backslash) = **opens a capture group**. This is not part of the text being matched — it's an instruction to "start saving here."
+- `(` (without backslash) = matches a **literal `(` character** in the text. It does not open a group.
+
+### Inside a capture group
+
+The text between `\(` and `)` works a little differently from the rest of the find field:
+
+- Wildcards like `\d`, `\w`, `\l` work the same way.
+- `\)` (backslash + close paren) matches a **literal `)` character** — it does NOT close the group. Only a bare `)` closes the group.
+
+**Example:** Find: `\(\w+\))` — this matches a word followed by a literal `)`, all inside a capture group. On the text `hello)`, it captures `hello)`.
+
+### Matching literal parentheses around content
+
+If the text is `(hello)` and you want to capture just the word `hello` without the `()`, use:
+
+**Find:** `\(\w+)`
+**Text:** `(hello)` → captures `hello`
+
+The `\(` opens the group, `\w+` matches the word, and the bare `)` closes the group. The parentheses in the text are just regular characters — `\(` and `)` in the find field are group delimiters, not literal matches.
+
+If you also want to consume the literal parentheses in the match (so the replace covers the whole thing):
+
+- put them outside the group:
+
+**Find:** `(\(\w+)\)`
+- `(` (bare) = literal `(` in text (auto-escaped by the compiler)
+- `\(` = opens capture group
+- `\w+` = matches the word
+- `)` = closes capture group
+- `)` (bare) = literal `)` in text
+
+On text `(hello)`: matches `(hello)`, captures `hello`.
+
+- or use 
+
+**Find:** `\(\(\w+\))`
+- `\(` = opens capture group
+- second `\(` = inside group works as literal `(` - `\` used as escape
+- `\w+` = matches the word
+- `\)` escaped = literal `)` in group
+- `)` = closes capture group
+
+On text `(hello)`: matches `(hello)`, captures `(hello)`.
+
+### Multiple capture groups
+
+You can have more than one capture group in a single rule. They are numbered in the order they open:
+
+**Find:** `\(\w+) \(\d+)`
+- First `\(`...`)` = capture group 1 (saves the word)
+- Second `\(`...`)` = capture group 2 (saves the number)
+
+On text `hello 42`: group 1 = `hello`, group 2 = `42`.
+
+---
+
+## The replace field
+
+The replace field controls what gets written in place of the matched text.
+
+### Using saved content (backreferences)
+
+Type `\` followed by a number to paste what a capture group saved:
+
+| What you type | What it pastes |
+|---|---|
+| `\1` | What capture group 1 matched |
+| `\2` | What capture group 2 matched |
+| `\3` | What capture group 3 matched |
+| ... | ... |
+
+**Example:**
+- Find: `\(\d+)` Replace: `[\1]`
+- On text `abc 123 def`: the group saves `123`, replace pastes it inside brackets → `abc [123] def`
+
+You can use backreferences more than once, or combine them with other text:
+
+- Find: `\(\w+)` Replace: `\1 and \1`
+- On text `abc hello def` → `abc hello and hello def`
+
+### Literal dollar sign
+
+If you need a literal `$` in the replacement, type `$$`:
+
+- Replace: `$$100` → outputs `$100`
+
+### Literal backslash
+
+If you need a literal `\` in the replacement, type `\\`:
+
+- Replace: `\\path` → outputs `\path`
+
+### Plain text
+
+Any text without `\` followed by a number is kept as-is:
+
+- Find: `hello` Replace: `goodbye`
+- On text `hello world` → `goodbye world`
+
+---
+
+## Worked examples
+
+### Example 1: Wrap numbers in brackets
+
+**Find:** `\(\d+)`
+**Replace:** `[\1]`
+
+| Input | Output |
+|---|---|
+| `abc 123 def` | `abc [123] def` |
+| `order 456 shipped` | `order [456] shipped` |
+
+The capture group saves the digits. The replace field wraps them in brackets.
+
+### Example 2: Swap two parts
+
+**Find:** `\(\w+) \(\d+)`
+**Replace:** `\2 \1`
+
+| Input | Output |
+|---|---|
+| `hello 42` | `42 hello` |
+
+Group 1 saves `hello`, group 2 saves `42`. The replace field puts group 2 first, then group 1.
+
+### Example 3: Replace but don't reuse
+
+**Find:** `\(\d+)`
+**Replace:** `NUMBER`
+
+| Input | Output |
+|---|---|
+| `abc 123 def` | `abc NUMBER def` |
+| `order 456 shipped` | `order NUMBER shipped` |
+
+The capture group still matches, but the replace field doesn't use `\1` — it just writes "NUMBER" every time.
+
+### Example 4: Remove em dashes
+
+**Find:** `—`
+**Replace:** ` - `
+
+| Input | Output |
+|---|---|
+| `she said—hello` | `she said - hello` |
+
+No capture groups needed — this is a simple find-and-replace of a special character (and only default rule shipped - because all this was started exactly due to the annoying habit of one otherwise wonderful LLM to use em-dashes without spacing...).
+
+### Example 5: Normalize multiple spaces to one
+
+**Find:** `\( )+`
+**Replace:** ` ` (a single space)
+
+| Input | Output |
+|---|---|
+| `hello   world` | `hello world` |
+| `a  b   c    d` | `a b c d` |
+
+`\( )` opens a capture group containing a single literal space, and `+` makes it match one or more. The replace pastes one space back.
+
+Why not `\p\p+`? Because `\p` matches any non-word character — punctuation, symbols, and spaces alike. `\p\p+` would happily eat `, `, `...`, `! `, and other punctuation+space combinations, turning `hello, world` into `hello world`. The pattern `\( )+` targets only spaces. That said, it can be exactly what you want in some situation...

--- a/lib/utils/output_sanitizer_regex.dart
+++ b/lib/utils/output_sanitizer_regex.dart
@@ -38,6 +38,7 @@ import 'package:front_porch_ai/models/output_sanitizer_rule.dart';
 ///   (none) – exactly one
 ///   `?`    – zero or one
 ///   `+`    – one or more
+///   `*`    – zero or more
 ///   `{n}`  – exactly n
 ///   `{n,m}` – between n and m (inclusive)
 ///   `{n,}`  – n or more
@@ -130,7 +131,7 @@ String compileFindPattern(String input) {
 int _consumeQuantifier(String input, int pos, StringBuffer out) {
   if (pos >= input.length) return pos;
   final ch = input[pos];
-  if (ch == '?' || ch == '+') {
+  if (ch == '?' || ch == '+' || ch == '*') {
     out.write(ch);
     return pos + 1;
   }

--- a/test/utils/output_sanitizer_regex_test.dart
+++ b/test/utils/output_sanitizer_regex_test.dart
@@ -82,6 +82,13 @@ void main() {
         expect(re.firstMatch('123')!.end, 3);
       });
 
+      test('* zero-or-more', () {
+        final re = RegExp(compileFindPattern(r'\d*'));
+        expect(re.firstMatch('')!.end, 0);
+        expect(re.firstMatch('3')!.end, 1);
+        expect(re.firstMatch('33')!.end, 2);
+      });
+
       test('{n} exactly n', () {
         final re = RegExp(compileFindPattern(r'\d{3}'));
         expect(re.firstMatch('123')!.end, 3);


### PR DESCRIPTION
A followup of PR162/169, fixing one thing that was found being wrong here - and adding a proper, user-friendly doc draft on the regex usage/capabilities that could be used for expansion of user-facing documentation or reference for further work that touches this.

- Add * (zero-or-more) quantifier to _consumeQuantifier alongside ? and +
- Add docs/output-sanitizer-syntax.md: comprehensive user-facing explanation of find/replace syntax for non-technical users
- Add * zero-or-more test in quantifiers group
- Update in-code doc comment to include * in the quantifiers list