### PR TITLE
test(enhance): pin Before vs After and empty-proposal mute-wipe

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -30,6 +30,18 @@
 - **Files:** chat_service_session_window.dart, chat_service_send.dart,
   chat_page.input*.dart, home_page_chrome.dart, enhance_review_body.dart,
   enhance_lorebook_merge.dart, web enhanceForm + EnhanceReviewModal
+## 2026-08-17 — test(enhance): pin Before vs After and empty-proposal mute-wipe
+- **Why:** A mute/empty Porch Life proposal must not silently wipe an
+  authored wardrobe. Review must show Before vs After. The default-off
+  and `if (use) write` gate existed; they were not pinned at save().
+- **What:** Extended existing tests. Non-empty Review asserts After
+  heading + authored Before lines + proposal chips. Empty Review keeps
+  authored Before and Use this off. save() with the default off leaves
+  the duplicate's wardrobe intact. Mute `{}` / `thanks` seed empties
+  the proposal only. isEmpty covers mute JSON. Wizard Interview lists
+  Porch Life. No product UI change. No goldens.
+- **Files:** enhance_porch_review_test.dart, enhance_porch_life_test.dart,
+  porch_life_identity_test.dart, enhance_wizard_test.dart
 
 ## 2026-08-16 — feat(enhance): Porch Life is a keep-or-accept proposal
 - **Why:** AI Create now seeds wardrobe/ambitions, but Enhance is a

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -3,6 +3,19 @@
 
 # Changelog
 
+## 2026-08-17 — fix(enhance): empty Porch Life lists do not wipe authored chips
+- **Why:** Bug Hunter: tests never called save(). Dropping `_use['porchLife']`
+  from the write gate stayed green, then mute copyWith emptied worn on
+  the duplicate. Ambitions-only is isEmpty false → Use this ON → worn:[]
+  dropped the coat while Before still showed it.
+- **What:** save() still gates on Use this (source-string pin, lorebook
+  class). applyPorchLifeProposal keeps authored lists the proposal left
+  empty. Mute-seed widget fixture uses empty-list extensions, not null.
+  Same merge on the PWA apply body.
+- **Files:** porch_life_identity.dart, enhance_review_body.dart,
+  enhance_porch_review_test.dart, porch_life_identity_test.dart,
+  web enhanceForm + EnhanceReviewModal
+
 ## 2026-08-17 — test(creator): pin RealismStep Porch Life vs engine split
 - **Why:** Feature Design lock: engine OFF on the AI creator still shows
   Time, Chaos, and identity chips. The existing form-level finder

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -36,10 +36,12 @@
   and `if (use) write` gate existed; they were not pinned at save().
 - **What:** Extended existing tests. Non-empty Review asserts After
   heading + authored Before lines + proposal chips. Empty Review keeps
-  authored Before and Use this off. save() with the default off leaves
-  the duplicate's wardrobe intact. Mute `{}` / `thanks` seed empties
+  authored Before and Use this off. Mute `{}` / `thanks` seed empties
   the proposal only. isEmpty covers mute JSON. Wizard Interview lists
-  Porch Life. No product UI change. No goldens.
+  Porch Life. save() was not widget-pinned — a CharacterRepository
+  fake still ran the real duplicateCharacter (`_isLoading`). The
+  `if (use) write` gate plus default-off is the wipe protection.
+  No product UI change. No goldens.
 - **Files:** enhance_porch_review_test.dart, enhance_porch_life_test.dart,
   porch_life_identity_test.dart, enhance_wizard_test.dart
 

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -13,5 +13,5 @@ These notes feed the in-app "Update Available" dialog for Rawhide / cutting-edge
 
 - 👗 **AI Create fills wardrobe, pockets and ambitions** — after it writes the greeting it seeds what they are wearing and carrying, what they want long-term, and (if you turned 18+ on in the wizard) intimate likes and limits. You can still edit every chip on the Porch Life step.
 
-- ✨ **AI Enhance proposes Porch Life the same way** — tick wardrobe / ambitions / likes on the interview checklist. Review shows Before vs After with a Use this switch, just like description. Untick to keep what the card already had.
+- ✨ **AI Enhance proposes Porch Life the same way** — tick wardrobe / ambitions / likes on the interview checklist. Review shows Before vs After with a Use this switch, just like description. Untick to keep what the card already had. A mute or partial proposal cannot wipe an authored wardrobe — empty lists stay off the write.
 

--- a/lib/services/chargen/porch_life_identity.dart
+++ b/lib/services/chargen/porch_life_identity.dart
@@ -164,6 +164,46 @@ Map<String, dynamic> _regexLists(String raw) {
   return out;
 }
 
+/// Keep [authored] for any list [proposed] left empty. A mute or partial
+/// Porch Life proposal must not silently wipe an authored wardrobe.
+PorchLifeIdentity mergePorchLifeIdentity(
+  PorchLifeIdentity authored,
+  PorchLifeIdentity proposed,
+) {
+  List<String> keep(List<String> next, List<String> prior) =>
+      next.isEmpty ? prior : next;
+  return PorchLifeIdentity(
+    ambitions: keep(proposed.ambitions, authored.ambitions),
+    likes: keep(proposed.likes, authored.likes),
+    dislikes: keep(proposed.dislikes, authored.dislikes),
+    worn: keep(proposed.worn, authored.worn),
+    carrying: keep(proposed.carrying, authored.carrying),
+    intimateInto: keep(proposed.intimateInto, authored.intimateInto),
+    intimateNotInto: keep(proposed.intimateNotInto, authored.intimateNotInto),
+  );
+}
+
+/// Stamp a merged Porch Life proposal onto the duplicate's extensions.
+/// Empty proposed lists keep the authored chips already on [base].
+FrontPorchExtensions applyPorchLifeProposal(
+  FrontPorchExtensions? base,
+  PorchLifeIdentity proposed,
+) {
+  final merged = mergePorchLifeIdentity(porchLifeIdentityOf(base), proposed);
+  final ext = base ?? FrontPorchExtensions();
+  return ext.copyWith(
+    ambitions: merged.ambitions,
+    likes: merged.likes,
+    dislikes: merged.dislikes,
+    intimateInto: merged.intimateInto,
+    intimateNotInto: merged.intimateNotInto,
+    inventory: Pockets.cardJsonFrom(
+      worn: merged.worn,
+      carrying: merged.carrying,
+    ),
+  );
+}
+
 /// Chip lists already stored on a card — the Enhance review "Before" column.
 PorchLifeIdentity porchLifeIdentityOf(FrontPorchExtensions? ext) {
   if (ext == null) return const PorchLifeIdentity();

--- a/lib/ui/pages/home/enhance/enhance_review_body.dart
+++ b/lib/ui/pages/home/enhance/enhance_review_body.dart
@@ -22,7 +22,6 @@ import 'package:provider/provider.dart';
 import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/services.dart';
 import 'package:front_porch_ai/services/chargen/chargen.dart';
-import 'package:front_porch_ai/services/chat/chat.dart' show Pockets;
 import 'package:front_porch_ai/ui/pages/home/enhance/enhance_review_porch_life.dart';
 import 'package:front_porch_ai/ui/theme/app_colors.dart';
 
@@ -178,16 +177,16 @@ class EnhanceReviewBodyState extends State<EnhanceReviewBody> {
         }
       }
       if (widget.selection.porchLife && (_use['porchLife'] ?? false)) {
-        final ext = copy.frontPorchExtensions ?? FrontPorchExtensions();
-        copy.frontPorchExtensions = ext.copyWith(
-          ambitions: _porchAmbitions,
-          likes: _porchLikes,
-          dislikes: _porchDislikes,
-          intimateInto: _porchIntimateInto,
-          intimateNotInto: _porchIntimateNotInto,
-          inventory: Pockets.cardJsonFrom(
+        copy.frontPorchExtensions = applyPorchLifeProposal(
+          copy.frontPorchExtensions,
+          PorchLifeIdentity(
+            ambitions: _porchAmbitions,
+            likes: _porchLikes,
+            dislikes: _porchDislikes,
             worn: _porchWorn,
             carrying: _porchCarrying,
+            intimateInto: _porchIntimateInto,
+            intimateNotInto: _porchIntimateNotInto,
           ),
         );
       }

--- a/test/services/chargen/enhance_porch_life_test.dart
+++ b/test/services/chargen/enhance_porch_life_test.dart
@@ -117,7 +117,10 @@ void main() {
           llm.prompts.any((p) => p.contains('Seed Porch Life identity')),
           isTrue,
         );
-        expect(porchLifeIdentityOf(result!.frontPorchExtensions).isEmpty, isTrue);
+        expect(
+          porchLifeIdentityOf(result!.frontPorchExtensions).isEmpty,
+          isTrue,
+        );
         expect(source.frontPorchExtensions?.ambitions, ['old goal']);
         expect(porchLifeIdentityOf(source.frontPorchExtensions).worn, [
           'old coat',

--- a/test/services/chargen/enhance_porch_life_test.dart
+++ b/test/services/chargen/enhance_porch_life_test.dart
@@ -82,18 +82,67 @@ void main() {
       expect(result!.frontPorchExtensions, isNull);
     },
   );
+
+  for (final mute in ['{}', 'thanks']) {
+    test(
+      'mute "$mute" empties the proposal identity, not the source card',
+      () async {
+        final source = CharacterCard(
+          name: 'Nina',
+          description: 'A baker.',
+          personality: 'Hungry and kind.',
+          firstMessage: 'I wipe flour off the apron.',
+          frontPorchExtensions: FrontPorchExtensions(
+            ambitions: const ['old goal'],
+            inventory: const {
+              'worn': ['old coat'],
+            },
+          ),
+        );
+        final llm = _EnhancePorchLlm(porchReply: mute);
+        final gen = CharacterGenService(llm);
+        final result = await gen.enhanceCharacter(
+          source: source,
+          selection: const EnhanceSelection(
+            description: false,
+            personality: false,
+            exampleDialogue: false,
+            porchLife: true,
+          ),
+          chatGrounding: _grounding,
+        );
+
+        expect(result, isNotNull);
+        expect(
+          llm.prompts.any((p) => p.contains('Seed Porch Life identity')),
+          isTrue,
+        );
+        expect(porchLifeIdentityOf(result!.frontPorchExtensions).isEmpty, isTrue);
+        expect(source.frontPorchExtensions?.ambitions, ['old goal']);
+        expect(porchLifeIdentityOf(source.frontPorchExtensions).worn, [
+          'old coat',
+        ]);
+      },
+    );
+  }
 }
 
 class _EnhancePorchLlm extends LLMService {
+  _EnhancePorchLlm({this.porchReply});
+
+  /// When set, the Porch Life seed yields this text instead of a valid JSON
+  /// proposal — mute (`{}`) and garbage (`thanks`) both parse to isEmpty.
+  final String? porchReply;
   final prompts = <String>[];
 
   @override
   Stream<String> generateStream(GenerationParams params) async* {
     prompts.add(params.prompt);
     if (params.prompt.contains('Seed Porch Life identity')) {
-      yield '{"ambitions":["stay fed"],"likes":["hot coffee"],'
-          '"dislikes":["being interrupted"],"worn":["flour-dusted apron"],'
-          '"carrying":["shop keys"]}';
+      yield porchReply ??
+          '{"ambitions":["stay fed"],"likes":["hot coffee"],'
+              '"dislikes":["being interrupted"],"worn":["flour-dusted apron"],'
+              '"carrying":["shop keys"]}';
       return;
     }
     if (params.prompt.contains('Write example dialogue exchanges')) {

--- a/test/services/chargen/porch_life_identity_test.dart
+++ b/test/services/chargen/porch_life_identity_test.dart
@@ -67,6 +67,18 @@ thanks
       expect(id.carrying.length, lessThanOrEqualTo(8));
       expect(id.carrying.first, 'car keys');
     });
+
+    test('isEmpty is all seven lists empty — mute JSON included', () {
+      expect(const PorchLifeIdentity().isEmpty, isTrue);
+      expect(parsePorchLifeIdentity('{}', nsfw: false).isEmpty, isTrue);
+      expect(parsePorchLifeIdentity('thanks', nsfw: false).isEmpty, isTrue);
+      expect(
+        parsePorchLifeIdentity({
+          'ambitions': ['stay fed'],
+        }, nsfw: false).isEmpty,
+        isFalse,
+      );
+    });
   });
 
   group('generateCharacter seeds Porch Life', () {

--- a/test/services/chargen/porch_life_identity_test.dart
+++ b/test/services/chargen/porch_life_identity_test.dart
@@ -5,6 +5,7 @@
 // and messy text JSON) and must NEVER leak intimate lists when 18+ is off.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/chargen/chargen.dart';
 import 'package:front_porch_ai/services/character_gen_service.dart';
 import 'package:front_porch_ai/services/llm_service.dart';
@@ -78,6 +79,32 @@ thanks
         }, nsfw: false).isEmpty,
         isFalse,
       );
+    });
+  });
+
+  group('applyPorchLifeProposal', () {
+    final authored = FrontPorchExtensions(
+      ambitions: const ['old goal'],
+      inventory: const {
+        'worn': ['old coat'],
+      },
+    );
+
+    test('mute/empty proposal does not drop authored old coat', () {
+      final out = applyPorchLifeProposal(authored, const PorchLifeIdentity());
+      final id = porchLifeIdentityOf(out);
+      expect(id.ambitions, ['old goal']);
+      expect(id.worn, ['old coat']);
+    });
+
+    test('ambitions-only proposal does not replace authored worn', () {
+      final out = applyPorchLifeProposal(
+        authored,
+        const PorchLifeIdentity(ambitions: ['stay fed']),
+      );
+      final id = porchLifeIdentityOf(out);
+      expect(id.ambitions, ['stay fed']);
+      expect(id.worn, ['old coat']);
     });
   });
 

--- a/test/ui/pages/home/enhance_porch_review_test.dart
+++ b/test/ui/pages/home/enhance_porch_review_test.dart
@@ -6,11 +6,29 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import 'package:front_porch_ai/models/models.dart';
-import 'package:front_porch_ai/services/chargen/chat_grounding.dart';
+import 'package:front_porch_ai/services/chargen/chargen.dart';
 import 'package:front_porch_ai/ui/pages/home/enhance/enhance_review_body.dart';
 
 Widget _app(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+const _porchOnly = EnhanceSelection(
+  description: false,
+  personality: false,
+  exampleDialogue: false,
+  porchLife: true,
+);
+
+FrontPorchExtensions _authored() => FrontPorchExtensions(
+  ambitions: const ['old goal'],
+  inventory: const {
+    'worn': ['old coat'],
+  },
+);
+
+CharacterCard _nina({FrontPorchExtensions? ext}) =>
+    CharacterCard(name: 'Nina', frontPorchExtensions: ext);
 
 void main() {
   testWidgets('Porch Life proposal shows Before vs After with Use this on', (
@@ -19,30 +37,16 @@ void main() {
     await tester.pumpWidget(
       _app(
         EnhanceReviewBody(
-          original: CharacterCard(
-            name: 'Nina',
-            frontPorchExtensions: FrontPorchExtensions(
-              ambitions: const ['old goal'],
-              inventory: const {
-                'worn': ['old coat'],
-              },
-            ),
-          ),
-          enhanced: CharacterCard(
-            name: 'Nina',
-            frontPorchExtensions: FrontPorchExtensions(
+          original: _nina(ext: _authored()),
+          enhanced: _nina(
+            ext: FrontPorchExtensions(
               ambitions: const ['stay fed'],
               inventory: const {
                 'worn': ['flour-dusted apron'],
               },
             ),
           ),
-          selection: const EnhanceSelection(
-            description: false,
-            personality: false,
-            exampleDialogue: false,
-            porchLife: true,
-          ),
+          selection: _porchOnly,
         ),
       ),
     );
@@ -52,8 +56,13 @@ void main() {
       find.text('Porch Life (wardrobe, ambitions, likes)'),
       findsOneWidget,
     );
-    expect(find.textContaining('old goal'), findsOneWidget);
+    expect(find.text('After (editable)'), findsOneWidget);
+    expect(find.text('Use this'), findsOneWidget);
+    // Before is the authored line, not a silent overwrite of the After chips.
+    expect(find.text('Ambitions: old goal'), findsOneWidget);
+    expect(find.text('Wearing: old coat'), findsOneWidget);
     expect(find.text('stay fed'), findsOneWidget);
+    expect(find.text('flour-dusted apron'), findsOneWidget);
     final useSwitch = tester.widget<Switch>(find.byType(Switch).first);
     expect(useSwitch.value, isTrue);
   });
@@ -64,24 +73,17 @@ void main() {
     await tester.pumpWidget(
       _app(
         EnhanceReviewBody(
-          original: CharacterCard(
-            name: 'Nina',
-            frontPorchExtensions: FrontPorchExtensions(
-              ambitions: const ['old goal'],
-            ),
-          ),
-          enhanced: CharacterCard(name: 'Nina'),
-          selection: const EnhanceSelection(
-            description: false,
-            personality: false,
-            exampleDialogue: false,
-            porchLife: true,
-          ),
+          original: _nina(ext: _authored()),
+          enhanced: _nina(),
+          selection: _porchOnly,
         ),
       ),
     );
     await tester.pumpAndSettle();
 
+    expect(find.text('After (editable)'), findsOneWidget);
+    expect(find.text('Ambitions: old goal'), findsOneWidget);
+    expect(find.text('Wearing: old coat'), findsOneWidget);
     final useSwitch = tester.widget<Switch>(find.byType(Switch).first);
     expect(useSwitch.value, isFalse);
   });

--- a/test/ui/pages/home/enhance_porch_review_test.dart
+++ b/test/ui/pages/home/enhance_porch_review_test.dart
@@ -4,6 +4,8 @@
 // Enhance Review must offer keep-or-accept for Porch Life, and an empty
 // proposal must default Use this OFF so a mute model cannot wipe a wardrobe.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -74,7 +76,15 @@ void main() {
       _app(
         EnhanceReviewBody(
           original: _nina(ext: _authored()),
-          enhanced: _nina(),
+          // Mute-seed shape: copyWith empty lists, not a null extensions
+          // object. A pin on `_nina()` (null ext) can stay green while
+          // `extensions != null` defaults Use this ON.
+          enhanced: _nina(
+            ext: FrontPorchExtensions(
+              ambitions: const [],
+              inventory: const {'worn': <String>[], 'carrying': <String>[]},
+            ),
+          ),
           selection: _porchOnly,
         ),
       ),
@@ -165,5 +175,20 @@ void main() {
 
     final useSwitch = tester.widget<Switch>(find.byType(Switch).first);
     expect(useSwitch.value, isFalse);
+  });
+
+  test('Save writes Porch Life only when Use this is on', () {
+    final src = File(
+      'lib/ui/pages/home/enhance/enhance_review_body.dart',
+    ).readAsStringSync();
+    final saveAt = src.indexOf('Future<CharacterCard?> save()');
+    expect(saveAt, greaterThanOrEqualTo(0));
+    final save = src.substring(saveAt);
+    expect(
+      save,
+      contains("widget.selection.porchLife && (_use['porchLife'] ?? false)"),
+    );
+    expect(save, contains('applyPorchLifeProposal'));
+    expect(save.contains('ext.copyWith('), isFalse);
   });
 }

--- a/test/ui/pages/home/enhance_wizard_test.dart
+++ b/test/ui/pages/home/enhance_wizard_test.dart
@@ -215,6 +215,10 @@ void main() {
     expect(find.text('What should the interview rewrite?'), findsOneWidget);
     expect(find.text('Description'), findsOneWidget);
     expect(find.text('Personality'), findsOneWidget);
+    expect(
+      find.text('Porch Life (wardrobe, ambitions, likes)'),
+      findsOneWidget,
+    );
     expect(find.text('Allow 18+ themes'), findsOneWidget);
     expect(find.textContaining('very short'), findsOneWidget);
     expect(find.text('Start the Interview'), findsOneWidget);

--- a/web_ui/src/components/aichargen/EnhanceReviewModal.tsx
+++ b/web_ui/src/components/aichargen/EnhanceReviewModal.tsx
@@ -89,7 +89,15 @@ export function EnhanceReviewModal({
       );
       await api.post(
         `/api/characters/${dup.id}`,
-        buildApplyBody(proposal, accepted, edits, { lorebook: old?.lorebook }),
+        buildApplyBody(proposal, accepted, edits, {
+          lorebook: old?.lorebook,
+          ambitions: old?.realism?.ambitions,
+          likes: old?.realism?.likes,
+          dislikes: old?.realism?.dislikes,
+          intimateInto: old?.realism?.intimateInto,
+          intimateNotInto: old?.realism?.intimateNotInto,
+          inventory: old?.realism?.inventory,
+        }),
       );
       // Don't leave yet — offer to bring the base character's chats along.
       setBusy(false);

--- a/web_ui/src/components/aichargen/enhanceForm.test.ts
+++ b/web_ui/src/components/aichargen/enhanceForm.test.ts
@@ -125,6 +125,30 @@ describe('buildApplyBody', () => {
     expect(body).not.toHaveProperty('description');
   });
 
+  it('empty proposed worn keeps authored old coat', () => {
+    const body = buildApplyBody(
+      {
+        porchLife: {
+          ambitions: ['stay fed'],
+          likes: [],
+          dislikes: [],
+          worn: [],
+          carrying: [],
+          intimateInto: [],
+          intimateNotInto: [],
+        },
+      },
+      { ...allOn, description: false, personality: false, exampleDialogue: false, scenario: false, greetings: false, lorebook: false },
+      {},
+      { ambitions: ['old goal'], inventory: { worn: ['old coat'] } },
+    );
+    expect(body.ambitions).toEqual(['stay fed']);
+    expect(body.inventory).toEqual({
+      worn: ['old coat'],
+      carrying: [],
+    });
+  });
+
   it('nothing accepted → empty body (duplicate stays pristine)', () => {
     const body = buildApplyBody(proposal, {
       description: false,

--- a/web_ui/src/components/aichargen/enhanceForm.ts
+++ b/web_ui/src/components/aichargen/enhanceForm.ts
@@ -168,6 +168,38 @@ export function mergeLorebook(original: unknown, incoming: unknown): Record<stri
   return { ...rest, entries };
 }
 
+/** Authored Porch Life on the duplicate — empty proposed lists keep these. */
+export type EnhanceApplyOriginal = {
+  lorebook?: unknown;
+  ambitions?: string[];
+  likes?: string[];
+  dislikes?: string[];
+  intimateInto?: string[];
+  intimateNotInto?: string[];
+  inventory?: { worn?: unknown[]; carrying?: unknown[] };
+};
+
+/** Keep [authored] when [proposed] is missing or empty. */
+export function keepAuthoredIfEmpty(
+  proposed: string[] | undefined,
+  authored: string[] | undefined,
+): string[] {
+  return proposed && proposed.length > 0 ? proposed : (authored ?? []);
+}
+
+function inventoryNames(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item === 'string' && item.trim()) out.push(item);
+    else if (item && typeof item === 'object' && typeof (item as { name?: unknown }).name === 'string') {
+      const name = ((item as { name: string }).name).trim();
+      if (name) out.push(name);
+    }
+  }
+  return out;
+}
+
 /**
  * The partial-update body for `POST /api/characters/<newId>`: only accepted
  * sections are included (the duplicate already carries the original for the
@@ -177,7 +209,7 @@ export function buildApplyBody(
   proposal: EnhanceProposal,
   accepted: EnhanceAccepted,
   edits: EnhanceEdits = {},
-  original: { lorebook?: unknown } = {},
+  original: EnhanceApplyOriginal = {},
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (accepted.description && proposal.description !== undefined) {
@@ -205,14 +237,14 @@ export function buildApplyBody(
   }
   if (accepted.porchLife && proposal.porchLife) {
     const p = edits.porchLife ?? proposal.porchLife;
-    body.ambitions = p.ambitions;
-    body.likes = p.likes;
-    body.dislikes = p.dislikes;
-    body.intimateInto = p.intimateInto;
-    body.intimateNotInto = p.intimateNotInto;
+    body.ambitions = keepAuthoredIfEmpty(p.ambitions, original.ambitions);
+    body.likes = keepAuthoredIfEmpty(p.likes, original.likes);
+    body.dislikes = keepAuthoredIfEmpty(p.dislikes, original.dislikes);
+    body.intimateInto = keepAuthoredIfEmpty(p.intimateInto, original.intimateInto);
+    body.intimateNotInto = keepAuthoredIfEmpty(p.intimateNotInto, original.intimateNotInto);
     body.inventory = {
-      worn: p.worn,
-      carrying: p.carrying,
+      worn: keepAuthoredIfEmpty(p.worn, inventoryNames(original.inventory?.worn)),
+      carrying: keepAuthoredIfEmpty(p.carrying, inventoryNames(original.inventory?.carrying)),
     };
   }
   return body;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

HOLD from Bug Hunter — do not merge until this is reviewed.

A mute or empty Porch Life proposal must not silently wipe an authored wardrobe. The first pins never called `save()`, so dropping `_use['porchLife']` from the write gate stayed green while mute `copyWith` emptied `worn` on the duplicate.

Ambitions-only is `isEmpty == false` → Use this ON → `save()` wrote `worn: []` and dropped the coat while Before still showed `Wearing: old coat`. That residual wipe was real.

## What landed

1. **Source-string pin** (same class as lorebook): `save()` must contain `widget.selection.porchLife && (_use['porchLife'] ?? false)` and `applyPorchLifeProposal`. Goes red if the use gate is deleted.
2. **Apply assert**: `applyPorchLifeProposal` keeps authored lists the proposal left empty. Mute/empty does not drop `old coat`. Ambitions-only updates ambitions and keeps the coat.
3. **Product fix (no UI redesign)**: empty proposed lists are not a silent replace. Default-off stays whole-section; save merges per-list.
4. Empty-widget fixture is now mute-seed shape (empty lists on extensions, not `null`). A pin on `_nina()` (null ext) can stay green while `extensions != null` defaults Use this ON.
5. Web twin: `keepAuthoredIfEmpty` in `buildApplyBody`, original wardrobe passed from the review modal.

No #194 voice. No goldens. No pubspec bump. Existing assertions not weakened.

## How was this tested?

Linux (this agent). App not launched.

```
flutter test test/ui/pages/home/enhance_porch_review_test.dart \
  test/services/chargen/porch_life_identity_test.dart
```

Green. `flutter analyze` on touched Dart paths: no issues.

`npx vitest run src/components/aichargen/enhanceForm.test.ts` — 14 passed.

**Red-then-green:**
- Drop `_use['porchLife']` from the write gate → source pin fails
- Skip merge in `applyPorchLifeProposal` → mute/ambitions-only apply asserts fail (`old coat` → `[]`)
- Restored → green

## Parity

Web apply body merges empty proposed lists with authored chips. Same rule as desktop `applyPorchLifeProposal`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fab03759-333c-4da0-9297-103e58cbffcd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fab03759-333c-4da0-9297-103e58cbffcd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

