### PR TITLE
feat(planner): wire Today into the objective tracker

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -266,7 +266,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 47;
+  int get schemaVersion => 48;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/lib/database/database.g.dart
+++ b/lib/database/database.g.dart
@@ -1843,6 +1843,17 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _todayObjectiveIdMeta = const VerificationMeta(
+    'todayObjectiveId',
+  );
+  @override
+  late final GeneratedColumn<String> todayObjectiveId = GeneratedColumn<String>(
+    'today_objective_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _evolvedPersonalityMeta =
       const VerificationMeta('evolvedPersonality');
   @override
@@ -2067,6 +2078,7 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
     needsSimEnabled,
     needsVector,
     pockets,
+    todayObjectiveId,
     evolvedPersonality,
     evolvedScenario,
     evolutionCount,
@@ -2448,6 +2460,15 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
         pockets.isAcceptableOrUnknown(data['pockets']!, _pocketsMeta),
       );
     }
+    if (data.containsKey('today_objective_id')) {
+      context.handle(
+        _todayObjectiveIdMeta,
+        todayObjectiveId.isAcceptableOrUnknown(
+          data['today_objective_id']!,
+          _todayObjectiveIdMeta,
+        ),
+      );
+    }
     if (data.containsKey('evolved_personality')) {
       context.handle(
         _evolvedPersonalityMeta,
@@ -2755,6 +2776,10 @@ class $SessionsTable extends Sessions with TableInfo<$SessionsTable, Session> {
         DriftSqlType.string,
         data['${effectivePrefix}pockets'],
       ),
+      todayObjectiveId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}today_objective_id'],
+      ),
       evolvedPersonality: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}evolved_personality'],
@@ -2889,6 +2914,14 @@ class Session extends DataClass implements Insertable<Session> {
   /// honest value both for every chat that predates this column and for any
   /// chat where Pockets is switched off.
   final String? pockets;
+
+  /// v48 — the live Today side-quest row for this chat, or null if none.
+  ///
+  /// Shape is not enough: a user-typed secondary is also isPrimary false,
+  /// tasks [], servedAmbition null. Persist the id so reload rebinds this
+  /// row and never guesses among secondaries. Nullable, no default: every
+  /// chat older than the column has no Today hold.
+  final String? todayObjectiveId;
   final String evolvedPersonality;
   final String evolvedScenario;
   final int evolutionCount;
@@ -2967,6 +3000,7 @@ class Session extends DataClass implements Insertable<Session> {
     required this.needsSimEnabled,
     this.needsVector,
     this.pockets,
+    this.todayObjectiveId,
     required this.evolvedPersonality,
     required this.evolvedScenario,
     required this.evolutionCount,
@@ -3052,6 +3086,9 @@ class Session extends DataClass implements Insertable<Session> {
     }
     if (!nullToAbsent || pockets != null) {
       map['pockets'] = Variable<String>(pockets);
+    }
+    if (!nullToAbsent || todayObjectiveId != null) {
+      map['today_objective_id'] = Variable<String>(todayObjectiveId);
     }
     map['evolved_personality'] = Variable<String>(evolvedPersonality);
     map['evolved_scenario'] = Variable<String>(evolvedScenario);
@@ -3152,6 +3189,9 @@ class Session extends DataClass implements Insertable<Session> {
       pockets: pockets == null && nullToAbsent
           ? const Value.absent()
           : Value(pockets),
+      todayObjectiveId: todayObjectiveId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(todayObjectiveId),
       evolvedPersonality: Value(evolvedPersonality),
       evolvedScenario: Value(evolvedScenario),
       evolutionCount: Value(evolutionCount),
@@ -3241,6 +3281,7 @@ class Session extends DataClass implements Insertable<Session> {
       needsSimEnabled: serializer.fromJson<bool>(json['needsSimEnabled']),
       needsVector: serializer.fromJson<String?>(json['needsVector']),
       pockets: serializer.fromJson<String?>(json['pockets']),
+      todayObjectiveId: serializer.fromJson<String?>(json['todayObjectiveId']),
       evolvedPersonality: serializer.fromJson<String>(
         json['evolvedPersonality'],
       ),
@@ -3319,6 +3360,7 @@ class Session extends DataClass implements Insertable<Session> {
       'needsSimEnabled': serializer.toJson<bool>(needsSimEnabled),
       'needsVector': serializer.toJson<String?>(needsVector),
       'pockets': serializer.toJson<String?>(pockets),
+      'todayObjectiveId': serializer.toJson<String?>(todayObjectiveId),
       'evolvedPersonality': serializer.toJson<String>(evolvedPersonality),
       'evolvedScenario': serializer.toJson<String>(evolvedScenario),
       'evolutionCount': serializer.toJson<int>(evolutionCount),
@@ -3383,6 +3425,7 @@ class Session extends DataClass implements Insertable<Session> {
     bool? needsSimEnabled,
     Value<String?> needsVector = const Value.absent(),
     Value<String?> pockets = const Value.absent(),
+    Value<String?> todayObjectiveId = const Value.absent(),
     String? evolvedPersonality,
     String? evolvedScenario,
     int? evolutionCount,
@@ -3451,6 +3494,9 @@ class Session extends DataClass implements Insertable<Session> {
     needsSimEnabled: needsSimEnabled ?? this.needsSimEnabled,
     needsVector: needsVector.present ? needsVector.value : this.needsVector,
     pockets: pockets.present ? pockets.value : this.pockets,
+    todayObjectiveId: todayObjectiveId.present
+        ? todayObjectiveId.value
+        : this.todayObjectiveId,
     evolvedPersonality: evolvedPersonality ?? this.evolvedPersonality,
     evolvedScenario: evolvedScenario ?? this.evolvedScenario,
     evolutionCount: evolutionCount ?? this.evolutionCount,
@@ -3593,6 +3639,9 @@ class Session extends DataClass implements Insertable<Session> {
           ? data.needsVector.value
           : this.needsVector,
       pockets: data.pockets.present ? data.pockets.value : this.pockets,
+      todayObjectiveId: data.todayObjectiveId.present
+          ? data.todayObjectiveId.value
+          : this.todayObjectiveId,
       evolvedPersonality: data.evolvedPersonality.present
           ? data.evolvedPersonality.value
           : this.evolvedPersonality,
@@ -3681,6 +3730,7 @@ class Session extends DataClass implements Insertable<Session> {
           ..write('needsSimEnabled: $needsSimEnabled, ')
           ..write('needsVector: $needsVector, ')
           ..write('pockets: $pockets, ')
+          ..write('todayObjectiveId: $todayObjectiveId, ')
           ..write('evolvedPersonality: $evolvedPersonality, ')
           ..write('evolvedScenario: $evolvedScenario, ')
           ..write('evolutionCount: $evolutionCount, ')
@@ -3745,6 +3795,7 @@ class Session extends DataClass implements Insertable<Session> {
     needsSimEnabled,
     needsVector,
     pockets,
+    todayObjectiveId,
     evolvedPersonality,
     evolvedScenario,
     evolutionCount,
@@ -3808,6 +3859,7 @@ class Session extends DataClass implements Insertable<Session> {
           other.needsSimEnabled == this.needsSimEnabled &&
           other.needsVector == this.needsVector &&
           other.pockets == this.pockets &&
+          other.todayObjectiveId == this.todayObjectiveId &&
           other.evolvedPersonality == this.evolvedPersonality &&
           other.evolvedScenario == this.evolvedScenario &&
           other.evolutionCount == this.evolutionCount &&
@@ -3869,6 +3921,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
   final Value<bool> needsSimEnabled;
   final Value<String?> needsVector;
   final Value<String?> pockets;
+  final Value<String?> todayObjectiveId;
   final Value<String> evolvedPersonality;
   final Value<String> evolvedScenario;
   final Value<int> evolutionCount;
@@ -3929,6 +3982,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     this.needsSimEnabled = const Value.absent(),
     this.needsVector = const Value.absent(),
     this.pockets = const Value.absent(),
+    this.todayObjectiveId = const Value.absent(),
     this.evolvedPersonality = const Value.absent(),
     this.evolvedScenario = const Value.absent(),
     this.evolutionCount = const Value.absent(),
@@ -3990,6 +4044,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     this.needsSimEnabled = const Value.absent(),
     this.needsVector = const Value.absent(),
     this.pockets = const Value.absent(),
+    this.todayObjectiveId = const Value.absent(),
     this.evolvedPersonality = const Value.absent(),
     this.evolvedScenario = const Value.absent(),
     this.evolutionCount = const Value.absent(),
@@ -4051,6 +4106,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     Expression<bool>? needsSimEnabled,
     Expression<String>? needsVector,
     Expression<String>? pockets,
+    Expression<String>? todayObjectiveId,
     Expression<String>? evolvedPersonality,
     Expression<String>? evolvedScenario,
     Expression<int>? evolutionCount,
@@ -4119,6 +4175,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
       if (needsSimEnabled != null) 'needs_sim_enabled': needsSimEnabled,
       if (needsVector != null) 'needs_vector': needsVector,
       if (pockets != null) 'pockets': pockets,
+      if (todayObjectiveId != null) 'today_objective_id': todayObjectiveId,
       if (evolvedPersonality != null) 'evolved_personality': evolvedPersonality,
       if (evolvedScenario != null) 'evolved_scenario': evolvedScenario,
       if (evolutionCount != null) 'evolution_count': evolutionCount,
@@ -4185,6 +4242,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     Value<bool>? needsSimEnabled,
     Value<String?>? needsVector,
     Value<String?>? pockets,
+    Value<String?>? todayObjectiveId,
     Value<String>? evolvedPersonality,
     Value<String>? evolvedScenario,
     Value<int>? evolutionCount,
@@ -4249,6 +4307,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
       needsSimEnabled: needsSimEnabled ?? this.needsSimEnabled,
       needsVector: needsVector ?? this.needsVector,
       pockets: pockets ?? this.pockets,
+      todayObjectiveId: todayObjectiveId ?? this.todayObjectiveId,
       evolvedPersonality: evolvedPersonality ?? this.evolvedPersonality,
       evolvedScenario: evolvedScenario ?? this.evolvedScenario,
       evolutionCount: evolutionCount ?? this.evolutionCount,
@@ -4410,6 +4469,9 @@ class SessionsCompanion extends UpdateCompanion<Session> {
     if (pockets.present) {
       map['pockets'] = Variable<String>(pockets.value);
     }
+    if (todayObjectiveId.present) {
+      map['today_objective_id'] = Variable<String>(todayObjectiveId.value);
+    }
     if (evolvedPersonality.present) {
       map['evolved_personality'] = Variable<String>(evolvedPersonality.value);
     }
@@ -4513,6 +4575,7 @@ class SessionsCompanion extends UpdateCompanion<Session> {
           ..write('needsSimEnabled: $needsSimEnabled, ')
           ..write('needsVector: $needsVector, ')
           ..write('pockets: $pockets, ')
+          ..write('todayObjectiveId: $todayObjectiveId, ')
           ..write('evolvedPersonality: $evolvedPersonality, ')
           ..write('evolvedScenario: $evolvedScenario, ')
           ..write('evolutionCount: $evolutionCount, ')
@@ -16984,6 +17047,7 @@ typedef $$SessionsTableCreateCompanionBuilder =
       Value<bool> needsSimEnabled,
       Value<String?> needsVector,
       Value<String?> pockets,
+      Value<String?> todayObjectiveId,
       Value<String> evolvedPersonality,
       Value<String> evolvedScenario,
       Value<int> evolutionCount,
@@ -17046,6 +17110,7 @@ typedef $$SessionsTableUpdateCompanionBuilder =
       Value<bool> needsSimEnabled,
       Value<String?> needsVector,
       Value<String?> pockets,
+      Value<String?> todayObjectiveId,
       Value<String> evolvedPersonality,
       Value<String> evolvedScenario,
       Value<int> evolutionCount,
@@ -17285,6 +17350,11 @@ class $$SessionsTableFilterComposer
 
   ColumnFilters<String> get pockets => $composableBuilder(
     column: $table.pockets,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get todayObjectiveId => $composableBuilder(
+    column: $table.todayObjectiveId,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -17588,6 +17658,11 @@ class $$SessionsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get todayObjectiveId => $composableBuilder(
+    column: $table.todayObjectiveId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get evolvedPersonality => $composableBuilder(
     column: $table.evolvedPersonality,
     builder: (column) => ColumnOrderings(column),
@@ -17872,6 +17947,11 @@ class $$SessionsTableAnnotationComposer
   GeneratedColumn<String> get pockets =>
       $composableBuilder(column: $table.pockets, builder: (column) => column);
 
+  GeneratedColumn<String> get todayObjectiveId => $composableBuilder(
+    column: $table.todayObjectiveId,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get evolvedPersonality => $composableBuilder(
     column: $table.evolvedPersonality,
     builder: (column) => column,
@@ -18013,6 +18093,7 @@ class $$SessionsTableTableManager
                 Value<bool> needsSimEnabled = const Value.absent(),
                 Value<String?> needsVector = const Value.absent(),
                 Value<String?> pockets = const Value.absent(),
+                Value<String?> todayObjectiveId = const Value.absent(),
                 Value<String> evolvedPersonality = const Value.absent(),
                 Value<String> evolvedScenario = const Value.absent(),
                 Value<int> evolutionCount = const Value.absent(),
@@ -18073,6 +18154,7 @@ class $$SessionsTableTableManager
                 needsSimEnabled: needsSimEnabled,
                 needsVector: needsVector,
                 pockets: pockets,
+                todayObjectiveId: todayObjectiveId,
                 evolvedPersonality: evolvedPersonality,
                 evolvedScenario: evolvedScenario,
                 evolutionCount: evolutionCount,
@@ -18135,6 +18217,7 @@ class $$SessionsTableTableManager
                 Value<bool> needsSimEnabled = const Value.absent(),
                 Value<String?> needsVector = const Value.absent(),
                 Value<String?> pockets = const Value.absent(),
+                Value<String?> todayObjectiveId = const Value.absent(),
                 Value<String> evolvedPersonality = const Value.absent(),
                 Value<String> evolvedScenario = const Value.absent(),
                 Value<int> evolutionCount = const Value.absent(),
@@ -18195,6 +18278,7 @@ class $$SessionsTableTableManager
                 needsSimEnabled: needsSimEnabled,
                 needsVector: needsVector,
                 pockets: pockets,
+                todayObjectiveId: todayObjectiveId,
                 evolvedPersonality: evolvedPersonality,
                 evolvedScenario: evolvedScenario,
                 evolutionCount: evolutionCount,

--- a/lib/database/database.migrations.dart
+++ b/lib/database/database.migrations.dart
@@ -831,5 +831,22 @@ extension _AppDatabaseMigrationLadder on AppDatabase {
           // already present (re-run / dual-version)
         }
       }
+
+      if (from < 48) {
+        // v47→v48: persist the Today side-quest row id on the session.
+        // A user-typed secondary has the same shape (isPrimary false,
+        // tasks [], servedAmbition null), so uniqueness-by-shape cannot
+        // rebind on load. NULL for every existing row is right — those
+        // chats have no Today hold to claim. Additive and nullable, so
+        // a downgrade to v47 keeps reading sessions; the column is ignored.
+        try {
+          await customStatement(
+            'ALTER TABLE sessions ADD COLUMN today_objective_id TEXT',
+          );
+          debugPrint('[DB] v48: added sessions.today_objective_id');
+        } catch (_) {
+          // already present (re-run / dual-version)
+        }
+      }
   }
 }

--- a/lib/database/database.repair.dart
+++ b/lib/database/database.repair.dart
@@ -219,6 +219,10 @@ extension AppDatabaseMaintenance on AppDatabase {
         // default. NULL means nothing was recorded, which is true for every
         // chat older than the column.
         'pockets TEXT',
+        // v48 — live Today side-quest row id. Nullable, no default. NULL
+        // means this chat has no Today hold, which is true for every row
+        // older than the column. Do not guess among secondaries.
+        'today_objective_id TEXT',
         // v38 Story Calendar — nullable; NULL = legacy row, synthesized on load
         'story_clock TEXT',
         'story_start_date TEXT',

--- a/lib/database/database.tables.core.dart
+++ b/lib/database/database.tables.core.dart
@@ -174,6 +174,14 @@ class Sessions extends Table {
   /// chat where Pockets is switched off.
   TextColumn get pockets => text().nullable()();
 
+  /// v48 — the live Today side-quest row for this chat, or null if none.
+  ///
+  /// Shape is not enough: a user-typed secondary is also isPrimary false,
+  /// tasks [], servedAmbition null. Persist the id so reload rebinds this
+  /// row and never guesses among secondaries. Nullable, no default: every
+  /// chat older than the column has no Today hold.
+  TextColumn get todayObjectiveId => text().nullable()();
+
   // Per-session character evolution (v19)
   // 1:1 chats: plain evolved text
   TextColumn get evolvedPersonality => text().withDefault(const Constant(''))();

--- a/lib/services/chat/chat_service_accessors.dart
+++ b/lib/services/chat/chat_service_accessors.dart
@@ -622,8 +622,10 @@ extension ChatServiceAccessors on ChatService {
     // retest tool support for the new model (sidebar pill contract).
     _storageService.addListener(_onBackendIdentity);
     _onTodayAbandoned = (held) {
-      unawaited(_deactivateTodayObjective());
-      unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.abandoned));
+      unawaited(() async {
+        await _deactivateTodayObjective();
+        await _journalResolvedToday(held, fate: PlannerTodayFate.abandoned);
+      }());
     };
   }
 }
@@ -772,8 +774,10 @@ extension ChatServicePlannerResolve on ChatService {
     _todayObjectiveId = null;
     _todayObjectiveText = null;
     setTodaySentence(null);
-    unawaited(_persistTodayObjectiveId(null));
-    unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.done));
+    unawaited(() async {
+      await _journalResolvedToday(held, fate: PlannerTodayFate.done);
+      await _persistTodayObjectiveId(null);
+    }());
   }
 
   /// Journal a finished or day-eaten line. Capture [held] before clearing.

--- a/lib/services/chat/chat_service_accessors.dart
+++ b/lib/services/chat/chat_service_accessors.dart
@@ -676,20 +676,6 @@ extension ChatServicePlannerResolve on ChatService {
     };
   }
 
-  bool _looksLikeTodayRow(Objective obj) {
-    if (obj.isPrimary) return false;
-    final served = obj.servedAmbition?.trim();
-    if (served != null && served.isNotEmpty) return false;
-    return tasksForObjective(obj).isEmpty;
-  }
-
-  Objective? _findLiveTodayRow(String text) {
-    return _activeObjectives
-        .where(_looksLikeTodayRow)
-        .where((o) => o.objective == text)
-        .firstOrNull;
-  }
-
   Future<void> _persistTodayObjectiveId(String? id) async {
     final sid = _currentSessionId;
     if (sid == null) return;
@@ -742,20 +728,28 @@ extension ChatServicePlannerResolve on ChatService {
   Future<void> _upsertTodayObjective(String line) async {
     final trimmed = line.trim();
     if (trimmed.isEmpty || _currentSessionId == null) return;
-    if (_todayObjectiveId != null &&
-        !_activeObjectives.any((o) => o.id == _todayObjectiveId)) {
-      _todayObjectiveId = null;
-      _todayObjectiveText = null;
-    }
-    final existing = _findLiveTodayRow(trimmed);
-    if (existing != null) {
-      _todayObjectiveId = existing.id;
-      _todayObjectiveText = trimmed;
-      await _persistTodayObjectiveId(existing.id);
-      return;
-    }
-    if (_todayObjectiveId != null && _todayObjectiveText != trimmed) {
-      await _deactivateTodayObjective();
+    final heldId = _todayObjectiveId;
+    if (heldId != null) {
+      final held =
+          _activeObjectives.where((o) => o.id == heldId).firstOrNull;
+      if (held != null && held.objective == trimmed) {
+        _todayObjectiveText = trimmed;
+        await _persistTodayObjectiveId(heldId);
+        return;
+      }
+      if (held == null &&
+          (_todayObjectiveText == trimmed || todaySentence == trimmed)) {
+        // List has not loaded the held row yet. Do not insert a second.
+        await _persistTodayObjectiveId(heldId);
+        return;
+      }
+      if (held != null && held.objective != trimmed) {
+        await _deactivateTodayObjective();
+      } else if (held == null) {
+        _todayObjectiveId = null;
+        _todayObjectiveText = null;
+        await _persistTodayObjectiveId(null);
+      }
     }
     final newId = const Uuid().v4();
     _todayObjectiveId = newId;

--- a/lib/services/chat/chat_service_accessors.dart
+++ b/lib/services/chat/chat_service_accessors.dart
@@ -622,6 +622,7 @@ extension ChatServiceAccessors on ChatService {
     // retest tool support for the new model (sidebar pill contract).
     _storageService.addListener(_onBackendIdentity);
     _onTodayAbandoned = (held) {
+      unawaited(_deactivateTodayObjective());
       unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.abandoned));
     };
   }
@@ -631,9 +632,12 @@ extension ChatServiceAccessors on ChatService {
 /// under the 1000-line ratchet. Day-clear is on the clock advance.
 mixin ChatServiceTodaySentence on ChangeNotifier {
   String? _todaySentence;
+  String? _todayObjectiveId;
+  String? _todayObjectiveText;
   void Function(String? held)? _onTodayAbandoned;
 
   String? get todaySentence => _todaySentence;
+  String? get todayObjectiveId => _todayObjectiveId;
 
   void setTodaySentence(String? value) {
     final next = value?.trim();
@@ -659,6 +663,48 @@ extension ChatServicePlannerResolve on ChatService {
       PlannerTodayFate.done => 'content',
       PlannerTodayFate.abandoned || PlannerTodayFate.dayAte => 'annoyed',
     };
+  }
+
+  Future<void> _deactivateTodayObjective() async {
+    final id = _todayObjectiveId;
+    if (id == null) return;
+    _todayObjectiveId = null;
+    _todayObjectiveText = null;
+    await _db.updateObjective(
+      ObjectivesCompanion(
+        id: drift.Value(id),
+        active: const drift.Value(false),
+      ),
+    );
+    await _loadActiveObjectives();
+  }
+
+  /// One secondary today-row. Match/replace by held id. Never primary,
+  /// never tasks, never an ambition, never evicts other secondaries.
+  Future<void> _upsertTodayObjective(String line) async {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty || _currentSessionId == null) return;
+    if (_todayObjectiveId != null) {
+      if (_todayObjectiveText == trimmed) return;
+      await _deactivateTodayObjective();
+    }
+    final newId = const Uuid().v4();
+    _todayObjectiveId = newId;
+    _todayObjectiveText = trimmed;
+    final inserted = await _insertTodaySideQuest(trimmed, id: newId);
+    if (inserted == null) {
+      _todayObjectiveId = null;
+      _todayObjectiveText = null;
+    }
+  }
+
+  Future<void> _onTodayObjectiveCompleted(Objective obj) async {
+    if (obj.id != _todayObjectiveId && _todayObjectiveId != null) return;
+    final held = todaySentence ?? obj.objective;
+    _todayObjectiveId = null;
+    _todayObjectiveText = null;
+    setTodaySentence(null);
+    unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.done));
   }
 
   /// Journal a finished or day-eaten line. Capture [held] before clearing.

--- a/lib/services/chat/chat_service_accessors.dart
+++ b/lib/services/chat/chat_service_accessors.dart
@@ -681,52 +681,41 @@ extension ChatServicePlannerResolve on ChatService {
     return tasksForObjective(obj).isEmpty;
   }
 
-  Objective? _findLiveTodayRow({String? text}) {
-    final hits = _activeObjectives.where(_looksLikeTodayRow);
-    if (text != null) {
-      return hits.where((o) => o.objective == text).firstOrNull;
-    }
-    final list = hits.toList();
-    return list.length == 1 ? list.first : null;
+  Objective? _findLiveTodayRow(String text) {
+    return _activeObjectives
+        .where(_looksLikeTodayRow)
+        .where((o) => o.objective == text)
+        .firstOrNull;
   }
 
-  /// Stale RAM id is dropped. Text match always. Unique today-shaped row
-  /// only when [claimIfUnique] — session load after a full pointer clear.
-  void _rebindTodayObjectiveFromDb({bool claimIfUnique = false}) {
-    if (_todayObjectiveId != null) {
-      final live =
-          _activeObjectives.where((o) => o.id == _todayObjectiveId).firstOrNull;
-      if (live != null) {
-        _todayObjectiveText = live.objective;
-        if (_todaySentence == null) setTodaySentence(live.objective);
-        return;
-      }
+  Future<void> _persistTodayObjectiveId(String? id) async {
+    final sid = _currentSessionId;
+    if (sid == null) return;
+    await _db.patchSession(
+      SessionsCompanion(
+        id: drift.Value(sid),
+        todayObjectiveId: drift.Value(id),
+      ),
+    );
+  }
+
+  /// Rebind by the persisted session id. Never guess among secondaries.
+  void _rebindTodayObjectiveFromDb() {
+    final id = _todayObjectiveId;
+    if (id == null) return;
+    final live =
+        _activeObjectives.where((o) => o.id == id).firstOrNull;
+    if (live == null) {
       _todayObjectiveId = null;
       _todayObjectiveText = null;
+      return;
     }
-    final text = _todaySentence;
-    if (text != null) {
-      final match = _findLiveTodayRow(text: text);
-      if (match != null) {
-        _todayObjectiveId = match.id;
-        _todayObjectiveText = match.objective;
-        return;
-      }
-    }
-    if (!claimIfUnique) return;
-    final unique = _findLiveTodayRow();
-    if (unique == null) return;
-    _todayObjectiveId = unique.id;
-    _todayObjectiveText = unique.objective;
-    setTodaySentence(unique.objective);
+    _todayObjectiveText = live.objective;
+    if (_todaySentence == null) setTodaySentence(live.objective);
   }
 
   bool _isHeldTodayObjective(Objective obj) {
-    if (obj.id == _todayObjectiveId) return true;
-    if (_todayObjectiveId != null) return false;
-    if (!_looksLikeTodayRow(obj)) return false;
-    if (_todaySentence != null) return obj.objective == _todaySentence;
-    return false;
+    return _todayObjectiveId != null && obj.id == _todayObjectiveId;
   }
 
   Future<void> _deactivateTodayObjective() async {
@@ -735,6 +724,7 @@ extension ChatServicePlannerResolve on ChatService {
     final live = _activeObjectives.where((o) => o.id == id).firstOrNull;
     _todayObjectiveId = null;
     _todayObjectiveText = null;
+    await _persistTodayObjectiveId(null);
     if (live == null) return;
     await _db.updateObjective(
       ObjectivesCompanion(
@@ -755,10 +745,11 @@ extension ChatServicePlannerResolve on ChatService {
       _todayObjectiveId = null;
       _todayObjectiveText = null;
     }
-    final existing = _findLiveTodayRow(text: trimmed);
+    final existing = _findLiveTodayRow(trimmed);
     if (existing != null) {
       _todayObjectiveId = existing.id;
       _todayObjectiveText = trimmed;
+      await _persistTodayObjectiveId(existing.id);
       return;
     }
     if (_todayObjectiveId != null && _todayObjectiveText != trimmed) {
@@ -771,6 +762,7 @@ extension ChatServicePlannerResolve on ChatService {
     if (inserted == null) {
       _todayObjectiveId = null;
       _todayObjectiveText = null;
+      await _persistTodayObjectiveId(null);
     }
   }
 
@@ -780,6 +772,7 @@ extension ChatServicePlannerResolve on ChatService {
     _todayObjectiveId = null;
     _todayObjectiveText = null;
     setTodaySentence(null);
+    unawaited(_persistTodayObjectiveId(null));
     unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.done));
   }
 

--- a/lib/services/chat/chat_service_accessors.dart
+++ b/lib/services/chat/chat_service_accessors.dart
@@ -662,12 +662,6 @@ mixin ChatServiceTodaySentence on ChangeNotifier {
     notifyListeners();
   }
 
-  /// Simulate a reload that lost the RAM id. Test only.
-  @visibleForTesting
-  void dropTodayPointerForTest() {
-    _todayObjectiveId = null;
-    _todayObjectiveText = null;
-  }
 }
 
 enum PlannerTodayFate { done, abandoned, dayAte }
@@ -687,16 +681,18 @@ extension ChatServicePlannerResolve on ChatService {
     return tasksForObjective(obj).isEmpty;
   }
 
-  Objective? _findLiveTodayRow(String text) {
-    return _activeObjectives
-        .where(_looksLikeTodayRow)
-        .where((o) => o.objective == text)
-        .firstOrNull;
+  Objective? _findLiveTodayRow({String? text}) {
+    final hits = _activeObjectives.where(_looksLikeTodayRow);
+    if (text != null) {
+      return hits.where((o) => o.objective == text).firstOrNull;
+    }
+    final list = hits.toList();
+    return list.length == 1 ? list.first : null;
   }
 
-  /// Stale RAM id is dropped. Rebound only by held id or sentence text.
-  /// Never claim a random taskless secondary.
-  void _rebindTodayObjectiveFromDb() {
+  /// Stale RAM id is dropped. Text match always. Unique today-shaped row
+  /// only when [claimIfUnique] — session load after a full pointer clear.
+  void _rebindTodayObjectiveFromDb({bool claimIfUnique = false}) {
     if (_todayObjectiveId != null) {
       final live =
           _activeObjectives.where((o) => o.id == _todayObjectiveId).firstOrNull;
@@ -709,11 +705,20 @@ extension ChatServicePlannerResolve on ChatService {
       _todayObjectiveText = null;
     }
     final text = _todaySentence;
-    if (text == null) return;
-    final match = _findLiveTodayRow(text);
-    if (match == null) return;
-    _todayObjectiveId = match.id;
-    _todayObjectiveText = match.objective;
+    if (text != null) {
+      final match = _findLiveTodayRow(text: text);
+      if (match != null) {
+        _todayObjectiveId = match.id;
+        _todayObjectiveText = match.objective;
+        return;
+      }
+    }
+    if (!claimIfUnique) return;
+    final unique = _findLiveTodayRow();
+    if (unique == null) return;
+    _todayObjectiveId = unique.id;
+    _todayObjectiveText = unique.objective;
+    setTodaySentence(unique.objective);
   }
 
   bool _isHeldTodayObjective(Objective obj) {
@@ -721,7 +726,7 @@ extension ChatServicePlannerResolve on ChatService {
     if (_todayObjectiveId != null) return false;
     if (!_looksLikeTodayRow(obj)) return false;
     if (_todaySentence != null) return obj.objective == _todaySentence;
-    return true;
+    return false;
   }
 
   Future<void> _deactivateTodayObjective() async {
@@ -750,7 +755,7 @@ extension ChatServicePlannerResolve on ChatService {
       _todayObjectiveId = null;
       _todayObjectiveText = null;
     }
-    final existing = _findLiveTodayRow(trimmed);
+    final existing = _findLiveTodayRow(text: trimmed);
     if (existing != null) {
       _todayObjectiveId = existing.id;
       _todayObjectiveText = trimmed;

--- a/lib/services/chat/chat_service_accessors.dart
+++ b/lib/services/chat/chat_service_accessors.dart
@@ -653,6 +653,21 @@ mixin ChatServiceTodaySentence on ChangeNotifier {
   }
 
   String? get todayLine => todaySentence;
+
+  /// Drop the RAM hold. Does not touch the DB row.
+  void _clearTodayPointer() {
+    _todaySentence = null;
+    _todayObjectiveId = null;
+    _todayObjectiveText = null;
+    notifyListeners();
+  }
+
+  /// Simulate a reload that lost the RAM id. Test only.
+  @visibleForTesting
+  void dropTodayPointerForTest() {
+    _todayObjectiveId = null;
+    _todayObjectiveText = null;
+  }
 }
 
 enum PlannerTodayFate { done, abandoned, dayAte }
@@ -665,11 +680,57 @@ extension ChatServicePlannerResolve on ChatService {
     };
   }
 
+  bool _looksLikeTodayRow(Objective obj) {
+    if (obj.isPrimary) return false;
+    final served = obj.servedAmbition?.trim();
+    if (served != null && served.isNotEmpty) return false;
+    return tasksForObjective(obj).isEmpty;
+  }
+
+  Objective? _findLiveTodayRow(String text) {
+    return _activeObjectives
+        .where(_looksLikeTodayRow)
+        .where((o) => o.objective == text)
+        .firstOrNull;
+  }
+
+  /// Stale RAM id is dropped. Rebound only by held id or sentence text.
+  /// Never claim a random taskless secondary.
+  void _rebindTodayObjectiveFromDb() {
+    if (_todayObjectiveId != null) {
+      final live =
+          _activeObjectives.where((o) => o.id == _todayObjectiveId).firstOrNull;
+      if (live != null) {
+        _todayObjectiveText = live.objective;
+        if (_todaySentence == null) setTodaySentence(live.objective);
+        return;
+      }
+      _todayObjectiveId = null;
+      _todayObjectiveText = null;
+    }
+    final text = _todaySentence;
+    if (text == null) return;
+    final match = _findLiveTodayRow(text);
+    if (match == null) return;
+    _todayObjectiveId = match.id;
+    _todayObjectiveText = match.objective;
+  }
+
+  bool _isHeldTodayObjective(Objective obj) {
+    if (obj.id == _todayObjectiveId) return true;
+    if (_todayObjectiveId != null) return false;
+    if (!_looksLikeTodayRow(obj)) return false;
+    if (_todaySentence != null) return obj.objective == _todaySentence;
+    return true;
+  }
+
   Future<void> _deactivateTodayObjective() async {
     final id = _todayObjectiveId;
     if (id == null) return;
+    final live = _activeObjectives.where((o) => o.id == id).firstOrNull;
     _todayObjectiveId = null;
     _todayObjectiveText = null;
+    if (live == null) return;
     await _db.updateObjective(
       ObjectivesCompanion(
         id: drift.Value(id),
@@ -684,8 +745,18 @@ extension ChatServicePlannerResolve on ChatService {
   Future<void> _upsertTodayObjective(String line) async {
     final trimmed = line.trim();
     if (trimmed.isEmpty || _currentSessionId == null) return;
-    if (_todayObjectiveId != null) {
-      if (_todayObjectiveText == trimmed) return;
+    if (_todayObjectiveId != null &&
+        !_activeObjectives.any((o) => o.id == _todayObjectiveId)) {
+      _todayObjectiveId = null;
+      _todayObjectiveText = null;
+    }
+    final existing = _findLiveTodayRow(trimmed);
+    if (existing != null) {
+      _todayObjectiveId = existing.id;
+      _todayObjectiveText = trimmed;
+      return;
+    }
+    if (_todayObjectiveId != null && _todayObjectiveText != trimmed) {
       await _deactivateTodayObjective();
     }
     final newId = const Uuid().v4();
@@ -699,7 +770,7 @@ extension ChatServicePlannerResolve on ChatService {
   }
 
   Future<void> _onTodayObjectiveCompleted(Objective obj) async {
-    if (obj.id != _todayObjectiveId && _todayObjectiveId != null) return;
+    if (!_isHeldTodayObjective(obj)) return;
     final held = todaySentence ?? obj.objective;
     _todayObjectiveId = null;
     _todayObjectiveText = null;

--- a/lib/services/chat/chat_service_chat_entry.dart
+++ b/lib/services/chat/chat_service_chat_entry.dart
@@ -203,6 +203,7 @@ extension ChatServiceChatEntry on ChatService {
     _messages.clear();
     _history.reset();
     _currentSessionId = null;
+    _clearTodayPointer();
     _summary = '';
     _summaryLastIndex = 0;
     _selectedLooks

--- a/lib/services/chat/chat_service_chat_entry.dart
+++ b/lib/services/chat/chat_service_chat_entry.dart
@@ -443,7 +443,7 @@ extension ChatServiceChatEntry on ChatService {
       }
       // Load active objectives for this session (must be after _loadLastSession
       // so _currentSessionId is set)
-      await _loadActiveObjectives(claimTodayIfUnique: true); // Awaited (was fire-and-forget); root fix for post-dispose notify races in tests + rapid switches. Central _disposed + notifyListeners override (rec 2) now protects residual unawaited/microtask paths + any other notify-after-async in god/services (see _disposed decl, overrides at end of class, and cleaned per-site guard in _loadActiveObjectives).
+      await _loadActiveObjectives(); // Awaited (was fire-and-forget); root fix for post-dispose notify races in tests + rapid switches. Central _disposed + notifyListeners override (rec 2) now protects residual unawaited/microtask paths + any other notify-after-async in god/services (see _disposed decl, overrides at end of class, and cleaned per-site guard in _loadActiveObjectives).
     }
     } finally {
       if (ownedLoad) endSessionLoad();

--- a/lib/services/chat/chat_service_chat_entry.dart
+++ b/lib/services/chat/chat_service_chat_entry.dart
@@ -443,7 +443,7 @@ extension ChatServiceChatEntry on ChatService {
       }
       // Load active objectives for this session (must be after _loadLastSession
       // so _currentSessionId is set)
-      await _loadActiveObjectives(); // Awaited (was fire-and-forget); root fix for post-dispose notify races in tests + rapid switches. Central _disposed + notifyListeners override (rec 2) now protects residual unawaited/microtask paths + any other notify-after-async in god/services (see _disposed decl, overrides at end of class, and cleaned per-site guard in _loadActiveObjectives).
+      await _loadActiveObjectives(claimTodayIfUnique: true); // Awaited (was fire-and-forget); root fix for post-dispose notify races in tests + rapid switches. Central _disposed + notifyListeners override (rec 2) now protects residual unawaited/microtask paths + any other notify-after-async in god/services (see _disposed decl, overrides at end of class, and cleaned per-site guard in _loadActiveObjectives).
     }
     } finally {
       if (ownedLoad) endSessionLoad();

--- a/lib/services/chat/chat_service_controls.dart
+++ b/lib/services/chat/chat_service_controls.dart
@@ -180,7 +180,7 @@ extension ChatServiceControls on ChatService {
   /// Same guard/save/notify shape as the nudge (it IS a precise nudge).
   Future<void> setStoryClock(DateTime clock) async {
     if (!_realismEnabled) return;
-    _timeService.setClockDirect(clock);
+    await _timeService.setClockDirect(clock);
     // Day-ate journal rides TimeService.onStoryDayChanged.
     await _saveChat();
     notifyListeners();

--- a/lib/services/chat/chat_service_group_entry.dart
+++ b/lib/services/chat/chat_service_group_entry.dart
@@ -121,6 +121,7 @@ extension ChatServiceGroupEntry on ChatService {
     _messages.clear();
     _history.reset();
     _currentSessionId = null;
+    _clearTodayPointer();
     // Clear fork/branch state so it doesn't leak across group switches
     // (see startNewChat and setActiveCharacter for rationale).
     _parentSessionId = null;

--- a/lib/services/chat/chat_service_group_entry.dart
+++ b/lib/services/chat/chat_service_group_entry.dart
@@ -292,7 +292,7 @@ extension ChatServiceGroupEntry on ChatService {
 
     // Load the objectives for whoever is the initial next speaker (or first char)
     if (_activeGroup != null) {
-      await _loadObjectivesForCurrentSpeaker(claimTodayIfUnique: true);
+      await _loadObjectivesForCurrentSpeaker();
     }
 
     // Seed objectives that came from an imported Group Card (one-time), in case it wasn't caught above

--- a/lib/services/chat/chat_service_group_entry.dart
+++ b/lib/services/chat/chat_service_group_entry.dart
@@ -292,7 +292,7 @@ extension ChatServiceGroupEntry on ChatService {
 
     // Load the objectives for whoever is the initial next speaker (or first char)
     if (_activeGroup != null) {
-      await _loadObjectivesForCurrentSpeaker();
+      await _loadObjectivesForCurrentSpeaker(claimTodayIfUnique: true);
     }
 
     // Seed objectives that came from an imported Group Card (one-time), in case it wasn't caught above

--- a/lib/services/chat/chat_service_objectives.dart
+++ b/lib/services/chat/chat_service_objectives.dart
@@ -219,6 +219,41 @@ extension ChatServiceObjectives on ChatService {
     }
   }
 
+  /// Planner today line: one secondary, no tasks, no ambition, no eviction.
+  Future<String?> _insertTodaySideQuest(String goal, {String? id}) async {
+    if (goal.trim().isEmpty || _currentSessionId == null) return null;
+    CharacterCard? target;
+    if (_activeGroup != null) {
+      final currentIsGroupMember =
+          _activeCharacter != null &&
+          _groupCharacters.any(
+            (c) =>
+                _getCharacterIdFromCard(c) ==
+                _getCharacterIdFromCard(_activeCharacter!),
+          );
+      target = currentIsGroupMember
+          ? _activeCharacter
+          : (nextCharacter ?? _groupCharacters.firstOrNull);
+    } else {
+      target = _activeCharacter;
+    }
+    if (target == null) return null;
+    final newId = id ?? const Uuid().v4();
+    await _db.insertObjective(
+      ObjectivesCompanion.insert(
+        id: newId,
+        characterId: _getCharacterIdFromCard(target),
+        objective: goal.trim(),
+        chatId: drift.Value(_currentSessionId),
+        active: const drift.Value(true),
+        isPrimary: const drift.Value(false),
+        servedAmbition: const drift.Value(null),
+      ),
+    );
+    await _loadActiveObjectives();
+    return newId;
+  }
+
   /// Promote an existing side quest to the primary quest IN PLACE, demoting any
   /// current primary to a side quest. Unlike calling [setObjective] with the same
   /// text (the old promote pattern), this keeps the objective's id and its

--- a/lib/services/chat/chat_service_objectives.dart
+++ b/lib/services/chat/chat_service_objectives.dart
@@ -52,6 +52,7 @@ extension ChatServiceObjectives on ChatService {
           false; // secondary zero in _loadActiveObjectives empty (0-session hygiene for summary flag)
       _isGrowthPassRunning =
           false; // growth-pass flag zero in _loadActiveObjectives empty (0-session hygiene; keep reset blocks in sync)
+      _clearTodayPointer();
       return;
     }
     final charId = _getCharacterIdFromCard(_activeCharacter!);
@@ -71,6 +72,7 @@ extension ChatServiceObjectives on ChatService {
       );
       _activeObjectives = [];
     }
+    _rebindTodayObjectiveFromDb();
     notifyListeners(); // Central _disposed guard in ChatService overrides now protects this (and all other) post-async notify sites. Per-site try/catch removed (deletion part of rec 2 task); see god _disposed + notify override + setActiveCharacter:2205 comment.
   }
 

--- a/lib/services/chat/chat_service_objectives.dart
+++ b/lib/services/chat/chat_service_objectives.dart
@@ -41,7 +41,7 @@ extension ChatServiceObjectives on ChatService {
   }
 
   /// Load the active objectives for the current session from DB.
-  Future<void> _loadActiveObjectives({bool claimTodayIfUnique = false}) async {
+  Future<void> _loadActiveObjectives() async {
     if (_activeCharacter == null || _currentSessionId == null) {
       _activeObjectives = [];
       _messagesSinceLastCheck = 0;
@@ -72,7 +72,7 @@ extension ChatServiceObjectives on ChatService {
       );
       _activeObjectives = [];
     }
-    _rebindTodayObjectiveFromDb(claimIfUnique: claimTodayIfUnique);
+    _rebindTodayObjectiveFromDb();
     notifyListeners(); // Central _disposed guard in ChatService overrides now protects this (and all other) post-async notify sites. Per-site try/catch removed (deletion part of rec 2 task); see god _disposed + notify override + setActiveCharacter:2205 comment.
   }
 
@@ -252,6 +252,7 @@ extension ChatServiceObjectives on ChatService {
         servedAmbition: const drift.Value(null),
       ),
     );
+    await _persistTodayObjectiveId(newId);
     await _loadActiveObjectives();
     return newId;
   }

--- a/lib/services/chat/chat_service_objectives.dart
+++ b/lib/services/chat/chat_service_objectives.dart
@@ -41,7 +41,7 @@ extension ChatServiceObjectives on ChatService {
   }
 
   /// Load the active objectives for the current session from DB.
-  Future<void> _loadActiveObjectives() async {
+  Future<void> _loadActiveObjectives({bool claimTodayIfUnique = false}) async {
     if (_activeCharacter == null || _currentSessionId == null) {
       _activeObjectives = [];
       _messagesSinceLastCheck = 0;
@@ -72,7 +72,7 @@ extension ChatServiceObjectives on ChatService {
       );
       _activeObjectives = [];
     }
-    _rebindTodayObjectiveFromDb();
+    _rebindTodayObjectiveFromDb(claimIfUnique: claimTodayIfUnique);
     notifyListeners(); // Central _disposed guard in ChatService overrides now protects this (and all other) post-async notify sites. Per-site try/catch removed (deletion part of rec 2 task); see god _disposed + notify override + setActiveCharacter:2205 comment.
   }
 

--- a/lib/services/chat/chat_service_session_load.dart
+++ b/lib/services/chat/chat_service_session_load.dart
@@ -73,6 +73,7 @@ extension ChatServiceSessionLoad on ChatService {
       // See "keep reset blocks in sync" (setActiveGroup, startNewChat 1:1+group (now explicit in both), load* , setActive* all must hit this; now includes needs/chaos/... + leaves (see CLAUDE.md for full; incomplete zeroing now complete) + " ; now complete in all group/0-session/new-chat hygiene)" ; incomplete zeroing now complete).
       // (cross-ref setActiveCharacter:1572)
       _timeService.resetForFreshChat();
+      _clearTodayPointer();
       // Fresh GROUP session: apply the group's authored scene-time seed on
       // top of the reset (story-calendar "As built" gap fix — the wizard's
       // time seed used to be editor-carried only and never reached the
@@ -523,6 +524,7 @@ extension ChatServiceSessionLoad on ChatService {
     // taken, and _waitForTurnToSettle has already drained the save chain.
     if (_currentSessionId != sessionId) {
       await flushPendingSaves();
+      _clearTodayPointer();
     }
 
     // Reset AFK idle state when loading a new session

--- a/lib/services/chat/chat_service_session_load.dart
+++ b/lib/services/chat/chat_service_session_load.dart
@@ -618,9 +618,9 @@ extension ChatServiceSessionLoad on ChatService {
       _messagesSinceLastCheck = 0;
       _isCheckingCompletion = false;
       if (_activeGroup != null) {
-        await _loadObjectivesForCurrentSpeaker();
+        await _loadObjectivesForCurrentSpeaker(claimTodayIfUnique: true);
       } else {
-        await _loadActiveObjectives();
+        await _loadActiveObjectives(claimTodayIfUnique: true);
       }
 
       // (Lorebook scanLatest already ran inside _hydrateMessagesFromRows —

--- a/lib/services/chat/chat_service_session_load.dart
+++ b/lib/services/chat/chat_service_session_load.dart
@@ -460,6 +460,9 @@ extension ChatServiceSessionLoad on ChatService {
     // did not save. Skipped when a record exists: the chat has moved on.
     seedPocketsFromCards();
 
+    _todayObjectiveId = s.todayObjectiveId;
+    _todayObjectiveText = null;
+
     // Re-sync from the character's current setting so that toggling
     // "Enjoys low hygiene" on the character affects existing chats on next load.
     _enjoysLowHygiene =
@@ -618,9 +621,9 @@ extension ChatServiceSessionLoad on ChatService {
       _messagesSinceLastCheck = 0;
       _isCheckingCompletion = false;
       if (_activeGroup != null) {
-        await _loadObjectivesForCurrentSpeaker(claimTodayIfUnique: true);
+        await _loadObjectivesForCurrentSpeaker();
       } else {
-        await _loadActiveObjectives(claimTodayIfUnique: true);
+        await _loadActiveObjectives();
       }
 
       // (Lorebook scanLatest already ran inside _hydrateMessagesFromRows —

--- a/lib/services/chat/chat_service_session_manage.dart
+++ b/lib/services/chat/chat_service_session_manage.dart
@@ -112,6 +112,7 @@ extension ChatServiceSessionManage on ChatService {
     if (tip == null) return;
 
     final oldSessionId = _currentSessionId!;
+    _clearTodayPointer();
     final forkedMessages = _messages
         .sublist(0, tip + 1)
         .map(
@@ -242,6 +243,7 @@ extension ChatServiceSessionManage on ChatService {
   /// it used to leak in through here whenever the picker was skipped.
   Future<void> startNewChat({String? personaId}) async {
     if (_activeCharacter == null && _activeGroup == null) return;
+    _clearTodayPointer();
 
     await _userPersonaService.setActivePersona(
       personaId ?? _userPersonaService.defaultPersonaId,

--- a/lib/services/chat/chat_service_speaker_objectives.dart
+++ b/lib/services/chat/chat_service_speaker_objectives.dart
@@ -33,6 +33,7 @@ extension ChatServiceSpeakerObjectives on ChatService {
       chatId: _currentSessionId,
     );
     _activeObjectives = objs.where((o) => o.active).toList();
+    _rebindTodayObjectiveFromDb();
     notifyListeners();
   }
 
@@ -140,6 +141,7 @@ extension ChatServiceSpeakerObjectives on ChatService {
     );
 
     _activeObjectives = objs.where((o) => o.active).toList();
+    _rebindTodayObjectiveFromDb();
     notifyListeners();
   }
 

--- a/lib/services/chat/chat_service_speaker_objectives.dart
+++ b/lib/services/chat/chat_service_speaker_objectives.dart
@@ -116,7 +116,7 @@ extension ChatServiceSpeakerObjectives on ChatService {
   /// Loads the personal objectives for the current/next speaker into _activeObjectives
   /// when in group mode. This makes the existing objective UI, generation, and injection
   /// work per-character in groups without duplicating the entire objective system.
-  Future<void> _loadObjectivesForCurrentSpeaker({bool claimTodayIfUnique = false}) async {
+  Future<void> _loadObjectivesForCurrentSpeaker() async {
     if (_activeGroup == null || _currentSessionId == null) return;
 
     final speaker = nextCharacter ?? _groupCharacters.firstOrNull;
@@ -141,7 +141,7 @@ extension ChatServiceSpeakerObjectives on ChatService {
     );
 
     _activeObjectives = objs.where((o) => o.active).toList();
-    _rebindTodayObjectiveFromDb(claimIfUnique: claimTodayIfUnique);
+    _rebindTodayObjectiveFromDb();
     notifyListeners();
   }
 

--- a/lib/services/chat/chat_service_speaker_objectives.dart
+++ b/lib/services/chat/chat_service_speaker_objectives.dart
@@ -116,7 +116,7 @@ extension ChatServiceSpeakerObjectives on ChatService {
   /// Loads the personal objectives for the current/next speaker into _activeObjectives
   /// when in group mode. This makes the existing objective UI, generation, and injection
   /// work per-character in groups without duplicating the entire objective system.
-  Future<void> _loadObjectivesForCurrentSpeaker() async {
+  Future<void> _loadObjectivesForCurrentSpeaker({bool claimTodayIfUnique = false}) async {
     if (_activeGroup == null || _currentSessionId == null) return;
 
     final speaker = nextCharacter ?? _groupCharacters.firstOrNull;
@@ -141,7 +141,7 @@ extension ChatServiceSpeakerObjectives on ChatService {
     );
 
     _activeObjectives = objs.where((o) => o.active).toList();
-    _rebindTodayObjectiveFromDb();
+    _rebindTodayObjectiveFromDb(claimIfUnique: claimTodayIfUnique);
     notifyListeners();
   }
 

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -487,6 +487,10 @@ extension ChatServiceWiringEvals on ChatService {
       // ambition progress can move. Fire-and-forget; owner resolved from the
       // objective row's characterId (per-character in groups by construction).
       onQuestAchieved: (obj) {
+        if (obj.id == _todayObjectiveId) {
+          unawaited(_onTodayObjectiveCompleted(obj));
+          return;
+        }
         // The Ambitions switch has to stop the WORK, not just the display.
         // Without this, turning ambitions off still spent a model call on
         // every quest completion — a switch that hid the feature while

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -487,7 +487,7 @@ extension ChatServiceWiringEvals on ChatService {
       // ambition progress can move. Fire-and-forget; owner resolved from the
       // objective row's characterId (per-character in groups by construction).
       onQuestAchieved: (obj) {
-        if (obj.id == _todayObjectiveId) {
+        if (_isHeldTodayObjective(obj)) {
           unawaited(_onTodayObjectiveCompleted(obj));
           return;
         }

--- a/lib/services/chat/chat_service_wiring_realism.dart
+++ b/lib/services/chat/chat_service_wiring_realism.dart
@@ -43,29 +43,25 @@ extension ChatServiceWiringRealism on ChatService {
       onStoryDayChanged: () {
         final held = todaySentence;
         setTodaySentence(null);
-        // Journal before deactivate: both hit Drift, and racing the
-        // today_objective_id clear can drop the dayAte card.
-        unawaited(() async {
+        return () async {
           await _journalResolvedToday(held, fate: PlannerTodayFate.dayAte);
           await _deactivateTodayObjective();
-        }());
+        }();
       },
       getPlannerEnabled: () => _storageService.realismSettings.plannerEnabled,
       onTodayEval: (line) {
         if (line.isEmpty) {
           abandonToday();
-        } else {
-          final prev = todaySentence;
-          setTodaySentence(line);
-          // Journal the retired line before upsert/persist so the done
-          // card cannot lose a Drift race with today_objective_id.
-          unawaited(() async {
-            if (prev != null && prev != line) {
-              await _journalResolvedToday(prev, fate: PlannerTodayFate.done);
-            }
-            await _upsertTodayObjective(line);
-          }());
+          return Future<void>.value();
         }
+        final prev = todaySentence;
+        setTodaySentence(line);
+        return () async {
+          if (prev != null && prev != line) {
+            await _journalResolvedToday(prev, fate: PlannerTodayFate.done);
+          }
+          await _upsertTodayObjective(line);
+        }();
       },
       onPatchLastMessageRealismState: (tod, dc, clockIso) {
         // Patch the newest REAL message — never a narration banner. Dream /

--- a/lib/services/chat/chat_service_wiring_realism.dart
+++ b/lib/services/chat/chat_service_wiring_realism.dart
@@ -43,8 +43,12 @@ extension ChatServiceWiringRealism on ChatService {
       onStoryDayChanged: () {
         final held = todaySentence;
         setTodaySentence(null);
-        unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.dayAte));
-        unawaited(_deactivateTodayObjective());
+        // Journal before deactivate: both hit Drift, and racing the
+        // today_objective_id clear can drop the dayAte card.
+        unawaited(() async {
+          await _journalResolvedToday(held, fate: PlannerTodayFate.dayAte);
+          await _deactivateTodayObjective();
+        }());
       },
       getPlannerEnabled: () => _storageService.realismSettings.plannerEnabled,
       onTodayEval: (line) {
@@ -52,11 +56,15 @@ extension ChatServiceWiringRealism on ChatService {
           abandonToday();
         } else {
           final prev = todaySentence;
-          if (prev != null && prev != line) {
-            unawaited(_journalResolvedToday(prev, fate: PlannerTodayFate.done));
-          }
           setTodaySentence(line);
-          unawaited(_upsertTodayObjective(line));
+          // Journal the retired line before upsert/persist so the done
+          // card cannot lose a Drift race with today_objective_id.
+          unawaited(() async {
+            if (prev != null && prev != line) {
+              await _journalResolvedToday(prev, fate: PlannerTodayFate.done);
+            }
+            await _upsertTodayObjective(line);
+          }());
         }
       },
       onPatchLastMessageRealismState: (tod, dc, clockIso) {

--- a/lib/services/chat/chat_service_wiring_realism.dart
+++ b/lib/services/chat/chat_service_wiring_realism.dart
@@ -44,6 +44,7 @@ extension ChatServiceWiringRealism on ChatService {
         final held = todaySentence;
         setTodaySentence(null);
         unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.dayAte));
+        unawaited(_deactivateTodayObjective());
       },
       getPlannerEnabled: () => _storageService.realismSettings.plannerEnabled,
       onTodayEval: (line) {
@@ -55,6 +56,7 @@ extension ChatServiceWiringRealism on ChatService {
             unawaited(_journalResolvedToday(prev, fate: PlannerTodayFate.done));
           }
           setTodaySentence(line);
+          unawaited(_upsertTodayObjective(line));
         }
       },
       onPatchLastMessageRealismState: (tod, dc, clockIso) {

--- a/lib/services/chat/realism_evals.dart
+++ b/lib/services/chat/realism_evals.dart
@@ -31,6 +31,7 @@ import 'package:front_porch_ai/services/chat/time_service.dart';
 import 'package:front_porch_ai/services/chat/pass_support.dart';
 import 'package:front_porch_ai/services/chat/realism_prompt_builder.dart';
 import 'package:front_porch_ai/services/chat/realism_tools.dart';
+import 'package:front_porch_ai/services/chat/today_line_tag.dart';
 import 'package:front_porch_ai/services/chat/realism_verification.dart';
 import 'package:front_porch_ai/services/llm_service.dart' show LlmToolResponse;
 import 'package:front_porch_ai/utils/utils.dart';

--- a/lib/services/chat/realism_evals.one_shot.dart
+++ b/lib/services/chat/realism_evals.one_shot.dart
@@ -205,7 +205,11 @@ extension RealismEvalOneShot on RealismEvals {
           final isDuplicate = active.any(
             (o) => o.objective.toLowerCase() == newObj.toLowerCase(),
           );
-          if (!isDuplicate) {
+          if (!isDuplicate &&
+              !TodayLineTag.proposedCollidesWithToday(
+                newObj,
+                textForOneShot,
+              )) {
             // Same decision as the narrative path (strict oneShot vs normal parity):
             // claim the main-quest slot when it's free, stay a side quest when a
             // primary already exists — never displace an existing main quest.

--- a/lib/services/chat/realism_evals.support.dart
+++ b/lib/services/chat/realism_evals.support.dart
@@ -119,7 +119,8 @@ extension _RealismEvalSupport on RealismEvals {
       final isDuplicate = active.any(
         (o) => o.objective.toLowerCase() == objectiveRaw.toLowerCase(),
       );
-      if (!isDuplicate) {
+      if (!isDuplicate &&
+          !TodayLineTag.proposedCollidesWithToday(objectiveRaw, text)) {
         // Claim the main-quest slot when it's free: the character's self-initiated
         // goal becomes their driving primary quest with a full task arc. When a
         // primary already exists (user-set or an earlier autonomous quest), the

--- a/lib/services/chat/time_service.dart
+++ b/lib/services/chat/time_service.dart
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import 'package:front_porch_ai/services/chat/pass_support.dart';
@@ -135,7 +137,7 @@ class TimeService {
 
   /// Fires when the story day actually rolls. ChatService journals
   /// the held today sentence here — not in a getter.
-  final void Function()? onStoryDayChanged;
+  final FutureOr<void> Function()? onStoryDayChanged;
 
   /// When true, the scene-time eval (and one-shot text) asks for
   /// `today_sentence`. Default off so existing constructors stay valid.
@@ -143,7 +145,7 @@ class TimeService {
 
   /// Empty string = abandon; non-empty = set. Do not write [todayLine]
   /// from the eval — ChatService owns the hold via this callback.
-  final void Function(String line)? onTodayEval;
+  final FutureOr<void> Function(String line)? onTodayEval;
 
   // Owned state — the whole subsystem.
   DateTime _clock = StoryClock.representativeTime(
@@ -165,10 +167,10 @@ class TimeService {
     _todayLineDayCount = null;
   }
 
-  void _ifDayChanged(int dayBefore) {
+  Future<void> _ifDayChanged(int dayBefore) async {
     if (dayCount == dayBefore) return;
     clearTodayLine();
-    onStoryDayChanged?.call();
+    await onStoryDayChanged?.call();
   }
 
   String? get visibleTodayLine {
@@ -468,7 +470,7 @@ class TimeService {
   /// Calendar dialog: set the story's current moment directly. Pulls the
   /// anchor back when the new moment predates Day 1 (the story now starts
   /// earlier). Same swipe-survival patch as a nudge.
-  void setClockDirect(DateTime newClock) {
+  Future<void> setClockDirect(DateTime newClock) async {
     final dayBefore = dayCount;
     _clock = DateTime.utc(
       newClock.year,
@@ -479,7 +481,7 @@ class TimeService {
     );
     if (_clock.isBefore(_startDate)) _startDate = StoryClock.dateOnly(_clock);
     _turnsSinceClockMoved = 0;
-    _ifDayChanged(dayBefore);
+    await _ifDayChanged(dayBefore);
     onPatchLastMessageRealismState(timeOfDay, dayCount, storyClockIso);
   }
 
@@ -675,10 +677,10 @@ class TimeService {
     return m == null ? null : int.tryParse(m.group(1)!);
   }
 
-  void _maybeApplyTodayEval(String text) {
+  Future<void> _maybeApplyTodayEval(String text) async {
     if (!(getPlannerEnabled?.call() ?? false)) return;
     final parsed = TodayLineTag.parseEvalSentence(text);
-    if (parsed != null) onTodayEval?.call(parsed);
+    if (parsed != null) await onTodayEval?.call(parsed);
   }
 
   /// The posture question alone — shared VERBATIM between the standalone
@@ -867,7 +869,7 @@ class TimeService {
           '[Realism:Time] OOC skip owns this turn — one-shot clock '
           'movement suppressed',
         );
-        _maybeApplyTodayEval(text);
+        await _maybeApplyTodayEval(text);
         return;
       }
       final saidNewDay = extractJsonBool(text, 'new_day') ?? false;
@@ -876,7 +878,7 @@ class TimeService {
         minutes: _extractMinutes(text),
         newDay: saidNewDay && newDayCorroborated,
       );
-      _maybeApplyTodayEval(text);
+      await _maybeApplyTodayEval(text);
       debugPrint(
         '[Realism:Time] One-shot elapsed applied → $displayClock (Day $dayCount)',
       );
@@ -940,7 +942,7 @@ class TimeService {
             newDay: saidNewDay && newDayCorroborated,
           );
         }
-        _maybeApplyTodayEval(text);
+        await _maybeApplyTodayEval(text);
       } else if (!skipOwnsClock) {
         _applyElapsed(minutes: null, newDay: false);
       }

--- a/lib/services/chat/today_line_tag.dart
+++ b/lib/services/chat/today_line_tag.dart
@@ -54,4 +54,12 @@ class TodayLineTag {
     if (line.length > 140) line = line.substring(0, 140).trim();
     return line;
   }
+
+  /// Same-turn collision: proposed_objective must not claim the today line
+  /// as a new main quest.
+  static bool proposedCollidesWithToday(String proposed, String evalText) {
+    final today = parseEvalSentence(evalText);
+    if (today == null || today.isEmpty) return false;
+    return today.toLowerCase() == proposed.trim().toLowerCase();
+  }
 }

--- a/test/database/pockets_persist_migration_test.dart
+++ b/test/database/pockets_persist_migration_test.dart
@@ -160,11 +160,14 @@ void main() {
       expect(repair, contains("'pockets TEXT'"));
     });
 
-    test('schemaVersion advanced to 47', () {
+    test('schemaVersion is at least 47', () {
+      final src = File('lib/database/database.dart').readAsStringSync();
+      final m = RegExp(r'schemaVersion => (\d+)').firstMatch(src);
+      expect(m, isNotNull);
       expect(
-        File('lib/database/database.dart').readAsStringSync(),
-        contains('schemaVersion => 47'),
-        reason: 'the ladder step is dead code if the version never asks for it',
+        int.parse(m!.group(1)!),
+        greaterThanOrEqualTo(47),
+        reason: 'the v47 ladder step is dead code if the version never asks for it',
       );
     });
   });

--- a/test/services/avatar_repository_test.dart
+++ b/test/services/avatar_repository_test.dart
@@ -75,7 +75,12 @@ void main() {
       //      the Table/ladder/repair trio AND that the save and load wires
       //      exist — the wires being the part that was actually missing and
       //      that made 1:1 chats forget her pockets on every reload.
-      expect(db.schemaVersion, 47);
+      // v48: sessions.today_objective_id — the live Today side-quest row.
+      //      Same pin: uniqueness-by-shape cannot rebind once a user-typed
+      //      secondary exists, so the session holds the id. The column itself
+      //      is guarded by the Table/ladder/repair trio plus
+      //      test/services/chat/today_side_quest_test.dart.
+      expect(db.schemaVersion, 48);
     });
 
     test('journal_memories table exists and round-trips (v35)', () async {

--- a/test/services/chat/planner_today_fate_test.dart
+++ b/test/services/chat/planner_today_fate_test.dart
@@ -104,7 +104,7 @@ void main() {
     expect(
       src,
       contains(
-        'unawaited(_journalResolvedToday(held, fate: PlannerTodayFate.abandoned))',
+        '_journalResolvedToday(held, fate: PlannerTodayFate.abandoned)',
       ),
     );
 

--- a/test/services/chat/planner_today_fate_test.dart
+++ b/test/services/chat/planner_today_fate_test.dart
@@ -189,7 +189,7 @@ void main() {
 
     chat.setTodaySentence('Hold the porch light.');
     final before = chat.timeService.clock;
-    chat.timeService.setClockDirect(before.add(const Duration(days: 1)));
+    await chat.timeService.setClockDirect(before.add(const Duration(days: 1)));
     await _drain();
 
     expect(chat.todaySentence, isNull);
@@ -262,7 +262,7 @@ void main() {
     expect(chat.todaySentence, line);
 
     final before = chat.timeService.clock;
-    chat.timeService.setClockDirect(before.add(const Duration(days: 1)));
+    await chat.timeService.setClockDirect(before.add(const Duration(days: 1)));
     expect(chat.todaySentence, isNull);
     await _drain();
 

--- a/test/services/chat/today_line_tag_test.dart
+++ b/test/services/chat/today_line_tag_test.dart
@@ -90,20 +90,4 @@ void main() {
     ]);
     expect(TodayLineTag.parseEvalSentence(none!), isEmpty);
   });
-
-  test('proposed_objective matching today_sentence is a collision', () {
-    const payload =
-        '{"today_sentence": "Sweep the stoop before dusk.", "proposed_objective": "Sweep the stoop before dusk."}';
-    expect(
-      TodayLineTag.proposedCollidesWithToday(
-        'Sweep the stoop before dusk.',
-        payload,
-      ),
-      isTrue,
-    );
-    expect(
-      TodayLineTag.proposedCollidesWithToday('Climb the mountain', payload),
-      isFalse,
-    );
-  });
 }

--- a/test/services/chat/today_line_tag_test.dart
+++ b/test/services/chat/today_line_tag_test.dart
@@ -90,4 +90,20 @@ void main() {
     ]);
     expect(TodayLineTag.parseEvalSentence(none!), isEmpty);
   });
+
+  test('proposed_objective matching today_sentence is a collision', () {
+    const payload =
+        '{"today_sentence": "Sweep the stoop before dusk.", "proposed_objective": "Sweep the stoop before dusk."}';
+    expect(
+      TodayLineTag.proposedCollidesWithToday(
+        'Sweep the stoop before dusk.',
+        payload,
+      ),
+      isTrue,
+    );
+    expect(
+      TodayLineTag.proposedCollidesWithToday('Climb the mountain', payload),
+      isFalse,
+    );
+  });
 }

--- a/test/services/chat/today_side_quest_test.dart
+++ b/test/services/chat/today_side_quest_test.dart
@@ -117,9 +117,10 @@ void main() {
           c.activeObjectives.any(
             (o) => o.id == c.todayObjectiveId && o.objective == sentence,
           )) {
-        return;
+        break;
       }
     }
+    await _drain();
   }
 
   Future<List<Objective>> allRows(ChatService c, CharacterCard who) {
@@ -225,6 +226,13 @@ void main() {
     chat.timeService.setClockDirect(
       chat.timeService.clock.add(const Duration(days: 1)),
     );
+    for (var i = 0; i < 200; i++) {
+      await Future<void>.delayed(Duration.zero);
+      if (chat.todayObjectiveId == null &&
+          chat.activeObjectives.every((o) => o.id != id)) {
+        break;
+      }
+    }
     await _drain();
 
     expect(chat.todaySentence, isNull);
@@ -379,13 +387,17 @@ void main() {
     expect(oldRows.where((o) => o.id == oldId && o.active).length, 1);
   });
 
-  test('loadSession rebinds Today from the live row', () async {
+  test('today plus a user side quest rebinds on loadSession', () async {
     final who = card();
     await chat.setActiveCharacter(who);
+    await chat.setObjective('Buy milk on the way home', isPrimary: false);
     await fireToday(chat, 'Sweep the stoop before dusk.');
     final sid = chat.currentSessionId!;
-    final held = chat.todayObjectiveId;
-    expect(held, isNotNull);
+    final held = chat.todayObjectiveId!;
+    final sideId = chat.secondaryObjectives
+        .firstWhere((o) => o.id != held)
+        .id;
+    expect(chat.secondaryObjectives, hasLength(2));
 
     await chat.startNewChat();
     await _drain();
@@ -397,41 +409,21 @@ void main() {
     expect(chat.currentSessionId, sid);
     expect(chat.todayObjectiveId, held);
     expect(chat.todaySentence, 'Sweep the stoop before dusk.');
-    expect(
-      chat.activeObjectives.where((o) => !o.isPrimary && o.active).length,
-      1,
-    );
-
-    await fireToday(chat, 'Sweep the stoop before dusk.');
-    expect(chat.todayObjectiveId, held);
-    expect(
-      (await allRows(chat, who)).where((o) => o.active && !o.isPrimary).length,
-      1,
-    );
-  });
-
-  test('new sentence after loadSession retires the rebound row', () async {
-    final who = card();
-    await chat.setActiveCharacter(who);
-    await fireToday(chat, 'Sweep the stoop before dusk.');
-    final sid = chat.currentSessionId!;
-    final held = chat.todayObjectiveId!;
-
-    await chat.startNewChat();
-    await _drain();
-    await chat.loadSession(sid);
-    await _drain();
-    expect(chat.todayObjectiveId, held);
+    expect(chat.activeObjectives.any((o) => o.id == sideId && o.active), isTrue);
 
     await fireToday(chat, 'Water the geraniums.');
     expect(chat.todayObjectiveId, isNot(held));
     expect(chat.todaySentence, 'Water the geraniums.');
     final rows = await allRows(chat, who);
     expect(rows.where((o) => o.id == held).single.active, isFalse);
-    expect(rows.where((o) => o.active && !o.isPrimary).length, 1);
+    expect(rows.where((o) => o.id == sideId).single.active, isTrue);
+    expect(
+      rows.where((o) => o.active && !o.isPrimary).map((o) => o.id).toSet(),
+      {sideId, chat.todayObjectiveId},
+    );
   });
 
-  test('null id and null sentence do not treat every secondary as today', () {
+  test('held today is the persisted id, never every taskless secondary', () {
     final evals = File(
       'lib/services/chat/chat_service_wiring_evals.dart',
     ).readAsStringSync();
@@ -440,10 +432,12 @@ void main() {
       'lib/services/chat/chat_service_accessors.dart',
     ).readAsStringSync();
     expect(accessors, contains('bool _isHeldTodayObjective(Objective obj)'));
-    expect(accessors, contains('if (_todayObjectiveId != null) return false;'));
-    expect(accessors, contains('if (_todaySentence != null) return obj.objective == _todaySentence;'));
-    expect(accessors, contains('return false;'));
-    expect(accessors, isNot(contains('dropTodayPointerForTest')));
+    expect(
+      accessors,
+      contains('return _todayObjectiveId != null && obj.id == _todayObjectiveId;'),
+    );
+    expect(accessors, contains('_persistTodayObjectiveId'));
+    expect(accessors, isNot(contains('claimIfUnique')));
   });
 
   test('session change clears the today pointer then rebinds', () {
@@ -455,10 +449,11 @@ void main() {
       'lib/services/chat/chat_service_session_load.dart',
     ).readAsStringSync();
     expect(load, contains('_clearTodayPointer();'));
+    expect(load, contains('_todayObjectiveId = s.todayObjectiveId;'));
     final objs = File(
       'lib/services/chat/chat_service_objectives.dart',
     ).readAsStringSync();
-    expect(objs, contains('_rebindTodayObjectiveFromDb(claimIfUnique: claimTodayIfUnique)'));
+    expect(objs, contains('_rebindTodayObjectiveFromDb();'));
     expect(objs, contains('_clearTodayPointer();'));
   });
 

--- a/test/services/chat/today_side_quest_test.dart
+++ b/test/services/chat/today_side_quest_test.dart
@@ -111,10 +111,12 @@ void main() {
       oneShotText:
           '{"minutes_elapsed": 5, "new_day": false, "today_sentence": "$sentence"}',
     );
-    for (var i = 0; i < 200; i++) {
+    for (var i = 0; i < 400; i++) {
       await Future<void>.delayed(Duration.zero);
       if (c.todayObjectiveId != null &&
-          c.activeObjectives.any((o) => o.id == c.todayObjectiveId)) {
+          c.activeObjectives.any(
+            (o) => o.id == c.todayObjectiveId && o.objective == sentence,
+          )) {
         return;
       }
     }
@@ -377,25 +379,59 @@ void main() {
     expect(oldRows.where((o) => o.id == oldId && o.active).length, 1);
   });
 
-  test('reload with a null pointer rebinds the live row', () async {
+  test('loadSession rebinds Today from the live row', () async {
     final who = card();
     await chat.setActiveCharacter(who);
     await fireToday(chat, 'Sweep the stoop before dusk.');
+    final sid = chat.currentSessionId!;
     final held = chat.todayObjectiveId;
     expect(held, isNotNull);
 
-    chat.dropTodayPointerForTest();
+    await chat.startNewChat();
+    await _drain();
     expect(chat.todayObjectiveId, isNull);
+    expect(chat.todaySentence, isNull);
 
-    await fireToday(chat, 'Sweep the stoop before dusk.');
+    await chat.loadSession(sid);
+    await _drain();
+    expect(chat.currentSessionId, sid);
     expect(chat.todayObjectiveId, held);
+    expect(chat.todaySentence, 'Sweep the stoop before dusk.');
     expect(
       chat.activeObjectives.where((o) => !o.isPrimary && o.active).length,
       1,
     );
+
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    expect(chat.todayObjectiveId, held);
+    expect(
+      (await allRows(chat, who)).where((o) => o.active && !o.isPrimary).length,
+      1,
+    );
   });
 
-  test('orphaned today-row is still the held today objective', () {
+  test('new sentence after loadSession retires the rebound row', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final sid = chat.currentSessionId!;
+    final held = chat.todayObjectiveId!;
+
+    await chat.startNewChat();
+    await _drain();
+    await chat.loadSession(sid);
+    await _drain();
+    expect(chat.todayObjectiveId, held);
+
+    await fireToday(chat, 'Water the geraniums.');
+    expect(chat.todayObjectiveId, isNot(held));
+    expect(chat.todaySentence, 'Water the geraniums.');
+    final rows = await allRows(chat, who);
+    expect(rows.where((o) => o.id == held).single.active, isFalse);
+    expect(rows.where((o) => o.active && !o.isPrimary).length, 1);
+  });
+
+  test('null id and null sentence do not treat every secondary as today', () {
     final evals = File(
       'lib/services/chat/chat_service_wiring_evals.dart',
     ).readAsStringSync();
@@ -406,6 +442,8 @@ void main() {
     expect(accessors, contains('bool _isHeldTodayObjective(Objective obj)'));
     expect(accessors, contains('if (_todayObjectiveId != null) return false;'));
     expect(accessors, contains('if (_todaySentence != null) return obj.objective == _todaySentence;'));
+    expect(accessors, contains('return false;'));
+    expect(accessors, isNot(contains('dropTodayPointerForTest')));
   });
 
   test('session change clears the today pointer then rebinds', () {
@@ -420,7 +458,7 @@ void main() {
     final objs = File(
       'lib/services/chat/chat_service_objectives.dart',
     ).readAsStringSync();
-    expect(objs, contains('_rebindTodayObjectiveFromDb();'));
+    expect(objs, contains('_rebindTodayObjectiveFromDb(claimIfUnique: claimTodayIfUnique)'));
     expect(objs, contains('_clearTodayPointer();'));
   });
 

--- a/test/services/chat/today_side_quest_test.dart
+++ b/test/services/chat/today_side_quest_test.dart
@@ -1,0 +1,307 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Today is one secondary objective on the existing tracker. Match by
+// held id. Never primary, never tasks, never an ambition.
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:front_porch_ai/database/database.dart';
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/llm_service.dart';
+import 'package:front_porch_ai/services/services.dart';
+
+final Directory _root = Directory.systemTemp.createTempSync(
+  'fpai_today_quest_',
+);
+
+void _setupPathProviderMock() {
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return _root.path;
+        }
+        return null;
+      });
+}
+
+class _YesLlm extends LLMService {
+  @override
+  Stream<String> generateStream(GenerationParams params) async* {
+    yield '1: YES';
+  }
+
+  @override
+  bool get isReady => true;
+
+  @override
+  String get backendName => 'YesLlm';
+}
+
+Future<void> _drain([int n = 40]) async {
+  for (var i = 0; i < n; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  _setupPathProviderMock();
+
+  late AppDatabase db;
+  late StorageService storage;
+  late ChatService chat;
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({
+      'update_auto_check': false,
+      'realism_default': false,
+      'pockets_enabled': false,
+      'journal_enabled': false,
+    });
+    db = AppDatabase.forTesting();
+    storage = StorageService();
+    chat =
+        ChatService(
+            KoboldService(storage),
+            UserPersonaService(db),
+            storage,
+            WorldRepository(storage, db),
+          )
+          ..setDatabase(db)
+          ..setCharacterRepository(CharacterRepository(db, storage))
+          ..testLlmServiceOverride = _YesLlm();
+    await storage.initialized;
+    await storage.realismSettings.setPlannerEnabled(true);
+  });
+
+  tearDown(() async {
+    chat.dispose();
+    await db.close();
+  });
+
+  CharacterCard card() => CharacterCard(
+    name: 'Ada',
+    description: 'Exists only inside the today side-quest lock.',
+    firstMessage: 'The screen door bangs shut behind you.',
+  )..dbId = 'char-today-quest';
+
+  Future<void> fireToday(ChatService c, String sentence) async {
+    await c.timeService.evaluateTimeProgressAndPostureIfNeeded(
+      charName: 'Ada',
+      recent: 'User: What are you doing?\nAda: She stacks the books.',
+      shortTermTierName: 'Warm',
+      onChunk: null,
+      fireLLMEval: (p, {onChunk}) async => null,
+      stripThinkBlocks: (s) => s,
+      extractJsonBool: (raw, key) {
+        final m = RegExp('"' + key + r'"\s*:\s*(true|false)').firstMatch(raw);
+        return m == null ? null : m.group(1) == 'true';
+      },
+      setSpatialStance: (_) {},
+      getCurrentSpatialStance: () => '',
+      getCharacterEmotion: () => '',
+      getEmotionIntensity: () => '',
+      oneShotMode: true,
+      oneShotText:
+          '{"minutes_elapsed": 5, "new_day": false, "today_sentence": "$sentence"}',
+    );
+    for (var i = 0; i < 200; i++) {
+      await Future<void>.delayed(Duration.zero);
+      if (c.todayObjectiveId != null &&
+          c.activeObjectives.any((o) => o.id == c.todayObjectiveId)) {
+        return;
+      }
+    }
+  }
+
+  Future<List<Objective>> allRows(ChatService c, CharacterCard who) {
+    return db.getObjectivesForCharacter(
+      c.characterIdFor(who),
+      chatId: c.currentSessionId,
+    );
+  }
+
+  Objective todayRow(ChatService c) {
+    final id = c.todayObjectiveId;
+    expect(id, isNotNull);
+    return c.activeObjectives.singleWhere((o) => o.id == id);
+  }
+
+  test('spawn writes one secondary with empty tasks and no ambition', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+
+    expect(chat.todaySentence, 'Sweep the stoop before dusk.');
+    expect(chat.todayObjectiveId, isNotNull);
+    final row = todayRow(chat);
+    expect(row.isPrimary, isFalse);
+    expect(row.servedAmbition, isNull);
+    expect(row.tasks, '[]');
+    expect(row.active, isTrue);
+    expect(row.objective, 'Sweep the stoop before dusk.');
+    expect(chat.primaryObjective, isNull);
+    expect(chat.secondaryObjectives, hasLength(1));
+  });
+
+  test('same sentence does not spawn a duplicate', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final id = chat.todayObjectiveId;
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+
+    expect(chat.todayObjectiveId, id);
+    expect(chat.activeObjectives, hasLength(1));
+    expect(chat.activeObjectives.single.id, id);
+  });
+
+  test('new sentence retires the old today-row and inserts the new one', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final oldId = chat.todayObjectiveId!;
+    await fireToday(chat, 'Hold the porch light.');
+
+    expect(chat.todaySentence, 'Hold the porch light.');
+    expect(chat.todayObjectiveId, isNotNull);
+    expect(chat.todayObjectiveId, isNot(oldId));
+    final live = todayRow(chat);
+    expect(live.objective, 'Hold the porch light.');
+    expect(live.isPrimary, isFalse);
+    expect(live.servedAmbition, isNull);
+    expect(live.tasks, '[]');
+
+    final rows = await allRows(chat, who);
+    final retired = rows.singleWhere((o) => o.id == oldId);
+    expect(retired.active, isFalse);
+    expect(retired.isPrimary, isFalse);
+  });
+
+  test('abandonToday deactivates the today-row and does not complete it', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final id = chat.todayObjectiveId!;
+    chat.abandonToday();
+    await _drain();
+
+    expect(chat.todaySentence, isNull);
+    expect(chat.todayObjectiveId, isNull);
+    expect(chat.characterEmotion, 'annoyed');
+    expect(chat.activeObjectives, isEmpty);
+    final retired = (await allRows(chat, who)).singleWhere((o) => o.id == id);
+    expect(retired.active, isFalse);
+    expect(retired.isPrimary, isFalse);
+    expect(retired.servedAmbition, isNull);
+    expect(retired.tasks, '[]');
+    final cards = await chat.journalStore.cardsFor(
+      chat.currentSessionId!,
+      chat.characterIdFor(who),
+    );
+    expect(cards, isEmpty);
+  });
+
+  test('day-roll miss deactivates and does not mark complete', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Hold the porch light.');
+    final id = chat.todayObjectiveId!;
+    chat.timeService.setClockDirect(
+      chat.timeService.clock.add(const Duration(days: 1)),
+    );
+    await _drain();
+
+    expect(chat.todaySentence, isNull);
+    expect(chat.todayObjectiveId, isNull);
+    expect(chat.characterEmotion, 'annoyed');
+    final retired = (await allRows(chat, who)).singleWhere((o) => o.id == id);
+    expect(retired.active, isFalse);
+    expect(retired.isPrimary, isFalse);
+  });
+
+  test('complete keeps secondary shape and does not serve an ambition', () async {
+    final wiring = File(
+      'lib/services/chat/chat_service_wiring_evals.dart',
+    ).readAsStringSync();
+    expect(wiring, contains('if (obj.id == _todayObjectiveId)'));
+    expect(wiring, contains('unawaited(_onTodayObjectiveCompleted(obj));'));
+    expect(
+      wiring.indexOf('if (obj.id == _todayObjectiveId)'),
+      lessThan(wiring.indexOf('_ambitionService.onQuestAchieved')),
+    );
+
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final todayId = chat.todayObjectiveId!;
+    expect(chat.primaryObjective, isNull);
+    expect(todayRow(chat).isPrimary, isFalse);
+
+    chat.forceCheckCompletion();
+    for (var i = 0; i < 200; i++) {
+      await Future<void>.delayed(Duration.zero);
+      if (chat.todayObjectiveId == null && chat.todaySentence == null) {
+        break;
+      }
+    }
+    await _drain(20);
+
+    expect(chat.todaySentence, isNull);
+    expect(chat.todayObjectiveId, isNull);
+    expect(chat.characterEmotion, 'content');
+    expect(chat.primaryObjective, isNull);
+
+    final done = (await allRows(chat, who)).singleWhere((o) => o.id == todayId);
+    expect(done.active, isFalse);
+    expect(done.isPrimary, isFalse);
+    expect(done.servedAmbition, isNull);
+    expect(done.tasks, '[]');
+
+    final cards = await chat.journalStore.cardsFor(
+      chat.currentSessionId!,
+      chat.characterIdFor(who),
+    );
+    expect(cards.any((c) => c.content == 'Sweep the stoop before dusk.'), isTrue);
+  });
+
+  test('today insert does not evict other secondaries or steal primary', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await chat.setObjective('Main quest', isPrimary: true);
+    await chat.setObjective('Side one', isPrimary: false);
+    await chat.setObjective('Side two', isPrimary: false);
+    final before = chat.activeObjectives.map((o) => o.id).toSet();
+    expect(chat.primaryObjective?.objective, 'Main quest');
+    expect(chat.secondaryObjectives, hasLength(2));
+
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    expect(chat.primaryObjective?.objective, 'Main quest');
+    expect(chat.todayObjectiveId, isNotNull);
+    expect(chat.secondaryObjectives.length, greaterThanOrEqualTo(3));
+    for (final id in before) {
+      expect(chat.activeObjectives.any((o) => o.id == id), isTrue);
+    }
+    final row = todayRow(chat);
+    expect(row.isPrimary, isFalse);
+    expect(row.servedAmbition, isNull);
+    expect(row.tasks, '[]');
+  });
+
+  test('1:1 Away and At work never skip still holds', () {
+    final skipSrc = File(
+      'lib/services/chat/chat_service_turn_flow.dart',
+    ).readAsStringSync();
+    final skipFn = RegExp(
+      r'bool _groupSpeakerSkips\(CharacterCard card\) \{([\s\S]*?)\n  \}',
+    ).firstMatch(skipSrc);
+    expect(skipFn, isNotNull);
+    expect(skipFn!.group(1)!, contains('if (_activeGroup == null) return false;'));
+    expect(skipFn.group(1)!, contains('return groupTurnSkips(where);'));
+  });
+}

--- a/test/services/chat/today_side_quest_test.dart
+++ b/test/services/chat/today_side_quest_test.dart
@@ -13,6 +13,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:front_porch_ai/database/database.dart';
 import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/llm_service.dart';
+import 'package:front_porch_ai/services/chat/today_line_tag.dart';
 import 'package:front_porch_ai/services/services.dart';
 
 final Directory _root = Directory.systemTemp.createTempSync(
@@ -304,4 +305,21 @@ void main() {
     expect(skipFn!.group(1)!, contains('if (_activeGroup == null) return false;'));
     expect(skipFn.group(1)!, contains('return groupTurnSkips(where);'));
   });
+
+  test('proposed_objective matching today_sentence is a collision', () {
+    const payload =
+        '{"today_sentence": "Sweep the stoop before dusk.", "proposed_objective": "Sweep the stoop before dusk."}';
+    expect(
+      TodayLineTag.proposedCollidesWithToday(
+        'Sweep the stoop before dusk.',
+        payload,
+      ),
+      isTrue,
+    );
+    expect(
+      TodayLineTag.proposedCollidesWithToday('Climb the mountain', payload),
+      isFalse,
+    );
+  });
+
 }

--- a/test/services/chat/today_side_quest_test.dart
+++ b/test/services/chat/today_side_quest_test.dart
@@ -223,7 +223,7 @@ void main() {
     await chat.setActiveCharacter(who);
     await fireToday(chat, 'Hold the porch light.');
     final id = chat.todayObjectiveId!;
-    chat.timeService.setClockDirect(
+    await chat.timeService.setClockDirect(
       chat.timeService.clock.add(const Duration(days: 1)),
     );
     for (var i = 0; i < 200; i++) {

--- a/test/services/chat/today_side_quest_test.dart
+++ b/test/services/chat/today_side_quest_test.dart
@@ -190,6 +190,13 @@ void main() {
     await fireToday(chat, 'Sweep the stoop before dusk.');
     final id = chat.todayObjectiveId!;
     chat.abandonToday();
+    for (var i = 0; i < 200; i++) {
+      await Future<void>.delayed(Duration.zero);
+      if (chat.todayObjectiveId == null &&
+          chat.activeObjectives.every((o) => o.id != id)) {
+        break;
+      }
+    }
     await _drain();
 
     expect(chat.todaySentence, isNull);
@@ -230,10 +237,10 @@ void main() {
     final wiring = File(
       'lib/services/chat/chat_service_wiring_evals.dart',
     ).readAsStringSync();
-    expect(wiring, contains('if (obj.id == _todayObjectiveId)'));
+    expect(wiring, contains('if (_isHeldTodayObjective(obj))'));
     expect(wiring, contains('unawaited(_onTodayObjectiveCompleted(obj));'));
     expect(
-      wiring.indexOf('if (obj.id == _todayObjectiveId)'),
+      wiring.indexOf('if (_isHeldTodayObjective(obj))'),
       lessThan(wiring.indexOf('_ambitionService.onQuestAchieved')),
     );
 
@@ -320,6 +327,101 @@ void main() {
       TodayLineTag.proposedCollidesWithToday('Climb the mountain', payload),
       isFalse,
     );
+  });
+
+  test('new chat + same sentence inserts in the new session', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final oldSid = chat.currentSessionId;
+    final oldId = chat.todayObjectiveId;
+    expect(oldSid, isNotNull);
+    expect(oldId, isNotNull);
+
+    await chat.startNewChat();
+    await _drain();
+    expect(chat.currentSessionId, isNot(oldSid));
+    expect(chat.todayObjectiveId, isNull);
+
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    expect(chat.todayObjectiveId, isNotNull);
+    expect(chat.todayObjectiveId, isNot(oldId));
+    expect(chat.currentSessionId, isNot(oldSid));
+
+    final oldRows = await db.getObjectivesForCharacter(
+      chat.characterIdFor(who),
+      chatId: oldSid,
+    );
+    expect(oldRows.where((o) => o.id == oldId && o.active).length, 1);
+    final newRows = await allRows(chat, who);
+    expect(newRows.where((o) => o.id == chat.todayObjectiveId && o.active).length, 1);
+  });
+
+  test('new chat + new sentence leaves the previous session row active', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final oldSid = chat.currentSessionId;
+    final oldId = chat.todayObjectiveId;
+
+    await chat.startNewChat();
+    await _drain();
+    await fireToday(chat, 'Water the geraniums.');
+    expect(chat.todayObjectiveId, isNot(oldId));
+    expect(todayRow(chat).objective, 'Water the geraniums.');
+
+    final oldRows = await db.getObjectivesForCharacter(
+      chat.characterIdFor(who),
+      chatId: oldSid,
+    );
+    expect(oldRows.where((o) => o.id == oldId && o.active).length, 1);
+  });
+
+  test('reload with a null pointer rebinds the live row', () async {
+    final who = card();
+    await chat.setActiveCharacter(who);
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    final held = chat.todayObjectiveId;
+    expect(held, isNotNull);
+
+    chat.dropTodayPointerForTest();
+    expect(chat.todayObjectiveId, isNull);
+
+    await fireToday(chat, 'Sweep the stoop before dusk.');
+    expect(chat.todayObjectiveId, held);
+    expect(
+      chat.activeObjectives.where((o) => !o.isPrimary && o.active).length,
+      1,
+    );
+  });
+
+  test('orphaned today-row is still the held today objective', () {
+    final evals = File(
+      'lib/services/chat/chat_service_wiring_evals.dart',
+    ).readAsStringSync();
+    expect(evals, contains('if (_isHeldTodayObjective(obj))'));
+    final accessors = File(
+      'lib/services/chat/chat_service_accessors.dart',
+    ).readAsStringSync();
+    expect(accessors, contains('bool _isHeldTodayObjective(Objective obj)'));
+    expect(accessors, contains('if (_todayObjectiveId != null) return false;'));
+    expect(accessors, contains('if (_todaySentence != null) return obj.objective == _todaySentence;'));
+  });
+
+  test('session change clears the today pointer then rebinds', () {
+    final start = File(
+      'lib/services/chat/chat_service_session_manage.dart',
+    ).readAsStringSync();
+    expect(start, contains('_clearTodayPointer();'));
+    final load = File(
+      'lib/services/chat/chat_service_session_load.dart',
+    ).readAsStringSync();
+    expect(load, contains('_clearTodayPointer();'));
+    final objs = File(
+      'lib/services/chat/chat_service_objectives.dart',
+    ).readAsStringSync();
+    expect(objs, contains('_rebindTodayObjectiveFromDb();'));
+    expect(objs, contains('_clearTodayPointer();'));
   });
 
 }


### PR DESCRIPTION
## Summary
- Scene-time `today_sentence` upserts one secondary objective (not primary, no tasks, no ambition).
- Same sentence does not duplicate. A new sentence retires the old row.
- Abandon and day-roll deactivate (sour / miss). Mid-day complete uses the existing checker.
- `proposed_objective` matching today's sentence is skipped so it cannot become the main quest.

## Test plan
- [x] today_side_quest + planner_today_fate + today_line_tag + presence_derive (39/39 local)
- [ ] CI green on this PR
- [ ] Do not merge until CoS says / CI green