### PR TITLE
test(creator): pin RealismStep Porch Life vs engine-off split

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -3,6 +3,16 @@
 
 # Changelog
 
+## 2026-08-17 — test(creator): pin RealismStep Porch Life vs engine split
+- **Why:** Feature Design lock: engine OFF on the AI creator still shows
+  Time, Chaos, and identity chips. The existing form-level finder
+  (`realism_form_porch_life_ungated_test.dart`) never pumps RealismStep,
+  so a wiring miss (no calendar callbacks, no Needs section, gating
+  Time/Chaos on the step) would stay green.
+- **What:** New finder test pumps public RealismStep with a seeded
+  CreatorState (engine off / 18+ on / engine on). No pixel golden.
+- **Files:** test/ui/character_creator/realism_step_porch_life_ungated_test.dart
+
 ## 2026-08-16 — feat(enhance): Porch Life is a keep-or-accept proposal
 - **Why:** AI Create now seeds wardrobe/ambitions, but Enhance is a
   sibling path. Blindly overwriting an authored wardrobe would be

--- a/test/ui/character_creator/realism_step_porch_life_ungated_test.dart
+++ b/test/ui/character_creator/realism_step_porch_life_ungated_test.dart
@@ -136,7 +136,8 @@ void main() {
 
       _expectPorchLifeVisible();
       expect(find.byType(NeedsFormSection), findsOneWidget);
-      expect(find.text('Needs Simulation'), findsOneWidget);
+      // Header + toggle row both say this; one would be a false red.
+      expect(find.text('Needs Simulation'), findsAtLeastNWidgets(1));
       expect(find.text('Short-Term Bond'), findsOneWidget);
       expect(find.text('Long-Term Bond'), findsOneWidget);
       expect(find.text('Trust Level'), findsOneWidget);

--- a/test/ui/character_creator/realism_step_porch_life_ungated_test.dart
+++ b/test/ui/character_creator/realism_step_porch_life_ungated_test.dart
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Feature Design lock: engine OFF on the AI creator RealismStep must still
+// show Porch Life (Time, Chaos, wardrobe / ambitions / likes) and hide
+// engine-only seeds (Needs, bond/trust, starting emotion, Afterglow,
+// Director). Intimate lists appear only when 18+ is on.
+//
+// Sibling of test/ui/widgets/realism_form_porch_life_ungated_test.dart, which
+// pumps RealismFormSection alone — no RealismStep, no needsFormSection, no
+// calendar callbacks, no 18+ path. This file pumps the public step so a
+// wiring regression (forgetting StoryBeginsRow callbacks, dropping Needs,
+// wrapping Time/Chaos behind the switch on the step) fails here even when
+// the form-level test stays green.
+//
+// Finder/widget test only — not a pixel golden. ChipListEditor uppercases
+// labels (`WEARING`), so assertions match that surface.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/services.dart';
+import 'package:front_porch_ai/ui/character_creator/character_creator.dart';
+import 'package:front_porch_ai/ui/character_creator/steps/realism_step.dart';
+import 'package:front_porch_ai/ui/widgets/needs_form_section.dart';
+import 'package:front_porch_ai/ui/widgets/story_begins_row.dart';
+import 'package:front_porch_ai/ui/widgets/widgets.dart';
+
+import '../../golden/support/fakes_storage.dart';
+
+CreatorState _seedState({required bool engineOn}) {
+  final state = CreatorState();
+  state.realismStepEnabled = engineOn;
+  // A card is required or RealismStep renders ValueKey('realism-error').
+  state.generatedCard = CharacterCard(name: 'Aria Vale');
+  return state;
+}
+
+Widget _app(CreatorState state, {StorageService? storage}) {
+  Widget home = Scaffold(body: RealismStep(state: state));
+  if (storage != null) {
+    home = ChangeNotifierProvider<StorageService>.value(
+      value: storage,
+      child: home,
+    );
+  }
+  return MaterialApp(home: home);
+}
+
+void _expectPorchLifeVisible() {
+  expect(find.byKey(const ValueKey('realism')), findsOneWidget);
+  expect(find.byKey(const ValueKey('realism-error')), findsNothing);
+  expect(find.byType(RealismFormSection), findsOneWidget);
+  expect(find.byType(IdentityChipLists), findsOneWidget);
+  expect(find.byType(StoryBeginsRow), findsOneWidget);
+  expect(find.text('Porch Life'), findsOneWidget);
+  expect(find.text('Enable Realism Engine'), findsOneWidget);
+  expect(find.text('Time & Day'), findsOneWidget);
+  expect(find.text('Time of Day'), findsOneWidget);
+  expect(find.text('Day Number'), findsOneWidget);
+  expect(find.text('Story begins: the day the chat starts'), findsOneWidget);
+  expect(find.text('Chaos Mode (Chance Time)'), findsOneWidget);
+  expect(find.text('Pockets & Wardrobe'), findsOneWidget);
+  expect(find.text('WEARING'), findsOneWidget);
+  expect(find.text('CARRYING'), findsOneWidget);
+  expect(find.text('Ambitions'), findsOneWidget);
+  expect(find.text('LONG-TERM GOALS'), findsOneWidget);
+  expect(find.text('Likes & Dislikes'), findsOneWidget);
+  expect(find.text('DRAWN TO'), findsOneWidget);
+  expect(find.text('PUT OFF BY'), findsOneWidget);
+}
+
+void _expectEngineOnlyHidden() {
+  expect(find.byType(NeedsFormSection), findsNothing);
+  expect(find.text('Needs Simulation'), findsNothing);
+  expect(find.text('Short-Term Bond'), findsNothing);
+  expect(find.text('Long-Term Bond'), findsNothing);
+  expect(find.text('Trust Level'), findsNothing);
+  expect(find.text('Starting Emotion'), findsNothing);
+  expect(find.text('Afterglow (intimacy pacing)'), findsNothing);
+  expect(find.text('Realism Verification (Director/Verifier)'), findsNothing);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('engine off keeps Porch Life and hides engine-only seeds', (
+    tester,
+  ) async {
+    final state = _seedState(engineOn: false);
+    addTearDown(state.dispose);
+
+    await tester.pumpWidget(_app(state));
+    await tester.pumpAndSettle();
+
+    _expectPorchLifeVisible();
+    _expectEngineOnlyHidden();
+    // No StorageService in scope → adultThemesEnabledOf is false.
+    expect(find.text('Intimate preferences'), findsNothing);
+    expect(find.text('WARMS TO'), findsNothing);
+    expect(find.text('NOT INTERESTED IN'), findsNothing);
+  });
+
+  testWidgets('engine off still shows intimate lists when 18+ is on', (
+    tester,
+  ) async {
+    final state = _seedState(engineOn: false);
+    addTearDown(state.dispose);
+    final storage = FakeStorageService();
+    addTearDown(storage.dispose);
+    // adultThemesEnabledOf reads realismSettings, not StorageService's
+    // own adultThemesEnabled getter (the fake's top-level getter is true
+    // for Porch Life goldens and would be the wrong switch here).
+    await storage.realismSettings.setAdultThemesEnabled(true);
+
+    await tester.pumpWidget(_app(state, storage: storage));
+    await tester.pumpAndSettle();
+
+    _expectPorchLifeVisible();
+    _expectEngineOnlyHidden();
+    expect(find.text('Intimate preferences'), findsOneWidget);
+    expect(find.text('WARMS TO'), findsOneWidget);
+    expect(find.text('NOT INTERESTED IN'), findsOneWidget);
+  });
+
+  testWidgets(
+    'engine on reveals Needs and bond because RealismStep wires them',
+    (tester) async {
+      final state = _seedState(engineOn: true);
+      addTearDown(state.dispose);
+
+      await tester.pumpWidget(_app(state));
+      await tester.pumpAndSettle();
+
+      _expectPorchLifeVisible();
+      expect(find.byType(NeedsFormSection), findsOneWidget);
+      expect(find.text('Needs Simulation'), findsOneWidget);
+      expect(find.text('Short-Term Bond'), findsOneWidget);
+      expect(find.text('Long-Term Bond'), findsOneWidget);
+      expect(find.text('Trust Level'), findsOneWidget);
+      expect(find.text('Starting Emotion'), findsOneWidget);
+      expect(find.text('Afterglow (intimacy pacing)'), findsOneWidget);
+      expect(
+        find.text('Realism Verification (Director/Verifier)'),
+        findsOneWidget,
+      );
+    },
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Feature Design lock: a mute / off Realism Engine on the AI creator **RealismStep** must still show Porch Life (Time & Day, Chaos, wardrobe / ambitions / likes) and must hide engine-only seeds (Needs, bond/trust, starting emotion, Afterglow, Director). Intimate lists stay behind 18+.

`test/ui/widgets/realism_form_porch_life_ungated_test.dart` already pumps `RealismFormSection` directly. That is not enough: it never mounts `RealismStep`, never passes `needsFormSection`, never wires calendar callbacks (`StoryBeginsRow`), and has no 18+ path. A wiring miss on the step would stay green there.

This PR adds a **finder/widget test** (not a pixel golden, no 900px surface bump) that pumps public `RealismStep` with a seeded `CreatorState` (`generatedCard` set so the key is `realism`, not `realism-error`).

- Engine off, no `StorageService`: Time / Chaos / identity chips visible; Needs / bond / emotion / Afterglow / Director / intimate hidden.
- Engine off + `FakeStorageService` with `realismSettings.adultThemesEnabled`: intimate lists appear.
- Engine on: Needs and bond appear — so a missing `needsFormSection` cannot hide behind the off-path `findsNothing`.

No product UI change. Kept the form-level sibling; this is the step-wiring pin.

## Target branch

- [x] This PR targets Rawhide

## Type of change

- [x] Test / CI pin (finder only)

## How was this tested?

Tested on: Linux (agent). Cannot launch the desktop app here.

- [x] `flutter analyze` on the new file — no issues
- [x] `flutter test` on this file **and** `realism_form_porch_life_ungated_test.dart` — 5 passed
- [x] Red-prove: `if (showTimeAndDay && enabled)` → first test red on missing `StoryBeginsRow`; restored → green. Forcing the engine-only block always on → red (duplicate Chaos). `dart fix --dry-run` — nothing to fix.

## Parity

- [x] Not applicable — test-only, no user-visible change

## Checklist

- [x] New file carries the AGPL header
- [x] I did not add a pixel golden or bump the 900px surface
- [x] I did not edit `pubspec.yaml` or rename leftover `realism*` identifiers

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4e6782-e0b0-45fd-b656-ba7419d0260a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4e6782-e0b0-45fd-b656-ba7419d0260a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

