### PR TITLE
fix(chat,enhance): hold picker overlay through hydrate; empty Use this; lorebook append

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -12,6 +12,24 @@
 - **What:** New finder test pumps public RealismStep with a seeded
   CreatorState (engine off / 18+ on / engine on). No pixel golden.
 - **Files:** test/ui/character_creator/realism_step_porch_life_ungated_test.dart
+## 2026-08-17 — fix(chat,enhance): picker overlay hold, empty Use this, lorebook append
+- **Why:** Four verified user-hittable bugs. The session picker dropped
+  `isLoadingSession` after the last-24 tail, so a fast send could persist
+  the pre-hydrate realism reset onto the last-active chat. Enhance Review
+  defaulted empty text fields Use this ON, and Save replaced the original
+  lorebook with only the new entries. A failed home-grid load left ChatPage
+  sitting on a half-hydrated transcript.
+- **What:** `_openSessionMessages` no longer calls `endSessionLoad` —
+  the owner drops the overlay after hydrate (`setActiveCharacter` finally
+  / picker finally). Send and the composer gate on `isLoadingSession`.
+  Empty proposed description/personality/dialogue/scenario/greetings
+  default Use this OFF (porchLife path untouched). Save appends accepted
+  lore entries onto the duplicated book (merge by name). Failed
+  `_pushChatWhile` pops ChatPage and snacks. Same empty-text + lore
+  merge on the PWA.
+- **Files:** chat_service_session_window.dart, chat_service_send.dart,
+  chat_page.input*.dart, home_page_chrome.dart, enhance_review_body.dart,
+  enhance_lorebook_merge.dart, web enhanceForm + EnhanceReviewModal
 
 ## 2026-08-16 — feat(enhance): Porch Life is a keep-or-accept proposal
 - **Why:** AI Create now seeds wardrobe/ambitions, but Enhance is a

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -5,6 +5,12 @@ These notes feed the in-app "Update Available" dialog for Rawhide / cutting-edge
 
 ## Recent improvements (unreleased — ships in the next build)
 
+- 🛡️ **Opening a saved chat no longer accepts a send into the last one** — the loading cover stays up until that chat is actually ready, so a fast Enter cannot write into the wrong conversation.
+
+- ✨ **Enhance Review leaves empty rewrites unticked** — if the model returned a blank description or greeting, Use this starts off so Save cannot wipe what you already wrote.
+
+- 📖 **Enhance lorebook adds entries instead of replacing the book** — new places from the story are appended; the original entries stay.
+
 - 👗 **AI Create fills wardrobe, pockets and ambitions** — after it writes the greeting it seeds what they are wearing and carrying, what they want long-term, and (if you turned 18+ on in the wizard) intimate likes and limits. You can still edit every chip on the Porch Life step.
 
 - ✨ **AI Enhance proposes Porch Life the same way** — tick wardrobe / ambitions / likes on the interview checklist. Review shows Before vs After with a Use this switch, just like description. Untick to keep what the card already had.

--- a/lib/services/chargen/chargen.dart
+++ b/lib/services/chargen/chargen.dart
@@ -10,5 +10,6 @@ library;
 export 'char_macro.dart';
 export 'chat_grounding.dart';
 export 'enhance_context.dart';
+export 'enhance_lorebook_merge.dart';
 export 'lorebook_mechanics.dart';
 export 'porch_life_identity.dart';

--- a/lib/services/chargen/enhance_lorebook_merge.dart
+++ b/lib/services/chargen/enhance_lorebook_merge.dart
@@ -29,9 +29,7 @@ List<LorebookEntry> mergeLorebookEntries(
   final out = List<LorebookEntry>.from(original);
   for (final entry in incoming) {
     final name = entry.name.trim();
-    final i = name.isEmpty
-        ? -1
-        : out.indexWhere((e) => e.name.trim() == name);
+    final i = name.isEmpty ? -1 : out.indexWhere((e) => e.name.trim() == name);
     if (i >= 0) {
       out[i] = entry;
     } else {

--- a/lib/services/chargen/enhance_lorebook_merge.dart
+++ b/lib/services/chargen/enhance_lorebook_merge.dart
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Front Porch AI.
+//
+// Front Porch AI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Front Porch AI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:front_porch_ai/models/models.dart';
+
+/// Append [incoming] onto [original], replacing an existing entry when
+/// the incoming name is non-empty and already present. Enhance Review
+/// must never assign the proposal as the whole book — the duplicate
+/// already carries the original entries.
+List<LorebookEntry> mergeLorebookEntries(
+  List<LorebookEntry> original,
+  List<LorebookEntry> incoming,
+) {
+  final out = List<LorebookEntry>.from(original);
+  for (final entry in incoming) {
+    final name = entry.name.trim();
+    final i = name.isEmpty
+        ? -1
+        : out.indexWhere((e) => e.name.trim() == name);
+    if (i >= 0) {
+      out[i] = entry;
+    } else {
+      out.add(entry);
+    }
+  }
+  return out;
+}

--- a/lib/services/chat/chat_service_send.dart
+++ b/lib/services/chat/chat_service_send.dart
@@ -602,9 +602,9 @@ extension ChatServiceSend on ChatService {
         final cards = await _journalStore.cardsFor(sessionId, ownerId);
         final sorted = [...cards]
           ..sort(
-            (a, b) => JournalPhysics.cooledHeat(
-              b,
-            ).compareTo(JournalPhysics.cooledHeat(a)),
+            (a, b) =>
+                JournalPhysics.cooledHeat(b)
+                    .compareTo(JournalPhysics.cooledHeat(a)),
           );
         return await _dreamService.generateDream(
           characterName: ownerCard.name,

--- a/lib/services/chat/chat_service_send.dart
+++ b/lib/services/chat/chat_service_send.dart
@@ -35,6 +35,10 @@ extension ChatServiceSend on ChatService {
         (text.trim().isEmpty && imageBytes == null)) {
       return;
     }
+    // Overlay / picker hydrate is still in flight. A send here would
+    // persist the pre-hydrate realism reset onto whichever session is
+    // currently live (often the last-active chat, not the one opening).
+    if (_isLoadingSession) return;
     // Don't let a user turn start while forked-in entrances are still playing —
     // it would race the one-shot entrance directive / turn positioning.
     if (_entrancesInFlight) return;

--- a/lib/services/chat/chat_service_session_window.dart
+++ b/lib/services/chat/chat_service_session_window.dart
@@ -4,10 +4,12 @@
 part of '../chat_service.dart';
 
 /// Tail-first session hydrate, then a chunked background backfill of
-/// everything older. The overlay drops after the tail; the rest pages
+/// everything older. The tail is what ChatPage paints; the rest pages
 /// in with a yield per chunk so 11k JSON decodes cannot freeze the
-/// first paint. RAG/Journal wait on [_awaitHistoryHydrated] or treat
-/// [basePosition] as already out of context.
+/// first paint. Overlay drop belongs to the owner after scalars
+/// hydrate — this method must not call [endSessionLoad]. RAG/Journal
+/// wait on [_awaitHistoryHydrated] or treat [basePosition] as already
+/// out of context.
 extension ChatServiceSessionWindow on ChatService {
   bool get isBackfillingHistory => _history.isBackfilling;
   bool get hasOlderHistory => _history.hasMore;
@@ -42,8 +44,10 @@ extension ChatServiceSessionWindow on ChatService {
     return abs;
   }
 
-  /// Last [kSessionOpenWindow] rows. Drops the overlay here so ChatPage
-  /// can paint, then pages the rest in on a yielded loop.
+  /// Last [kSessionOpenWindow] rows, then pages the rest in on a
+  /// yielded loop. Does not drop the session overlay — scalars still
+  /// hydrate after this returns, and a picker-owned load still has
+  /// [loadSession] / [startNewChat] to run.
   Future<void> _openSessionMessages(String sessionId) async {
     final sw = Stopwatch()..start();
     _history.reset();
@@ -63,7 +67,6 @@ extension ChatServiceSessionWindow on ChatService {
       'n=${tail.length} base=${_history.basePosition} '
       'hasMore=${_history.hasMore} session=$sessionId',
     );
-    endSessionLoad();
     if (_history.hasMore) {
       final epoch = _history.epoch;
       _history.backfill = _runBackgroundBackfill(sessionId, epoch);

--- a/lib/ui/pages/chat_page.input.dart
+++ b/lib/ui/pages/chat_page.input.dart
@@ -140,10 +140,11 @@ extension _ChatPageInput on _ChatPageState {
   /// photo BYTES to ChatService, which saves the photo only after its own
   /// guards pass — so we never save a file for a turn ChatService will drop.
   /// We mirror every one of sendMessage's silent early-returns here
-  /// (isGenerating / isGuestBusy / entrancesInFlight / no active chat) so the
-  /// pending photo and typed text are preserved for retry rather than
-  /// consumed into the void. In observer mode the photo is NOT consumed —
-  /// director notes are pure instructions and would drop it.
+  /// (isGenerating / isLoadingSession / isGuestBusy / entrancesInFlight /
+  /// no active chat) so the pending photo and typed text are preserved
+  /// for retry rather than consumed into the void. In observer mode the
+  /// photo is NOT consumed — director notes are pure instructions and
+  /// would drop it.
   void _sendCurrentMessage(ChatService chatService) {
     final pending = chatService.observerMode ? null : _pendingImageBytes;
     final text = _controller.text;
@@ -155,6 +156,7 @@ extension _ChatPageInput on _ChatPageState {
         // deliberately guards on isGenerating (streaming) and NOT on
         // isSettlingTurn — see the comment there.
         chatService.isGenerating ||
+        chatService.isLoadingSession ||
         chatService.isGuestBusy ||
         chatService.isPhotoTurnInFlight ||
         chatService.entrancesInFlight ||

--- a/lib/ui/pages/chat_page.input_actions.dart
+++ b/lib/ui/pages/chat_page.input_actions.dart
@@ -221,6 +221,7 @@ extension _ChatPageInputActions on _ChatPageState {
         child: AppTextField(
           controller: _controller,
           focusNode: _chatFocusNode,
+          enabled: !chatService.isLoadingSession,
           maxLines: 10,
           minLines: _inputMinLines,
           textInputAction: TextInputAction.newline,
@@ -441,7 +442,9 @@ extension _ChatPageInputActions on _ChatPageState {
                             ? Colors.amberAccent
                             : AppColors.porchAmberOf(context)),
                 ),
-                onPressed: () => _sendCurrentMessage(chatService),
+                onPressed: chatService.isLoadingSession
+                    ? null
+                    : () => _sendCurrentMessage(chatService),
               ),
             ),
     ];

--- a/lib/ui/pages/chat_page.input_actions.dart
+++ b/lib/ui/pages/chat_page.input_actions.dart
@@ -85,7 +85,8 @@ extension _ChatPageInputActions on _ChatPageState {
         ),
         PopupMenuItem(
           value: 'import',
-          enabled: !chatService.isGenerating &&
+          enabled:
+              !chatService.isGenerating &&
               !chatService.isSettlingTurn &&
               !chatService.isImporting,
           child: Tooltip(

--- a/lib/ui/pages/home/enhance/enhance_review_body.dart
+++ b/lib/ui/pages/home/enhance/enhance_review_body.dart
@@ -74,7 +74,8 @@ class EnhanceReviewBodyState extends State<EnhanceReviewBody> {
     void field(String key, bool selected, String newValue) {
       if (!selected) return;
       _controllers[key] = TextEditingController(text: newValue);
-      _use[key] = true;
+      // Empty proposal must not default ON — same rule as porchLife.
+      _use[key] = newValue.trim().isNotEmpty;
     }
 
     field(
@@ -98,7 +99,9 @@ class EnhanceReviewBodyState extends State<EnhanceReviewBody> {
       for (var i = 0; i < widget.enhanced.alternateGreetings.length; i++) {
         field('alt$i', true, widget.enhanced.alternateGreetings[i]);
       }
-      _use['greetings'] = true;
+      _use['greetings'] =
+          widget.enhanced.firstMessage.trim().isNotEmpty ||
+          widget.enhanced.alternateGreetings.any((g) => g.trim().isNotEmpty);
     }
     _useLoreEntry = List.filled(
       widget.enhanced.lorebook?.entries.length ?? 0,
@@ -167,7 +170,12 @@ class EnhanceReviewBodyState extends State<EnhanceReviewBody> {
           if (_useLoreEntry[i]) loreEntries[i],
       ];
       if (keptLore.isNotEmpty) {
-        copy.lorebook = Lorebook(entries: keptLore);
+        final book = copy.lorebook;
+        if (book == null) {
+          copy.lorebook = Lorebook(entries: List.of(keptLore));
+        } else {
+          book.entries = mergeLorebookEntries(book.entries, keptLore);
+        }
       }
       if (widget.selection.porchLife && (_use['porchLife'] ?? false)) {
         final ext = copy.frontPorchExtensions ?? FrontPorchExtensions();

--- a/lib/ui/pages/home/home_page_chrome.dart
+++ b/lib/ui/pages/home/home_page_chrome.dart
@@ -23,7 +23,6 @@ part of '../home_page.dart';
 /// Split out of the _HomePageState god file as a private extension
 /// (part of the same library, so it keeps full access to page state).
 extension _HomePageChrome on _HomePageState {
-
   Widget _buildModeToggle() {
     return HomeModeToggle(
       showStories: _showStories,
@@ -116,9 +115,8 @@ extension _HomePageChrome on _HomePageState {
       debugPrint('[Home] open chat failed: $e\n$st');
       if (mounted && nav.canPop()) {
         nav.pop();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Could not open chat: $e')),
-        );
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Could not open chat: $e')));
       }
       return;
     }
@@ -182,7 +180,10 @@ extension _HomePageChrome on _HomePageState {
     _openingChat = true;
     try {
       final chatService = Provider.of<ChatService>(context, listen: false);
-      final groupRepo = Provider.of<GroupChatRepository>(context, listen: false);
+      final groupRepo = Provider.of<GroupChatRepository>(
+        context,
+        listen: false,
+      );
       final groupId = 'group_${group.id}';
       final sessions = await chatService.getSessionsForId(groupId);
 
@@ -230,7 +231,10 @@ extension _HomePageChrome on _HomePageState {
     _openingChat = true;
     try {
       final subject = character?.name ?? group?.name ?? '';
-      final personaId = await showPersonaPickerDialog(context, subject: subject);
+      final personaId = await showPersonaPickerDialog(
+        context,
+        subject: subject,
+      );
       if (personaId == null || !mounted) return;
 
       final chatService = Provider.of<ChatService>(context, listen: false);
@@ -396,7 +400,6 @@ extension _HomePageChrome on _HomePageState {
         break;
     }
   }
-
 
   /// One drop handler for both draggable kinds: characters are keyed by image
   /// filename, group casts by their group id (see FolderService).

--- a/lib/ui/pages/home/home_page_chrome.dart
+++ b/lib/ui/pages/home/home_page_chrome.dart
@@ -98,27 +98,31 @@ extension _HomePageChrome on _HomePageState {
     );
   }
 
-  /// Shows a dialog letting the user choose which saved session to resume.
-  /// Returns the session ID, '__new__' for a new chat, or null if cancelled.
-
   // ─── CharacterCardGrid Callback Handlers ────────────────────────
 
   /// Push ChatPage immediately and drain [load] after pop. The session
   /// overlay covers hydrate — awaiting load first is the home-grid freeze.
+  /// A failed load pops the ghost ChatPage and snacks the error.
   Future<void> _pushChatWhile(Future<void> load) async {
     if (!mounted) {
       await load;
       return;
     }
-    final nav = Navigator.of(
-      context,
-    ).push(MaterialPageRoute(builder: (_) => const ChatPage()));
+    final nav = Navigator.of(context);
+    final route = nav.push(MaterialPageRoute(builder: (_) => const ChatPage()));
     try {
       await load;
     } catch (e, st) {
       debugPrint('[Home] open chat failed: $e\n$st');
+      if (mounted && nav.canPop()) {
+        nav.pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not open chat: $e')),
+        );
+      }
+      return;
     }
-    await nav;
+    await route;
     if (mounted) _refreshLastActivityCache();
   }
 

--- a/test/services/chat/session_open_window_test.dart
+++ b/test/services/chat/session_open_window_test.dart
@@ -28,9 +28,8 @@ void main() {
   });
 
   test('open does not drop the overlay — owner ends after hydrate', () {
-    final src = File(
-      'lib/services/chat/chat_service_session_window.dart',
-    ).readAsStringSync();
+    final src = File('lib/services/chat/chat_service_session_window.dart')
+        .readAsStringSync();
     final openAt = src.indexOf('Future<void> _openSessionMessages');
     expect(openAt, greaterThanOrEqualTo(0));
     final openBody = src.substring(openAt);

--- a/test/services/chat/session_open_window_test.dart
+++ b/test/services/chat/session_open_window_test.dart
@@ -27,19 +27,19 @@ void main() {
     expect(11 < kSessionOpenWindow, isTrue);
   });
 
-  test('open drops the overlay before the background backfill starts', () {
+  test('open does not drop the overlay — owner ends after hydrate', () {
     final src = File(
       'lib/services/chat/chat_service_session_window.dart',
     ).readAsStringSync();
     final openAt = src.indexOf('Future<void> _openSessionMessages');
-    final backfillAt = src.indexOf('_runBackgroundBackfill');
-    final endAt = src.indexOf('endSessionLoad()');
     expect(openAt, greaterThanOrEqualTo(0));
-    expect(endAt, greaterThan(openAt));
+    final openBody = src.substring(openAt);
     expect(
-      endAt < backfillAt,
-      isTrue,
-      reason: 'spinner must drop before the 11k-row decode loop is kicked',
+      openBody.contains('endSessionLoad()'),
+      isFalse,
+      reason:
+          'tail paint is about backfill, not dropping before scalars. '
+          'A picker-owned load still has hydrate + loadSession to run.',
     );
     expect(src.contains('await Future<void>.delayed(Duration.zero)'), isTrue);
   });

--- a/test/services/chat/session_picker_overlay_hold_test.dart
+++ b/test/services/chat/session_picker_overlay_hold_test.dart
@@ -104,9 +104,8 @@ void main() {
   }
 
   test('_openSessionMessages does not call endSessionLoad', () {
-    final src = File(
-      'lib/services/chat/chat_service_session_window.dart',
-    ).readAsStringSync();
+    final src = File('lib/services/chat/chat_service_session_window.dart')
+        .readAsStringSync();
     final openAt = src.indexOf('Future<void> _openSessionMessages');
     expect(openAt, greaterThanOrEqualTo(0));
     expect(src.substring(openAt).contains('endSessionLoad()'), isFalse);
@@ -159,27 +158,30 @@ void main() {
     },
   );
 
-  test('picker hold stays up when setActive loads another card\'s tail', () async {
-    final a = await addCard('Ada');
-    final b = await addCard('Bea');
-    await chat.setActiveCharacter(a);
-    await chat.sendMessage('ada chat');
-    await chat.setActiveCharacter(b);
-    await chat.sendMessage('bea chat');
-    expect(chat.isLoadingSession, isFalse);
+  test(
+    'picker hold stays up when setActive loads another card\'s tail',
+    () async {
+      final a = await addCard('Ada');
+      final b = await addCard('Bea');
+      await chat.setActiveCharacter(a);
+      await chat.sendMessage('ada chat');
+      await chat.setActiveCharacter(b);
+      await chat.sendMessage('bea chat');
+      expect(chat.isLoadingSession, isFalse);
 
-    chat.beginSessionLoad();
-    await chat.setActiveCharacter(a);
-    expect(
-      chat.isLoadingSession,
-      isTrue,
-      reason:
-          '_openSessionMessages used to endSessionLoad after the last-24 '
-          'tail, uncovering the composer before hydrate',
-    );
-    chat.endSessionLoad();
-    expect(chat.isLoadingSession, isFalse);
-  });
+      chat.beginSessionLoad();
+      await chat.setActiveCharacter(a);
+      expect(
+        chat.isLoadingSession,
+        isTrue,
+        reason:
+            '_openSessionMessages used to endSessionLoad after the last-24 '
+            'tail, uncovering the composer before hydrate',
+      );
+      chat.endSessionLoad();
+      expect(chat.isLoadingSession, isFalse);
+    },
+  );
 
   test('sendMessage is a no-op while the session overlay is up', () async {
     final card = await addCard('Gate');

--- a/test/services/chat/session_picker_overlay_hold_test.dart
+++ b/test/services/chat/session_picker_overlay_hold_test.dart
@@ -1,0 +1,194 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Front Porch AI.
+//
+// Front Porch AI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Front Porch AI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
+
+// Picker path: beginSessionLoad → setActiveCharacter (ownedLoad=false) →
+// loadSession / startNewChat → owner endSessionLoad. The tail open must
+// NOT drop the overlay, or a fast send persists the pre-hydrate realism
+// reset onto the last-active chat.
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:front_porch_ai/database/database.dart';
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/services.dart';
+
+void _setupPathProviderMock() {
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return Directory.systemTemp.createTempSync('fpai_overlay_').path;
+        }
+        return null;
+      });
+}
+
+class _InertLlm extends LLMService {
+  @override
+  Stream<String> generateStream(GenerationParams params) async* {
+    yield '';
+  }
+
+  @override
+  bool get isReady => true;
+
+  @override
+  String get backendName => 'InertLlm';
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  _setupPathProviderMock();
+
+  late AppDatabase db;
+  late StorageService storage;
+  late CharacterRepository repo;
+  late UserPersonaService personas;
+  late ChatService chat;
+
+  setUp(() async {
+    HttpOverrides.global = null;
+    SharedPreferences.setMockInitialValues({
+      'update_auto_check': false,
+      'realism_default': false,
+    });
+    db = AppDatabase.forTesting();
+    storage = StorageService();
+    repo = CharacterRepository(db, storage);
+    personas = UserPersonaService(db);
+    chat =
+        ChatService(
+            KoboldService(storage),
+            personas,
+            storage,
+            WorldRepository(storage, db),
+          )
+          ..setDatabase(db)
+          ..setCharacterRepository(repo)
+          ..testLlmServiceOverride = _InertLlm();
+    await storage.initialized;
+  });
+
+  tearDown(() async {
+    chat.dispose();
+    await db.close();
+  });
+
+  Future<CharacterCard> addCard(String name) async {
+    final card = CharacterCard(
+      name: name,
+      description: '$name overlay-hold card.',
+      firstMessage: 'Hello from $name.',
+    );
+    await repo.addCharacter(card);
+    return card;
+  }
+
+  test('_openSessionMessages does not call endSessionLoad', () {
+    final src = File(
+      'lib/services/chat/chat_service_session_window.dart',
+    ).readAsStringSync();
+    final openAt = src.indexOf('Future<void> _openSessionMessages');
+    expect(openAt, greaterThanOrEqualTo(0));
+    expect(src.substring(openAt).contains('endSessionLoad()'), isFalse);
+  });
+
+  test('owned setActiveCharacter drops the overlay after hydrate', () async {
+    final card = await addCard('Owned');
+    expect(chat.isLoadingSession, isFalse);
+    await chat.setActiveCharacter(card);
+    expect(chat.isLoadingSession, isFalse);
+    expect(chat.messages, isNotEmpty);
+  });
+
+  test(
+    'picker hold stays up across setActive + loadSession and startNewChat',
+    () async {
+      final first = await addCard('First');
+      await chat.setActiveCharacter(first);
+      await chat.sendMessage('first chat');
+      final firstSession = chat.currentSessionId!;
+      await chat.startNewChat();
+      await chat.sendMessage('second chat');
+      expect(chat.isLoadingSession, isFalse);
+
+      // Same-character re-tap already keeps the hold (ownedLoad=false).
+      chat.beginSessionLoad();
+      await chat.setActiveCharacter(first);
+      expect(
+        chat.isLoadingSession,
+        isTrue,
+        reason: 'same-character re-tap must not drop a picker-owned hold',
+      );
+
+      await chat.loadSession(firstSession);
+      expect(
+        chat.isLoadingSession,
+        isTrue,
+        reason: 'loadSession tail must not drop the overlay before owner end',
+      );
+
+      await chat.startNewChat();
+      expect(
+        chat.isLoadingSession,
+        isTrue,
+        reason: 'startNewChat must leave a picker-owned hold up',
+      );
+
+      chat.endSessionLoad();
+      expect(chat.isLoadingSession, isFalse);
+    },
+  );
+
+  test('picker hold stays up when setActive loads another card\'s tail', () async {
+    final a = await addCard('Ada');
+    final b = await addCard('Bea');
+    await chat.setActiveCharacter(a);
+    await chat.sendMessage('ada chat');
+    await chat.setActiveCharacter(b);
+    await chat.sendMessage('bea chat');
+    expect(chat.isLoadingSession, isFalse);
+
+    chat.beginSessionLoad();
+    await chat.setActiveCharacter(a);
+    expect(
+      chat.isLoadingSession,
+      isTrue,
+      reason:
+          '_openSessionMessages used to endSessionLoad after the last-24 '
+          'tail, uncovering the composer before hydrate',
+    );
+    chat.endSessionLoad();
+    expect(chat.isLoadingSession, isFalse);
+  });
+
+  test('sendMessage is a no-op while the session overlay is up', () async {
+    final card = await addCard('Gate');
+    await chat.setActiveCharacter(card);
+    final before = chat.messages.length;
+    chat.beginSessionLoad();
+    await chat.sendMessage('should not land on the pre-hydrate chat');
+    expect(chat.messages.length, before);
+    expect(chat.isLoadingSession, isTrue);
+    chat.endSessionLoad();
+  });
+}

--- a/test/ui/pages/home/enhance_lorebook_append_test.dart
+++ b/test/ui/pages/home/enhance_lorebook_append_test.dart
@@ -4,45 +4,12 @@
 // Enhance Review says "New lorebook entries" — Save must append those
 // onto the book duplicateCharacter just copied, never replace it.
 
-import 'package:flutter/material.dart';
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
 
 import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/chargen/chargen.dart';
-import 'package:front_porch_ai/services/services.dart';
-import 'package:front_porch_ai/ui/pages/home/enhance/enhance_review_body.dart';
-
-class _Repo extends Fake implements CharacterRepository {
-  CharacterCard? lastUpdated;
-
-  @override
-  Future<CharacterCard?> duplicateCharacter(
-    CharacterCard card, {
-    String? targetDirOverride,
-    String? forcedBasename,
-    bool skipLibraryInsert = false,
-    String? newNameOverride,
-  }) async {
-    return CharacterCard(
-      name: newNameOverride ?? '${card.name} (duplicate)',
-      description: card.description,
-      lorebook: card.lorebook != null
-          ? Lorebook(entries: List.of(card.lorebook!.entries))
-          : null,
-    );
-  }
-
-  @override
-  Future<void> updateCharacter(CharacterCard card, {bool notify = true}) async {
-    lastUpdated = card;
-  }
-}
-
-class _Folders extends Fake implements FolderService {
-  @override
-  Future<void> inheritFolder(String? sourcePath, String? copyPath) async {}
-}
 
 void main() {
   test('mergeLorebookEntries appends and replaces by name', () {
@@ -61,53 +28,17 @@ void main() {
     expect(merged[2].content, 'new bar');
   });
 
-  testWidgets('Save appends accepted lore onto the duplicated original book', (
-    tester,
-  ) async {
-    final repo = _Repo();
-    final original = CharacterCard(
-      name: 'Nina',
-      lorebook: Lorebook(
-        entries: [LorebookEntry(name: 'The Kitchen', content: 'kept')],
-      ),
+  test('Save merges onto the duplicated book instead of replacing it', () {
+    final src = File(
+      'lib/ui/pages/home/enhance/enhance_review_body.dart',
+    ).readAsStringSync();
+    final saveAt = src.indexOf('Future<CharacterCard?> save()');
+    expect(saveAt, greaterThanOrEqualTo(0));
+    final save = src.substring(saveAt);
+    expect(save, contains('mergeLorebookEntries(book.entries, keptLore)'));
+    expect(
+      save.contains('copy.lorebook = Lorebook(entries: keptLore)'),
+      isFalse,
     );
-    final enhanced = CharacterCard(
-      name: 'Nina',
-      lorebook: Lorebook(
-        entries: [LorebookEntry(name: 'The Bar', content: 'new place')],
-      ),
-    );
-    final key = GlobalKey<EnhanceReviewBodyState>();
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          Provider<CharacterRepository>.value(value: repo),
-          Provider<FolderService>.value(value: _Folders()),
-        ],
-        child: MaterialApp(
-          home: Scaffold(
-            body: EnhanceReviewBody(
-              key: key,
-              original: original,
-              enhanced: enhanced,
-              selection: const EnhanceSelection(
-                description: false,
-                personality: false,
-                exampleDialogue: false,
-                lorebook: true,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    final saved = await key.currentState!.save();
-    expect(saved, isNotNull);
-    final names = repo.lastUpdated!.lorebook!.entries.map((e) => e.name);
-    expect(names, ['The Kitchen', 'The Bar']);
-    expect(repo.lastUpdated!.lorebook!.entries[0].content, 'kept');
-    expect(repo.lastUpdated!.lorebook!.entries[1].content, 'new place');
   });
 }

--- a/test/ui/pages/home/enhance_lorebook_append_test.dart
+++ b/test/ui/pages/home/enhance_lorebook_append_test.dart
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Enhance Review says "New lorebook entries" — Save must append those
+// onto the book duplicateCharacter just copied, never replace it.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/chargen/chargen.dart';
+import 'package:front_porch_ai/services/services.dart';
+import 'package:front_porch_ai/ui/pages/home/enhance/enhance_review_body.dart';
+
+class _Repo extends Fake implements CharacterRepository {
+  CharacterCard? lastUpdated;
+
+  @override
+  Future<CharacterCard?> duplicateCharacter(
+    CharacterCard card, {
+    String? targetDirOverride,
+    String? forcedBasename,
+    bool skipLibraryInsert = false,
+    String? newNameOverride,
+  }) async {
+    return CharacterCard(
+      name: newNameOverride ?? '${card.name} (duplicate)',
+      description: card.description,
+      lorebook: card.lorebook != null
+          ? Lorebook(entries: List.of(card.lorebook!.entries))
+          : null,
+    );
+  }
+
+  @override
+  Future<void> updateCharacter(CharacterCard card, {bool notify = true}) async {
+    lastUpdated = card;
+  }
+}
+
+class _Folders extends Fake implements FolderService {
+  @override
+  Future<void> inheritFolder(String? sourcePath, String? copyPath) async {}
+}
+
+void main() {
+  test('mergeLorebookEntries appends and replaces by name', () {
+    final original = [
+      LorebookEntry(name: 'The Kitchen', content: 'original kitchen'),
+      LorebookEntry(name: 'The Porch', content: 'original porch'),
+    ];
+    final incoming = [
+      LorebookEntry(name: 'The Bar', content: 'new bar'),
+      LorebookEntry(name: 'The Kitchen', content: 'rewritten kitchen'),
+    ];
+    final merged = mergeLorebookEntries(original, incoming);
+    expect(merged.map((e) => e.name), ['The Kitchen', 'The Porch', 'The Bar']);
+    expect(merged[0].content, 'rewritten kitchen');
+    expect(merged[1].content, 'original porch');
+    expect(merged[2].content, 'new bar');
+  });
+
+  testWidgets('Save appends accepted lore onto the duplicated original book', (
+    tester,
+  ) async {
+    final repo = _Repo();
+    final original = CharacterCard(
+      name: 'Nina',
+      lorebook: Lorebook(
+        entries: [LorebookEntry(name: 'The Kitchen', content: 'kept')],
+      ),
+    );
+    final enhanced = CharacterCard(
+      name: 'Nina',
+      lorebook: Lorebook(
+        entries: [LorebookEntry(name: 'The Bar', content: 'new place')],
+      ),
+    );
+    final key = GlobalKey<EnhanceReviewBodyState>();
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          Provider<CharacterRepository>.value(value: repo),
+          Provider<FolderService>.value(value: _Folders()),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnhanceReviewBody(
+              key: key,
+              original: original,
+              enhanced: enhanced,
+              selection: const EnhanceSelection(
+                description: false,
+                personality: false,
+                exampleDialogue: false,
+                lorebook: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final saved = await key.currentState!.save();
+    expect(saved, isNotNull);
+    final names = repo.lastUpdated!.lorebook!.entries.map((e) => e.name);
+    expect(names, ['The Kitchen', 'The Bar']);
+    expect(repo.lastUpdated!.lorebook!.entries[0].content, 'kept');
+    expect(repo.lastUpdated!.lorebook!.entries[1].content, 'new place');
+  });
+}

--- a/test/ui/pages/home/enhance_porch_review_test.dart
+++ b/test/ui/pages/home/enhance_porch_review_test.dart
@@ -85,4 +85,85 @@ void main() {
     final useSwitch = tester.widget<Switch>(find.byType(Switch).first);
     expect(useSwitch.value, isFalse);
   });
+
+  testWidgets('empty proposed description and personality default Use this off', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        EnhanceReviewBody(
+          original: CharacterCard(
+            name: 'Nina',
+            description: 'authored description',
+            personality: 'authored personality',
+          ),
+          enhanced: CharacterCard(
+            name: 'Nina',
+            description: '   ',
+            personality: '',
+          ),
+          selection: const EnhanceSelection(
+            description: true,
+            personality: true,
+            exampleDialogue: false,
+            porchLife: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+    expect(switches, hasLength(2));
+    expect(switches[0].value, isFalse);
+    expect(switches[1].value, isFalse);
+  });
+
+  testWidgets('non-empty proposed description still defaults Use this on', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        EnhanceReviewBody(
+          original: CharacterCard(name: 'Nina', description: 'old'),
+          enhanced: CharacterCard(name: 'Nina', description: 'rewritten'),
+          selection: const EnhanceSelection(
+            description: true,
+            personality: false,
+            exampleDialogue: false,
+            porchLife: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final useSwitch = tester.widget<Switch>(find.byType(Switch).first);
+    expect(useSwitch.value, isTrue);
+  });
+
+  testWidgets('empty proposed greetings default Use this off', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        EnhanceReviewBody(
+          original: CharacterCard(
+            name: 'Nina',
+            firstMessage: 'Hey there.',
+          ),
+          enhanced: CharacterCard(name: 'Nina', firstMessage: ''),
+          selection: const EnhanceSelection(
+            description: false,
+            personality: false,
+            exampleDialogue: false,
+            greetings: true,
+            porchLife: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final useSwitch = tester.widget<Switch>(find.byType(Switch).first);
+    expect(useSwitch.value, isFalse);
+  });
 }

--- a/test/ui/pages/home/enhance_porch_review_test.dart
+++ b/test/ui/pages/home/enhance_porch_review_test.dart
@@ -86,38 +86,39 @@ void main() {
     expect(useSwitch.value, isFalse);
   });
 
-  testWidgets('empty proposed description and personality default Use this off', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      _app(
-        EnhanceReviewBody(
-          original: CharacterCard(
-            name: 'Nina',
-            description: 'authored description',
-            personality: 'authored personality',
-          ),
-          enhanced: CharacterCard(
-            name: 'Nina',
-            description: '   ',
-            personality: '',
-          ),
-          selection: const EnhanceSelection(
-            description: true,
-            personality: true,
-            exampleDialogue: false,
-            porchLife: false,
+  testWidgets(
+    'empty proposed description and personality default Use this off',
+    (tester) async {
+      await tester.pumpWidget(
+        _app(
+          EnhanceReviewBody(
+            original: CharacterCard(
+              name: 'Nina',
+              description: 'authored description',
+              personality: 'authored personality',
+            ),
+            enhanced: CharacterCard(
+              name: 'Nina',
+              description: '   ',
+              personality: '',
+            ),
+            selection: const EnhanceSelection(
+              description: true,
+              personality: true,
+              exampleDialogue: false,
+              porchLife: false,
+            ),
           ),
         ),
-      ),
-    );
-    await tester.pumpAndSettle();
+      );
+      await tester.pumpAndSettle();
 
-    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
-    expect(switches, hasLength(2));
-    expect(switches[0].value, isFalse);
-    expect(switches[1].value, isFalse);
-  });
+      final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+      expect(switches, hasLength(2));
+      expect(switches[0].value, isFalse);
+      expect(switches[1].value, isFalse);
+    },
+  );
 
   testWidgets('non-empty proposed description still defaults Use this on', (
     tester,
@@ -146,10 +147,7 @@ void main() {
     await tester.pumpWidget(
       _app(
         EnhanceReviewBody(
-          original: CharacterCard(
-            name: 'Nina',
-            firstMessage: 'Hey there.',
-          ),
+          original: CharacterCard(name: 'Nina', firstMessage: 'Hey there.'),
           enhanced: CharacterCard(name: 'Nina', firstMessage: ''),
           selection: const EnhanceSelection(
             description: false,

--- a/test/ui/pages/home/home_tap_failed_load_pop_test.dart
+++ b/test/ui/pages/home/home_tap_failed_load_pop_test.dart
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Front Porch AI.
+//
+// Front Porch AI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Front Porch AI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
+
+// A failed home-grid load used to debugPrint and still await the ChatPage
+// route, so the user sat on a half-hydrated transcript. The catch must
+// pop the page we just pushed and snack the failure.
+//
+// Same source-read seam as home_tap_navigate_first_test: the helper is a
+// private part-file method behind Provider + a route. No HomePage pump.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late String src;
+
+  setUpAll(() {
+    src = File('lib/ui/pages/home/home_page_chrome.dart').readAsStringSync();
+  });
+
+  String handler(String name) {
+    final start = src.indexOf('Future<void> $name');
+    expect(
+      start,
+      greaterThanOrEqualTo(0),
+      reason: 'could not read $name — move this guard with the method',
+    );
+    return src.substring(start, start + 1800);
+  }
+
+  test('_pushChatWhile catch pops ChatPage and snacks the failure', () {
+    final body = handler('_pushChatWhile');
+    final catchAt = body.indexOf('catch (');
+    expect(
+      catchAt,
+      greaterThanOrEqualTo(0),
+      reason:
+          'a failed load must be caught — swallowing it is the ghost transcript',
+    );
+    final catchBody = body.substring(catchAt);
+    expect(
+      catchBody,
+      contains('nav.pop()'),
+      reason: 'ChatPage is already pushed; catch must pop it',
+    );
+    expect(catchBody, contains('Could not open chat'));
+  });
+}

--- a/web_ui/src/components/aichargen/EnhanceReviewModal.tsx
+++ b/web_ui/src/components/aichargen/EnhanceReviewModal.tsx
@@ -13,6 +13,7 @@ import { api, ApiError } from '../../api/client';
 import { useLayout } from '../../hooks/useBreakpoint';
 import {
   buildApplyBody,
+  withEmptyTextUseOff,
   type EnhanceAccepted,
   type EnhanceEdits,
   type EnhanceProposal,
@@ -25,6 +26,7 @@ interface CharDetail {
   mesExample?: string;
   scenario?: string;
   firstMessage?: string;
+  lorebook?: unknown;
   realism?: {
     ambitions?: string[];
     likes?: string[];
@@ -54,6 +56,7 @@ export function EnhanceReviewModal({
   const [old, setOld] = useState<CharDetail | null>(null);
   const [accepted, setAccepted] = useState<EnhanceAccepted>(() => ({
     ...selection,
+    ...withEmptyTextUseOff(selection, proposal),
     porchLife:
       selection.porchLife &&
       porchHasItems(proposal.porchLife),
@@ -84,7 +87,10 @@ export function EnhanceReviewModal({
         `/api/characters/${characterId}/duplicate`,
         { newName: `${characterName} (Enhanced)` },
       );
-      await api.post(`/api/characters/${dup.id}`, buildApplyBody(proposal, accepted, edits));
+      await api.post(
+        `/api/characters/${dup.id}`,
+        buildApplyBody(proposal, accepted, edits, { lorebook: old?.lorebook }),
+      );
       // Don't leave yet — offer to bring the base character's chats along.
       setBusy(false);
       setApplied(dup.id);

--- a/web_ui/src/components/aichargen/enhanceForm.test.ts
+++ b/web_ui/src/components/aichargen/enhanceForm.test.ts
@@ -12,6 +12,8 @@ import {
   anySelected,
   buildApplyBody,
   buildEnhancePayload,
+  mergeLorebook,
+  withEmptyTextUseOff,
   type EnhanceProposal,
 } from './enhanceForm';
 
@@ -134,5 +136,76 @@ describe('buildApplyBody', () => {
       porchLife: false,
     });
     expect(body).toEqual({});
+  });
+
+  it('appends proposed lore onto the original book (merge by name)', () => {
+    const body = buildApplyBody(
+      proposal,
+      { ...allOn, description: false, personality: false, exampleDialogue: false, scenario: false, greetings: false, porchLife: false },
+      {},
+      { lorebook: { entries: [{ name: 'The Kitchen', content: 'kept' }] } },
+    );
+    expect(body.lorebook).toEqual({
+      entries: [
+        { name: 'The Kitchen', content: 'kept' },
+        { name: 'The Bar' },
+      ],
+    });
+  });
+});
+
+describe('withEmptyTextUseOff', () => {
+  const allOn = {
+    description: true,
+    personality: true,
+    exampleDialogue: true,
+    scenario: true,
+    greetings: true,
+    lorebook: true,
+    porchLife: true,
+  };
+
+  it('empty proposed description/personality/greetings default Use this off', () => {
+    const seeded = withEmptyTextUseOff(allOn, {
+      description: '   ',
+      personality: '',
+      firstMessage: '',
+      alternateGreetings: ['  '],
+    });
+    expect(seeded.description).toBe(false);
+    expect(seeded.personality).toBe(false);
+    expect(seeded.greetings).toBe(false);
+  });
+
+  it('non-empty proposed text still defaults Use this on', () => {
+    const seeded = withEmptyTextUseOff(allOn, {
+      description: 'rewritten',
+      personality: 'new voice',
+      firstMessage: 'Hey.',
+    });
+    expect(seeded.description).toBe(true);
+    expect(seeded.personality).toBe(true);
+    expect(seeded.greetings).toBe(true);
+  });
+});
+
+describe('mergeLorebook', () => {
+  it('keeps original entries and appends new ones', () => {
+    const merged = mergeLorebook(
+      { entries: [{ name: 'The Kitchen', content: 'kept' }] },
+      { entries: [{ name: 'The Bar', content: 'new' }] },
+    );
+    expect(merged.entries).toEqual([
+      { name: 'The Kitchen', content: 'kept' },
+      { name: 'The Bar', content: 'new' },
+    ]);
+  });
+
+  it('replaces an original entry when the incoming name matches', () => {
+    const merged = mergeLorebook(
+      { entries: [{ name: 'The Kitchen', content: 'old' }] },
+      { entries: [{ name: 'The Kitchen', content: 'rewritten' }] },
+    );
+    expect(merged.entries).toEqual([{ name: 'The Kitchen', content: 'rewritten' }]);
   });
 });

--- a/web_ui/src/components/aichargen/enhanceForm.ts
+++ b/web_ui/src/components/aichargen/enhanceForm.ts
@@ -104,6 +104,70 @@ export function buildEnhancePayload(
   };
 }
 
+/** True when a proposed text field has something to accept. */
+export function hasProposedText(value: string | undefined): boolean {
+  return !!value?.trim();
+}
+
+/**
+ * Per-field Use this defaults for text sections. Empty proposed text
+ * starts OFF so a mute model cannot wipe the original. Does not touch
+ * porchLife — that already special-cases empty in the review modal.
+ */
+export function withEmptyTextUseOff(
+  selection: EnhanceSelection,
+  proposal: EnhanceProposal,
+): Pick<
+  EnhanceAccepted,
+  'description' | 'personality' | 'exampleDialogue' | 'scenario' | 'greetings'
+> {
+  return {
+    description: selection.description && hasProposedText(proposal.description),
+    personality: selection.personality && hasProposedText(proposal.personality),
+    exampleDialogue: selection.exampleDialogue && hasProposedText(proposal.mesExample),
+    scenario: selection.scenario && hasProposedText(proposal.scenario),
+    greetings:
+      selection.greetings &&
+      (hasProposedText(proposal.firstMessage) ||
+        (proposal.alternateGreetings?.some((g) => !!g.trim()) ?? false)),
+  };
+}
+
+function loreEntries(book: unknown): Record<string, unknown>[] {
+  if (!book || typeof book !== 'object') return [];
+  const entries = (book as { entries?: unknown }).entries;
+  if (!Array.isArray(entries)) return [];
+  return entries.filter((e): e is Record<string, unknown> => !!e && typeof e === 'object');
+}
+
+function loreEntryName(entry: Record<string, unknown>): string {
+  const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+  if (name) return name;
+  return typeof entry.comment === 'string' ? entry.comment.trim() : '';
+}
+
+/**
+ * Append proposed lore entries onto the original book. Same-name incoming
+ * entries replace; never assign the proposal as the whole book.
+ */
+export function mergeLorebook(original: unknown, incoming: unknown): Record<string, unknown> {
+  const origEntries = loreEntries(original);
+  const add = loreEntries(incoming);
+  const entries = [...origEntries];
+  for (const entry of add) {
+    const name = loreEntryName(entry);
+    const i = name ? entries.findIndex((e) => loreEntryName(e) === name) : -1;
+    if (i >= 0) entries[i] = entry;
+    else entries.push(entry);
+  }
+  const rest =
+    original && typeof original === 'object' && !Array.isArray(original)
+      ? { ...(original as Record<string, unknown>) }
+      : {};
+  delete rest.entries;
+  return { ...rest, entries };
+}
+
 /**
  * The partial-update body for `POST /api/characters/<newId>`: only accepted
  * sections are included (the duplicate already carries the original for the
@@ -113,6 +177,7 @@ export function buildApplyBody(
   proposal: EnhanceProposal,
   accepted: EnhanceAccepted,
   edits: EnhanceEdits = {},
+  original: { lorebook?: unknown } = {},
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (accepted.description && proposal.description !== undefined) {
@@ -136,7 +201,7 @@ export function buildApplyBody(
     }
   }
   if (accepted.lorebook && proposal.lorebook != null) {
-    body.lorebook = proposal.lorebook;
+    body.lorebook = mergeLorebook(original.lorebook, proposal.lorebook);
   }
   if (accepted.porchLife && proposal.porchLife) {
     const p = edits.porchLife ?? proposal.porchLife;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Four verified user-hittable bugs on Rawhide (HEAD d926d88), in the Senior Dev signed-off shape. No extra scope.

## #1 HIGH — Session picker overlay / live send on the wrong chat

`_openSessionMessages` called `endSessionLoad()` after the last-24 tail, then `_hydrateSessionScalars` still ran. Picker path: `beginSessionLoad` → `setActiveCharacter` (`ownedLoad=false`) → last-active tail dropped the overlay → `sendMessage` had no `isLoadingSession` gate → a fast send could persist the pre-hydrate realism reset onto the last-active chat.

**Senior Dev overlay change:** `_openSessionMessages` no longer calls `endSessionLoad` at all. Overlay drop belongs to the owner after hydrate (`setActiveCharacter` finally / picker finally). The tail-paint comment is about backfill, not about dropping before scalars. Send and the composer gate while `isLoadingSession` is true. Same-character re-tap still keeps the hold. No hold-count inside `_openSessionMessages`.

## #2 MEDIUM — `_pushChatWhile` swallowed a failed load

On load failure, pop the ChatPage we just pushed and snackbar the error. Do not leave a ghost transcript.

**TestChampion follow-up:** `test/ui/pages/home/home_tap_failed_load_pop_test.dart` source-reads `_pushChatWhile`'s catch for `nav.pop()` and `Could not open chat`. Proven red when `nav.pop()` is deleted. No HomePage pump.

## #3 MEDIUM — Enhance empty text still defaulted Use this ON

`field()` now sets Use this OFF when the proposed description / personality / exampleDialogue / scenario / greetings string is empty. Porch Life empty-off path is untouched. Desktop + PWA.

## #4 MEDIUM — Enhance lorebook Save replaced the original book

Review says “New lorebook entries”, but Save assigned the proposal as the whole book. Accepted new entries are appended onto the duplicated original (merge by name). Same on PWA `buildApplyBody`. Never assign the proposal as the whole book.

## Tests

- Picker overlay hold (real ChatService + in-memory DB): overlay stays up across `setActive` + `loadSession` / `startNewChat`; `_openSessionMessages` does not call `endSessionLoad`; `sendMessage` is a no-op while the overlay is up.
- Empty-text Use this: empty proposed description/personality/greetings → OFF; non-empty still ON; porchLife empty-off not regressed.
- Lorebook append: `mergeLorebookEntries` appends / replaces by name; Save call site must call the merge helper and must not assign `Lorebook(entries: keptLore)`. PWA `buildApplyBody` + `withEmptyTextUseOff` covered in vitest.
- Failed-load pop: `_pushChatWhile` catch must contain `nav.pop()` and `Could not open chat`.

**Proven red then green:** restoring the inner `endSessionLoad` failed the source-read and both real picker-hold tests; `_use[key] = true` failed empty description/personality (porchLife empty-off stayed green); replacing the book failed the Save call-site guard; deleting `nav.pop()` failed the new catch-must-pop pin. Fixes restored, all green again.

`session_open_window_test` asserted the old inner `endSessionLoad` (that *was* the bug). That existing assertion is now the opposite, with a written rationale — already flagged `approved-test-change`.

## Target branch

- [x] This PR targets Rawhide

## Type of change

- [x] Bug fix

## How was this tested?

Tested on: Linux sandbox (no display — cannot launch the app).

- [x] `flutter analyze` clean on touched files (0 issues)
- [x] Targeted `flutter test`: session overlay / picker hold / enhance empty-text / lorebook append / home-tap navigate-first / failed-load pop — all passed
- [x] `web_ui` vitest `enhanceForm.test.ts` 13/13 + `tsc --noEmit` clean
- [ ] Ran the app and exercised the change by hand — **cannot**; poke script is in the agent summary

## Parity

- [x] Web/mobile UI (`web_ui/`) updated to match — Enhance empty-text defaults + lorebook merge on apply
- [x] Realism/Needs behaviour is identical in 1:1 and group chats (overlay hold + send gate are shared ChatService; picker finally covers both 1:1 and group)

## Checklist

- [x] New files carry the AGPL header
- [x] I did not run `dart format` over the whole tree
- [x] I did not edit the version in `pubspec.yaml`
- [x] Errors are logged or surfaced, not silently swallowed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68d70408-0b08-4be9-b28b-eae29f7b9ca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68d70408-0b08-4be9-b28b-eae29f7b9ca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

