### PR TITLE
feat(memory): gist-first recall and cued RAG

### DIFF
--- a/lib/services/chat/chat_service_generation.dart
+++ b/lib/services/chat/chat_service_generation.dart
@@ -81,6 +81,16 @@ class _GenTurn {
   String journalBlock = '';
   Set<int> expandedJournalPositions = const {};
 
+  /// Cued RAG / journal-cold query for this turn (emotion + fixation +
+  /// top hot journal line + last words). Empty until the blocks phase.
+  String ragQuery = '';
+
+  /// Top hot journal line baked into [ragQuery] (re-composed after Continue pops).
+  String ragHotJournalLine = '';
+
+  /// Journal card contents used to drop RAG windows the diary already covers.
+  List<String> journalCoverLines = const [];
+
   // ── plan phase → rag/request phases ──
   String history = '';
   int droppedMessages = 0;

--- a/lib/services/chat/chat_service_generation_blocks.dart
+++ b/lib/services/chat/chat_service_generation_blocks.dart
@@ -304,7 +304,10 @@ extension ChatServiceGenerationBlocks on ChatService {
       final cards = speakerId.isEmpty
           ? const <JournalMemoryData>[]
           : await _journalStore.cardsFor(_currentSessionId!, speakerId);
-      t.journalCoverLines = [for (final c in cards) c.content];
+      // Cover-drop uses THIS-BEAT injected gist only (set after the
+      // journal block builds). The whole cabinet here would eat a
+      // fallen-off fact that shares filler with a cold card.
+      t.journalCoverLines = const [];
       t.ragHotJournalLine =
           JournalPhysics.topHotJournalLine(cards, _characterEmotion) ?? '';
       t.ragQuery = composeRagQuery(
@@ -337,6 +340,9 @@ extension ChatServiceGenerationBlocks on ChatService {
       );
       t.journalBlock = journal.text;
       t.expandedJournalPositions = journal.expandedPositions;
+      if (journal.text.isNotEmpty) {
+        t.journalCoverLines = journal.injectedContents;
+      }
     }
   }
 }

--- a/lib/services/chat/chat_service_generation_blocks.dart
+++ b/lib/services/chat/chat_service_generation_blocks.dart
@@ -314,7 +314,7 @@ extension ChatServiceGenerationBlocks on ChatService {
         emotion: _characterEmotion,
         fixation: _relationshipService.activeFixation,
         hotJournalLine: t.ragHotJournalLine,
-        lastWords: lastSpokenLineFromMessages(_messages),
+        lastWords: lastWordsFromMessages(_messages),
       );
     }
 
@@ -336,7 +336,7 @@ extension ChatServiceGenerationBlocks on ChatService {
         // not the last-3 live lines. promptText still rides lastWords so
         // photo captions reach cold-resurface the way they reach RAG.
         queryText: t.ragQuery,
-        lastWords: lastWordsFromMessages(_messages),
+        lastWords: lastSpokenLineFromMessages(_messages),
         messageCount: _messages.length,
       );
       t.journalBlock = journal.text;

--- a/lib/services/chat/chat_service_generation_blocks.dart
+++ b/lib/services/chat/chat_service_generation_blocks.dart
@@ -65,8 +65,7 @@ extension ChatServiceGenerationBlocks on ChatService {
     }
 
     // In call mode, inject voice-specific instructions for natural conversation
-    if (_callMode &&
-        _storageService.sttSettings.callSystemPrompt.isNotEmpty) {
+    if (_callMode && _storageService.sttSettings.callSystemPrompt.isNotEmpty) {
       t.systemPrompt +=
           '\n\n[Voice Call Mode] ${_storageService.sttSettings.callSystemPrompt}';
     }
@@ -297,6 +296,25 @@ extension ChatServiceGenerationBlocks on ChatService {
         ? ''
         : buildRecapBlock(recap: _summary);
 
+    // Cued query for journal cold-resurface AND RAG (not last-3 live lines
+    // alone). Guests skip both. Compose even when the Journal toggle is off
+    // so RAG still searches by feeling / fixation / last words.
+    if (t.guestSpeaker == null && _currentSessionId != null) {
+      final speakerId = _getCharacterIdFromCard(t.speakingCharacter);
+      final cards = speakerId.isEmpty
+          ? const <JournalMemoryData>[]
+          : await _journalStore.cardsFor(_currentSessionId!, speakerId);
+      t.journalCoverLines = [for (final c in cards) c.content];
+      t.ragHotJournalLine =
+          JournalPhysics.topHotJournalLine(cards, _characterEmotion) ?? '';
+      t.ragQuery = composeRagQuery(
+        emotion: _characterEmotion,
+        fixation: _relationshipService.activeFixation,
+        hotJournalLine: t.ragHotJournalLine,
+        lastWords: lastWordsFromMessages(_messages),
+      );
+    }
+
     // The Journal — the upcoming speaker's pinned + hot memory cards, with
     // their felt emotions (strictly this chat's cards; guests never
     // journal). Built HERE, before the fixed-content token count below, so
@@ -311,15 +329,10 @@ extension ChatServiceGenerationBlocks on ChatService {
         characterId: _getCharacterIdFromCard(t.speakingCharacter),
         characterName: t.speakingCharacter.name,
         userName: t.userName,
-        // Cold-card resurfacing query — same last-3-messages recipe as RAG
-        // retrieval below (built separately: that one runs after continue
-        // mode pops the tail message, this one before). promptText (not
-        // bare displayText) so photo turns carry their caption marker the
-        // way RAG already does.
-        queryText: _messages.reversed
-            .take(3)
-            .map((m) => '${m.sender}: ${m.promptText}')
-            .join('\n'),
+        // Cued query (emotion + fixation + top hot card + last words),
+        // not the last-3 live lines. promptText still rides lastWords so
+        // photo captions reach cold-resurface the way they reach RAG.
+        queryText: t.ragQuery,
         messageCount: _messages.length,
       );
       t.journalBlock = journal.text;

--- a/lib/services/chat/chat_service_generation_blocks.dart
+++ b/lib/services/chat/chat_service_generation_blocks.dart
@@ -314,7 +314,7 @@ extension ChatServiceGenerationBlocks on ChatService {
         emotion: _characterEmotion,
         fixation: _relationshipService.activeFixation,
         hotJournalLine: t.ragHotJournalLine,
-        lastWords: lastWordsFromMessages(_messages),
+        lastWords: lastSpokenLineFromMessages(_messages),
       );
     }
 

--- a/lib/services/chat/chat_service_generation_blocks.dart
+++ b/lib/services/chat/chat_service_generation_blocks.dart
@@ -336,6 +336,7 @@ extension ChatServiceGenerationBlocks on ChatService {
         // not the last-3 live lines. promptText still rides lastWords so
         // photo captions reach cold-resurface the way they reach RAG.
         queryText: t.ragQuery,
+        lastWords: lastWordsFromMessages(_messages),
         messageCount: _messages.length,
       );
       t.journalBlock = journal.text;

--- a/lib/services/chat/chat_service_generation_rag.dart
+++ b/lib/services/chat/chat_service_generation_rag.dart
@@ -182,8 +182,9 @@ extension ChatServiceGenerationRag on ChatService {
             included.add(m);
           }
           if (included.isNotEmpty) {
-            // Role frame (spec §6): RAG = exact earlier lines, reference
-            // only — the journal outranks it on feelings, the recap on plot.
+            // Role frame: RAG is a remembered-from-earlier fact that left
+            // history, or (quote-reach only) the words they asked for.
+            // Journal gist outranks it on feelings, the recap on plot.
             // Leading '\n' because this now follows the history transcript,
             // whose last line carries no trailing newline.
             String buildBlock(List<RetrievedMemory> mems) =>

--- a/lib/services/chat/chat_service_generation_rag.dart
+++ b/lib/services/chat/chat_service_generation_rag.dart
@@ -60,6 +60,17 @@ extension ChatServiceGenerationRag on ChatService {
           lastWords: lastWordsFromMessages(_messages),
         );
         final queryMessages = t.ragQuery;
+        final reaching = isReachingForQuote(
+          lastSpokenLineFromMessages(_messages),
+        );
+        final skipCueLess = !shouldRetrieveRag(
+          hasCues: ragHasCues(
+            emotion: _characterEmotion,
+            fixation: _relationshipService.activeFixation,
+            hotJournalLine: t.ragHotJournalLine,
+          ),
+          reachingForQuote: reaching,
+        );
 
         // Scene Guests Phase 4: a guest turn retrieves the GUEST's own
         // episodic memories (keyed on the guest id), not the host's. The
@@ -90,15 +101,21 @@ extension ChatServiceGenerationRag on ChatService {
             ? groupRetrievalCount
             : _storageService.memorySettings.ragRetrievalCount;
 
-        final rawMemories = await _memoryService!.retrieve(
-          queryText: queryMessages,
-          sourceCharacterIds: sourceIds,
-          currentSessionId: _currentSessionId ?? '',
-          inContextStart: _history.basePosition + t.droppedMessages,
-          limit: retrievalLimit == 0 ? 9999 : retrievalLimit,
-          characterPriorities: currentGroupRAGPriorities,
-          sessionScopedCharacterIds: sessionScoped,
-        );
+        final List<RetrievedMemory> rawMemories;
+        if (skipCueLess) {
+          debugPrint('[RAG:Chat] Skipping memory retrieval — cue-less beat');
+          rawMemories = const [];
+        } else {
+          rawMemories = await _memoryService!.retrieve(
+            queryText: queryMessages,
+            sourceCharacterIds: sourceIds,
+            currentSessionId: _currentSessionId ?? '',
+            inContextStart: _history.basePosition + t.droppedMessages,
+            limit: retrievalLimit == 0 ? 9999 : retrievalLimit,
+            characterPriorities: currentGroupRAGPriorities,
+            sessionScopedCharacterIds: sessionScoped,
+          );
+        }
         // Two-tier memory dedupe: the journal expanded these exact lines
         // above — never pay for them twice.
         final afterExpand = RetrievedMemory.excludingPositions(
@@ -112,7 +129,6 @@ extension ChatServiceGenerationRag on ChatService {
           afterExpand,
           t.journalCoverLines,
         );
-        final reaching = isReachingForQuote(lastWordsFromMessages(_messages));
         final memories = capRagWindows(uncovered, reachingForQuote: reaching);
         if (memories.length < rawMemories.length) {
           debugPrint(
@@ -124,7 +140,9 @@ extension ChatServiceGenerationRag on ChatService {
         // retrieve() awaits checkAvailability first. Only then is
         // isOperational honest — gating on the flag *before* retrieve
         // skipped a cold engine and stamped a fake empty search.
-        if (rawMemories.isEmpty && !_memoryService!.isOperational) {
+        if (skipCueLess) {
+          // Journal gist can still inject. No last-1 search, no receipt.
+        } else if (rawMemories.isEmpty && !_memoryService!.isOperational) {
           t.ragReceipt = buildRagReceipt(
             found: 0,
             journalDeduped: 0,

--- a/lib/services/chat/chat_service_generation_rag.dart
+++ b/lib/services/chat/chat_service_generation_rag.dart
@@ -36,16 +36,12 @@ extension ChatServiceGenerationRag on ChatService {
         : _storageService.memorySettings.ragEnabled;
 
     if (_isNewChat) {
-      debugPrint(
-        '[RAG:Chat] Skipping memory retrieval - new chat in progress',
-      );
+      debugPrint('[RAG:Chat] Skipping memory retrieval - new chat in progress');
     } else if (t.guestSpeaker != null) {
       // Guest turns answer THIS beat. Guest RAG resurfaces dropped Magus
       // Q&As; a reasoning model treats those as the live question
       // (Discord 2026-08-15: reasoning+RAG = old line; RAG off = latest).
-      debugPrint(
-        '[RAG:Chat] Skipping memory retrieval — Scene Guest turn',
-      );
+      debugPrint('[RAG:Chat] Skipping memory retrieval — Scene Guest turn');
     } else if ((t.droppedMessages > 0 || _history.basePosition > 0) &&
         _memoryService != null &&
         effectiveRagEnabled) {
@@ -54,14 +50,16 @@ extension ChatServiceGenerationRag on ChatService {
         'dropped, base=${_history.basePosition}, triggering retrieval ──',
       );
       try {
-        // Use last 3 messages as the query. promptText, not displayText
-        // (2026-08-10, same fix recentExchange got): only photo turns
-        // differ, and a query blind to "[shared a photo: …]" can't retrieve
-        // the memories a photo-centered exchange is actually about.
-        final queryMessages = _messages.reversed
-            .take(3)
-            .map((m) => '${m.sender}: ${m.promptText}')
-            .join('\n');
+        // Cued query: emotion + fixation + top hot journal line + last
+        // words (photo markers ride lastWords via promptText). Recomposed
+        // here so Continue's plan-phase pop is visible. Not last-3 alone.
+        t.ragQuery = composeRagQuery(
+          emotion: _characterEmotion,
+          fixation: _relationshipService.activeFixation,
+          hotJournalLine: t.ragHotJournalLine,
+          lastWords: lastWordsFromMessages(_messages),
+        );
+        final queryMessages = t.ragQuery;
 
         // Scene Guests Phase 4: a guest turn retrieves the GUEST's own
         // episodic memories (keyed on the guest id), not the host's. The
@@ -81,8 +79,7 @@ extension ChatServiceGenerationRag on ChatService {
         final sessionScoped = <String>{
           if (sourceIds.isNotEmpty) sourceIds.first,
           if (t.guestSpeaker == null && _activeGroup != null)
-            for (final c in _groupCharacters)
-              _getCharacterIdFromCard(c),
+            for (final c in _groupCharacters) _getCharacterIdFromCard(c),
         }..remove('');
 
         // Retrieval limit: groups use the per-session group setting; 1:1
@@ -104,15 +101,23 @@ extension ChatServiceGenerationRag on ChatService {
         );
         // Two-tier memory dedupe: the journal expanded these exact lines
         // above — never pay for them twice.
-        final memories = RetrievedMemory.excludingPositions(
+        final afterExpand = RetrievedMemory.excludingPositions(
           rawMemories,
           t.expandedJournalPositions,
           currentSessionId: _currentSessionId ?? '',
         );
+        // Journal gist already covers this beat — drop extra RAG windows.
+        // Facts that left history and have no card still pass (remember).
+        final uncovered = dropCoveredRagWindows(
+          afterExpand,
+          t.journalCoverLines,
+        );
+        final reaching = isReachingForQuote(lastWordsFromMessages(_messages));
+        final memories = capRagWindows(uncovered, reachingForQuote: reaching);
         if (memories.length < rawMemories.length) {
           debugPrint(
-            '[RAG:Chat] Deduped ${rawMemories.length - memories.length} '
-            'retrieval(s) already expanded by the journal',
+            '[RAG:Chat] Dropped ${rawMemories.length - memories.length} '
+            'retrieval(s) already expanded or covered by the journal',
           );
         }
 
@@ -167,8 +172,7 @@ extension ChatServiceGenerationRag on ChatService {
           int usedTokens = 0;
           for (final m in memories) {
             final memTokens = (lineFor(m).length / 4).ceil();
-            if (usedTokens + memTokens > memoryBudget &&
-                included.isNotEmpty) {
+            if (usedTokens + memTokens > memoryBudget && included.isNotEmpty) {
               debugPrint(
                 '[RAG:Chat] ⚠ Trimmed ${memories.length - included.length} memories to fit budget ($memoryBudget tokens)',
               );
@@ -183,9 +187,12 @@ extension ChatServiceGenerationRag on ChatService {
             // Leading '\n' because this now follows the history transcript,
             // whose last line carries no trailing newline.
             String buildBlock(List<RetrievedMemory> mems) =>
-                '\n[Exact earlier lines from this chat, in story order '
-                '(already happened — reference only, do not revisit):\n'
-                '${chronologicalRagOrder(mems, sessionForStamps).map(lineFor).join('\n')}]\n';
+                buildRagMemoriesBlock(
+                  memories: mems,
+                  currentSessionId: sessionForStamps,
+                  days: days,
+                  reachingForQuote: reaching,
+                );
             t.memoriesBlock = buildBlock(included);
 
             // Budget accounting fix (spec §5f): memories were previously
@@ -250,8 +257,8 @@ extension ChatServiceGenerationRag on ChatService {
           // what shipped, not what was hoped for.
           t.ragReceipt = buildRagReceipt(
             found: rawMemories.length,
-            journalDeduped: rawMemories.length - memories.length,
-            budgetTrimmed: memories.length - included.length,
+            journalDeduped: rawMemories.length - uncovered.length,
+            budgetTrimmed: uncovered.length - included.length,
             injected: chronologicalRagOrder(included, sessionForStamps),
             days: days,
             currentSessionId: sessionForStamps,

--- a/lib/services/chat/chat_service_message_ops.dart
+++ b/lib/services/chat/chat_service_message_ops.dart
@@ -462,7 +462,7 @@ extension ChatServiceMessageOps on ChatService {
   /// was BEFORE the rewrite, and [MemoryService]'s dedupe is purely positional
   /// — a window whose range already exists is skipped forever — so the
   /// discarded/edited reply stayed retrievable and got injected 20+ turns
-  /// later under "Exact earlier lines from this chat … already happened". And
+  /// later as a remembered-from-earlier line. And
   /// after a DELETE every later window's (start,end) addresses different
   /// messages, which mis-stamps story days and mis-aligns the journal de-dupe.
   /// Removing the rows is what lets `_maybeEmbedMessages` rebuild them from

--- a/lib/services/chat/journal_physics.dart
+++ b/lib/services/chat/journal_physics.dart
@@ -228,4 +228,27 @@ class JournalPhysics {
     }
     return false;
   }
+
+  /// The hottest card's content for the cued RAG / cold-resurface query.
+  /// Null when the diary has no hot set — the query then falls back to
+  /// emotion, fixation, and last words. Does not write cards.
+  static String? topHotJournalLine(
+    List<JournalMemoryData> cards,
+    String currentEmotion,
+  ) {
+    JournalMemoryData? best;
+    var bestKey = double.negativeInfinity;
+    for (final c in cards) {
+      if (!isHot(c)) continue;
+      final key = hotSortKey(c, currentEmotion);
+      if (best == null ||
+          key > bestKey ||
+          (key == bestKey && c.createdAt.isAfter(best.createdAt))) {
+        best = c;
+        bestKey = key;
+      }
+    }
+    final text = best?.content.trim() ?? '';
+    return text.isEmpty ? null : text;
+  }
 }

--- a/lib/services/chat/prompt_injection/journal_injection.dart
+++ b/lib/services/chat/prompt_injection/journal_injection.dart
@@ -84,6 +84,9 @@ class JournalInjection {
   /// [queryText] is the cued query used to resurface cold cards
   /// semantically (same composeRagQuery as RAG retrieval); empty
   /// skips cold retrieval entirely.
+  /// [lastWords] is the live beat (same string RAG uses). Expand
+  /// gates on this — never on [queryText], which can contain a diary
+  /// "I remember when…" that is not an ask.
   Future<
     ({String text, Set<int> expandedPositions, List<String> injectedContents})
   >
@@ -92,6 +95,7 @@ class JournalInjection {
     required String characterName,
     required String userName,
     String queryText = '',
+    String lastWords = '',
     int messageCount = 0,
   }) async {
     const empty = (
@@ -186,7 +190,7 @@ class JournalInjection {
     // embeddings, cosine ≥ 0.45, and receipts old enough to be out of the
     // visible transcript. A plain sit-down stays gist — the cued query
     // contains the top hot line, so cosine alone would always expand it.
-    final (excerpt, expandedPositions) = isReachingForQuote(queryText)
+    final (excerpt, expandedPositions) = isReachingForQuote(lastWords)
         ? _expandBestCard(injected, queryVector, messageCount)
         : ('', <int>{});
 

--- a/lib/services/chat/prompt_injection/journal_injection.dart
+++ b/lib/services/chat/prompt_injection/journal_injection.dart
@@ -84,14 +84,21 @@ class JournalInjection {
   /// [queryText] is the cued query used to resurface cold cards
   /// semantically (same composeRagQuery as RAG retrieval); empty
   /// skips cold retrieval entirely.
-  Future<({String text, Set<int> expandedPositions})> buildJournalBlock({
+  Future<
+    ({String text, Set<int> expandedPositions, List<String> injectedContents})
+  >
+  buildJournalBlock({
     required String characterId,
     required String characterName,
     required String userName,
     String queryText = '',
     int messageCount = 0,
   }) async {
-    const empty = (text: '', expandedPositions: <int>{});
+    const empty = (
+      text: '',
+      expandedPositions: <int>{},
+      injectedContents: <String>[],
+    );
     final sessionId = getSessionId();
     if (sessionId == null || characterId.isEmpty) return empty;
 
@@ -159,6 +166,7 @@ class JournalInjection {
     // cosine ones.
     final injected = [...pinned, ...hot, ...lexical, ...resurfaced];
     final lines = <String>[];
+    final injectedContents = <String>[];
     var usedChars = 0;
     const budgetChars = kHotSetTokenBudget * 4;
     for (final card in injected) {
@@ -167,20 +175,20 @@ class JournalInjection {
       if (usedChars + line.length > budgetChars && lines.isNotEmpty) break;
       usedChars += line.length;
       lines.add(line);
+      injectedContents.add(card.content);
     }
     if (lines.isEmpty) return empty;
 
     // Expand-memory (two-tier memory, living-time-features.md §8): when the
     // conversation clearly reaches for ONE remembered moment ("remember our
     // wedding vows?"), the card supplies the feeling and its receipts supply
-    // the exact words. Strictly gated: needs embeddings (same floor as cold
-    // resurfacing), a similarity above the expand threshold, and receipts
-    // old enough to be out of the visible transcript.
-    final (excerpt, expandedPositions) = _expandBestCard(
-      injected,
-      queryVector,
-      messageCount,
-    );
+    // the exact words. Strictly gated: quote-reach (isReachingForQuote),
+    // embeddings, cosine ≥ 0.45, and receipts old enough to be out of the
+    // visible transcript. A plain sit-down stays gist — the cued query
+    // contains the top hot line, so cosine alone would always expand it.
+    final (excerpt, expandedPositions) = isReachingForQuote(queryText)
+        ? _expandBestCard(injected, queryVector, messageCount)
+        : ('', <int>{});
 
     // Role frame (docs/design/prompt-state-injection.md §6): the journal is
     // the FEELINGS channel — when a card covers the same moment as the recap
@@ -227,7 +235,11 @@ class JournalInjection {
         '$userName — the feelings here are the truer guide:\n'
         '${lines.join('\n')}'
         '$excerpt\n]\n';
-    return (text: text, expandedPositions: expandedPositions);
+    return (
+      text: text,
+      expandedPositions: expandedPositions,
+      injectedContents: injectedContents,
+    );
   }
 
   /// Top-1 card the query is reaching for, expanded into trimmed verbatim

--- a/lib/services/chat/prompt_injection/journal_injection.dart
+++ b/lib/services/chat/prompt_injection/journal_injection.dart
@@ -81,8 +81,8 @@ class JournalInjection {
   /// memoriesBlock budget uses).
   static const int kHotSetTokenBudget = 600;
 
-  /// [queryText] is the recent-turn text used to resurface cold cards
-  /// semantically (same last-3-messages recipe as RAG retrieval); empty
+  /// [queryText] is the cued query used to resurface cold cards
+  /// semantically (same composeRagQuery as RAG retrieval); empty
   /// skips cold retrieval entirely.
   Future<({String text, Set<int> expandedPositions})> buildJournalBlock({
     required String characterId,

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -171,6 +171,14 @@ String lastWordsFromMessages(List<ChatMessage> messages) {
   return parts.join('\n');
 }
 
+/// Last spoken line only. Photo captions stay in [lastWordsFromMessages]
+/// for the retrieval query — they must not trip quote-ask.
+String lastSpokenLineFromMessages(List<ChatMessage> messages) {
+  if (messages.isEmpty) return '';
+  final last = messages.last;
+  return '${last.sender}: ${last.promptText}';
+}
+
 /// True only when they ASKED for the words — remember what you
 /// said/promised, what did I say/promise, exact words, can you quote,
 /// vows as a question. "Remember to lock the door?" and "Remember the
@@ -275,6 +283,14 @@ const _kCoverFiller = {
   'why',
   'our',
   'its',
+  'tonight',
+  'today',
+  'night',
+  'morning',
+  'evening',
+  'afternoon',
+  'yesterday',
+  'tomorrow',
 };
 
 Set<String> coverContentTokens(String s) =>
@@ -327,8 +343,48 @@ const String kRagQuoteHeader =
     '[Words they are reaching for, from earlier (already happened — '
     'quote only if asked):\n';
 
+/// Emotion, fixation, or a hot journal line — not last words alone.
+bool ragHasCues({
+  String emotion = '',
+  String fixation = '',
+  String hotJournalLine = '',
+}) =>
+    emotion.trim().isNotEmpty ||
+    fixation.trim().isNotEmpty ||
+    hotJournalLine.trim().isNotEmpty;
+
+/// Cue-less sit-down must not last-1 search. Quote-reach still retrieves.
+bool shouldRetrieveRag({
+  required bool hasCues,
+  required bool reachingForQuote,
+}) => hasCues || reachingForQuote;
+
+/// Plain turn: one short remembered line, not the multi-line transcript
+/// window. A single line is already short and stays as-is. Quote-reach
+/// uses the raw window via [buildRagMemoriesBlock].
+String rememberedLineFromWindow(String content) {
+  final lines = [
+    for (final raw in content.split('\n'))
+      if (raw.trim().isNotEmpty) raw.trim(),
+  ];
+  if (lines.isEmpty) return content.trim();
+  if (lines.length == 1) return lines.first;
+  String body(String line) {
+    final m = RegExp(r'^[^:\n]{1,40}:\s+(.*)').firstMatch(line);
+    return (m != null ? m.group(1)! : line).trim();
+  }
+
+  final bodies = [for (final l in lines) body(l)].where((b) => b.isNotEmpty);
+  return bodies.reduce(
+    (a, b) =>
+        coverContentTokens(b).length > coverContentTokens(a).length ? b : a,
+  );
+}
+
 /// Build the memories block. Day stamps stay display-only; packing order
 /// is the caller's (score-descending). Display order is chronological.
+/// Plain turn renders [rememberedLineFromWindow]; quote-reach keeps the
+/// raw window.
 String buildRagMemoriesBlock({
   required List<RetrievedMemory> memories,
   required String currentSessionId,
@@ -337,7 +393,7 @@ String buildRagMemoriesBlock({
 }) {
   if (memories.isEmpty) return '';
   String lineFor(RetrievedMemory m) => formatRagLine(
-    m.content,
+    reachingForQuote ? m.content : rememberedLineFromWindow(m.content),
     day: days[m],
     otherChat: m.sessionId != currentSessionId,
   );

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -293,8 +293,24 @@ const _kCoverFiller = {
   'tomorrow',
 };
 
+/// Place compounds count as ONE token so {front, porch} is not cover.
+const _kPlaceCompounds = [
+  'front porch',
+  'back porch',
+  'front yard',
+  'back yard',
+];
+
+String _foldPlaceCompounds(String s) {
+  var out = s.toLowerCase();
+  for (final phrase in _kPlaceCompounds) {
+    out = out.replaceAll(phrase, phrase.replaceAll(' ', ''));
+  }
+  return out;
+}
+
 Set<String> coverContentTokens(String s) =>
-    itemNameTokens(s).difference(_kCoverFiller);
+    itemNameTokens(_foldPlaceCompounds(s)).difference(_kCoverFiller);
 
 /// Drop RAG windows a THIS-BEAT injected journal gist already covers
 /// (shared content tokens ≥ 2). One shared place/noun (porch, spare) is
@@ -368,13 +384,17 @@ String rememberedLineFromWindow(String content) {
       if (raw.trim().isNotEmpty) raw.trim(),
   ];
   if (lines.isEmpty) return content.trim();
-  if (lines.length == 1) return lines.first;
   String body(String line) {
     final m = RegExp(r'^[^:\n]{1,40}:\s+(.*)').firstMatch(line);
     return (m != null ? m.group(1)! : line).trim();
   }
 
+  if (lines.length == 1) {
+    final one = body(lines.first);
+    return one.isEmpty ? lines.first : one;
+  }
   final bodies = [for (final l in lines) body(l)].where((b) => b.isNotEmpty);
+  if (bodies.isEmpty) return lines.first;
   return bodies.reduce(
     (a, b) =>
         coverContentTokens(b).length > coverContentTokens(a).length ? b : a,

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -291,13 +291,36 @@ const _kCoverFiller = {
   'afternoon',
   'yesterday',
   'tomorrow',
+  'porch',
+  'yard',
+  'lawn',
+  'deck',
+  'stoop',
+  'steps',
+  'patio',
+  'walk',
+  'path',
+  'my',
+  'your',
+  'on',
 };
 
 /// Any token immediately before a place noun is ONE token
-/// (screened porch, wraparound deck) so {screened, porch} is not cover.
-/// Articles stay articles — "the porch" does not become theporch.
-final _kPlaceNounCompound = RegExp(r'\b(\w+)\s+(porch|yard|lawn|deck|stoop)\b');
-const _kNoFoldBeforePlace = {'the', 'a', 'an'};
+/// (screened porch, wraparound deck). Particles stay particles.
+/// Setting nouns are cover filler, so front steps is not a new list.
+final _kPlaceNounCompound = RegExp(
+  r'\b(\w+)\s+(porch|yard|lawn|deck|stoop)\b',
+);
+const _kNoFoldBeforePlace = {
+  'the',
+  'a',
+  'an',
+  'this',
+  'my',
+  'our',
+  'your',
+  'on',
+};
 
 String _foldPlaceCompounds(String s) =>
     s.toLowerCase().replaceAllMapped(_kPlaceNounCompound, (m) {
@@ -310,8 +333,8 @@ Set<String> coverContentTokens(String s) =>
     itemNameTokens(_foldPlaceCompounds(s)).difference(_kCoverFiller);
 
 /// Drop RAG windows a THIS-BEAT injected journal gist already covers
-/// (shared content tokens ≥ 2). One shared place/noun (porch, spare) is
-/// not cover. Empty [journalCardContents] means Journal is off or no
+/// (shared content tokens ≥ 2). Setting nouns and this/my/our/your/on
+/// are filler, like tonight. Empty [journalCardContents] means Journal is off or no
 /// gist injected — do not cover-drop. Not uniqueness-by-shape.
 List<RetrievedMemory> dropCoveredRagWindows(
   List<RetrievedMemory> memories,

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -171,10 +171,11 @@ String lastWordsFromMessages(List<ChatMessage> messages) {
   return parts.join('\n');
 }
 
-/// True only when they ASKED for the words — "remember what you said",
-/// "what did I promise", "exact words", "vows?" as a question.
-/// Spoken report ("I told you the tomatoes came in", "she said the
-/// cicadas") is not quote-reach and must not dump every RAG window.
+/// True only when they ASKED for the words — remember what you
+/// said/promised, what did I say/promise, exact words, can you quote,
+/// vows as a question. "Remember to lock the door?" and "Remember the
+/// tomatoes came in?" are reminders, not quote-reach. Spoken
+/// said/told/promised is not an ask.
 bool isReachingForQuote(String lastWords) {
   final t = lastWords.toLowerCase();
   if (t.trim().isEmpty) return false;
@@ -191,15 +192,24 @@ bool isReachingForQuote(String lastWords) {
   ).hasMatch(t)) {
     return true;
   }
-  if (RegExp(r'\bremember\b').hasMatch(t)) {
-    if (t.contains('?')) return true;
-    if (RegExp(
-      r'\bremember (what|when|where|how|who|the|our|my|your|that)\b',
-    ).hasMatch(t)) {
-      return true;
-    }
+  if (RegExp(r'\b((can you )?quote|quoted)\b').hasMatch(t)) {
+    return true;
   }
-  if (RegExp(r'\bvows\b').hasMatch(t) && t.contains('?')) return true;
+  if (RegExp(r'\bvows\b').hasMatch(t) && t.contains('?')) {
+    return true;
+  }
+  if (RegExp(
+    r'\bremember what (you|i|we|they|she|he) (said|told|promised)\b',
+  ).hasMatch(t)) {
+    return true;
+  }
+  // Recall-ask: remember where/how/who. Not "remember to" / "remember the".
+  if (RegExp(r'\bremember (where|how|who)\b').hasMatch(t)) {
+    return true;
+  }
+  if (RegExp(r'\bremember (our|my|your)\b').hasMatch(t) && t.contains('?')) {
+    return true;
+  }
   return false;
 }
 
@@ -271,17 +281,16 @@ Set<String> coverContentTokens(String s) =>
     itemNameTokens(s).difference(_kCoverFiller);
 
 /// Drop RAG windows a THIS-BEAT injected journal gist already covers
-/// (any shared content token: lighthouse, flowerpot). Empty
-/// [journalCardContents] means Journal is off or no gist injected — do
-/// not cover-drop. Position-overlap with expanded receipts is
-/// [RetrievedMemory.excludingPositions]. Not uniqueness-by-shape.
+/// (shared content tokens ≥ 2). One shared place/noun (porch, spare) is
+/// not cover. Empty [journalCardContents] means Journal is off or no
+/// gist injected — do not cover-drop. Not uniqueness-by-shape.
 List<RetrievedMemory> dropCoveredRagWindows(
   List<RetrievedMemory> memories,
   Iterable<String> journalCardContents,
 ) {
   final cardTokenSets = [
     for (final c in journalCardContents) coverContentTokens(c),
-  ].where((s) => s.isNotEmpty).toList();
+  ].where((s) => s.length >= 2).toList();
   if (cardTokenSets.isEmpty) return memories;
   return [
     for (final m in memories)
@@ -291,9 +300,9 @@ List<RetrievedMemory> dropCoveredRagWindows(
 
 bool _ragCoveredByJournal(String ragContent, List<Set<String>> cardTokenSets) {
   final rag = coverContentTokens(ragContent);
-  if (rag.isEmpty) return false;
+  if (rag.length < 2) return false;
   for (final card in cardTokenSets) {
-    if (rag.intersection(card).isNotEmpty) return true;
+    if (rag.intersection(card).length >= 2) return true;
   }
   return false;
 }

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -221,36 +221,114 @@ bool isReachingForQuote(String lastWords) {
   return false;
 }
 
-/// Narrative filler that [itemNameTokens] still keeps (≥3 chars). Cover
-/// overlap must be content (flowerpot / lighthouse), not still/think/about.
+/// Closed English function words (articles, possessives, prepositions,
+/// pronouns). Not grown one word at a time.
+const _kFunctionWords = {
+  'a',
+  'an',
+  'the',
+  'my',
+  'our',
+  'your',
+  'his',
+  'her',
+  'its',
+  'their',
+  'i',
+  'me',
+  'we',
+  'us',
+  'you',
+  'he',
+  'she',
+  'him',
+  'they',
+  'them',
+  'it',
+  'this',
+  'that',
+  'these',
+  'those',
+  'who',
+  'whom',
+  'what',
+  'which',
+  'on',
+  'in',
+  'at',
+  'off',
+  'to',
+  'from',
+  'of',
+  'for',
+  'with',
+  'by',
+  'as',
+  'into',
+  'onto',
+  'over',
+  'under',
+  'about',
+  'up',
+  'down',
+  'out',
+  'around',
+  'through',
+  'between',
+  'among',
+  'against',
+  'without',
+  'within',
+  'before',
+  'after',
+  'during',
+  'since',
+  'until',
+  'above',
+  'below',
+  'across',
+  'along',
+  'behind',
+  'beside',
+  'near',
+  'toward',
+  'towards',
+  'upon',
+  'and',
+  'but',
+  'or',
+  'nor',
+};
+
+const _kTimeFiller = {
+  'tonight',
+  'today',
+  'night',
+  'morning',
+  'evening',
+  'afternoon',
+  'yesterday',
+  'tomorrow',
+};
+
+/// Narrative leftover that [itemNameTokens] still keeps (≥3 chars).
 const _kCoverFiller = {
   'still',
   'think',
-  'about',
   'just',
   'like',
   'very',
   'really',
   'then',
   'when',
-  'what',
-  'this',
-  'that',
-  'with',
-  'from',
   'have',
   'been',
   'were',
-  'they',
-  'them',
-  'their',
   'there',
   'here',
   'some',
   'more',
   'than',
-  'into',
-  'over',
   'also',
   'only',
   'even',
@@ -265,32 +343,10 @@ const _kCoverFiller = {
   'does',
   'dont',
   'not',
-  'but',
-  'and',
-  'for',
-  'the',
-  'you',
-  'she',
-  'him',
-  'her',
-  'his',
   'was',
   'are',
   'had',
   'has',
-  'who',
-  'how',
-  'why',
-  'our',
-  'its',
-  'tonight',
-  'today',
-  'night',
-  'morning',
-  'evening',
-  'afternoon',
-  'yesterday',
-  'tomorrow',
   'porch',
   'yard',
   'lawn',
@@ -300,61 +356,73 @@ const _kCoverFiller = {
   'patio',
   'walk',
   'path',
-  'my',
-  'your',
-  'on',
+  ..._kFunctionWords,
+  ..._kTimeFiller,
 };
 
 /// Any token immediately before a place noun is ONE token
-/// (screened porch, wraparound deck). Particles stay particles.
-/// Setting nouns are cover filler, so front steps is not a new list.
-final _kPlaceNounCompound = RegExp(
-  r'\b(\w+)\s+(porch|yard|lawn|deck|stoop)\b',
-);
-const _kNoFoldBeforePlace = {
-  'the',
-  'a',
-  'an',
-  'this',
-  'my',
-  'our',
-  'your',
-  'on',
-};
+/// (screened porch, wraparound deck). Function words stay function words.
+final _kPlaceNounCompound = RegExp(r'\b(\w+)\s+(porch|yard|lawn|deck|stoop)\b');
+final _kSpeakerPrefix = RegExp(r'^[^:\n]{1,40}:\s*');
+final _kNonWord = RegExp(r'[^a-z0-9\s]+');
+final _kSpaces = RegExp(r'\s+');
 
 String _foldPlaceCompounds(String s) =>
     s.toLowerCase().replaceAllMapped(_kPlaceNounCompound, (m) {
       final prep = m[1]!;
-      if (_kNoFoldBeforePlace.contains(prep)) return m[0]!;
+      if (_kFunctionWords.contains(prep)) return m[0]!;
       return '$prep${m[2]}';
     });
 
 Set<String> coverContentTokens(String s) =>
     itemNameTokens(_foldPlaceCompounds(s)).difference(_kCoverFiller);
 
-/// Drop RAG windows a THIS-BEAT injected journal gist already covers
-/// (shared content tokens ≥ 2). Setting nouns and this/my/our/your/on
-/// are filler, like tonight. Empty [journalCardContents] means Journal is off or no
-/// gist injected — do not cover-drop. Not uniqueness-by-shape.
+String _normalizeCoverLine(String s) {
+  var t = s.toLowerCase().replaceFirst(_kSpeakerPrefix, '');
+  t = t.replaceAll(_kNonWord, ' ');
+  final kept = <String>[
+    for (final w in t.split(_kSpaces))
+      if (w.isNotEmpty &&
+          !_kFunctionWords.contains(w) &&
+          !_kTimeFiller.contains(w))
+        w,
+  ];
+  return kept.join(' ');
+}
+
+bool _nearCover(String card, String window) {
+  final a = _normalizeCoverLine(card);
+  final b = _normalizeCoverLine(window);
+  if (a.isEmpty || b.isEmpty) return false;
+  final shorter = a.length <= b.length ? a : b;
+  final longer = a.length <= b.length ? b : a;
+  if (shorter.split(' ').length < 2) return false;
+  return longer.contains(shorter);
+}
+
+/// Drop RAG windows a THIS-BEAT injected journal gist already covers.
+/// Receipt/position overlap is excludingPositions at the call site.
+/// Content cover is a near-substring of the normalized card and window,
+/// not leftover 2-token overlap. Empty [journalCardContents] means
+/// Journal is off or no gist injected — do not cover-drop.
 List<RetrievedMemory> dropCoveredRagWindows(
   List<RetrievedMemory> memories,
   Iterable<String> journalCardContents,
 ) {
-  final cardTokenSets = [
-    for (final c in journalCardContents) coverContentTokens(c),
-  ].where((s) => s.length >= 2).toList();
-  if (cardTokenSets.isEmpty) return memories;
+  final cards = [
+    for (final c in journalCardContents)
+      if (c.trim().isNotEmpty) c,
+  ];
+  if (cards.isEmpty) return memories;
   return [
     for (final m in memories)
-      if (!_ragCoveredByJournal(m.content, cardTokenSets)) m,
+      if (!_ragCoveredByJournal(m.content, cards)) m,
   ];
 }
 
-bool _ragCoveredByJournal(String ragContent, List<Set<String>> cardTokenSets) {
-  final rag = coverContentTokens(ragContent);
-  if (rag.length < 2) return false;
-  for (final card in cardTokenSets) {
-    if (rag.intersection(card).length >= 2) return true;
+bool _ragCoveredByJournal(String ragContent, List<String> cards) {
+  for (final card in cards) {
+    if (_nearCover(card, ragContent)) return true;
   }
   return false;
 }

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -402,6 +402,9 @@ const _kJournalBoilerplate = {
   'remember',
 };
 
+/// Same-beat restatement. Not an extra fact. One closed set.
+const _kCoverParaphrase = {'lives', 'hidden', 'creaked'};
+
 bool _isDistinctive(String w) =>
     w.length >= 5 && !_kJournalBoilerplate.contains(w);
 
@@ -425,13 +428,17 @@ bool _lineCovers(List<String> a, List<String> b) {
     for (final w in longer)
       if (_isDistinctive(w)) w,
   };
-  final leftover = longer.toSet().difference(shorter.toSet());
+  final leftover = {
+    for (final w in longer.toSet().difference(shorter.toSet()))
+      if (!_kCoverParaphrase.contains(w)) w,
+  };
   final distinctiveLeftover = longD.difference(shortD);
   if (leftover.isEmpty && distinctiveLeftover.isEmpty) return true;
-  // One leftover word on a complete gist is same-beat paraphrase
-  // (that creaked, lives). Two leftover words are an extra fact
-  // (swing creaked). key is not keyboard. A stem does not cover died.
-  return leftover.length == 1 && shortD.length >= 3;
+  // Paraphrase leftovers (lives / hidden / creaked) do not count.
+  // Short leftover on a complete gist is still the same beat (sat).
+  // Distinctive leftover is an extra fact (burned, lighthouse, swing).
+  if (leftover.isEmpty) return true;
+  return leftover.every((w) => !_isDistinctive(w)) && shortD.length >= 3;
 }
 
 bool _nearCover(String card, String window) {
@@ -471,41 +478,59 @@ List<RetrievedMemory> dropCoveredRagWindows(
       if (c.trim().isNotEmpty) c,
   ];
   if (cards.isEmpty) return memories;
-  return [
-    for (final m in memories)
-      if (_uncoveredMemory(m, cards) case final kept?) kept,
-  ];
+  return [for (final m in memories) ..._uncoveredMemory(m, cards)];
 }
 
-RetrievedMemory? _uncoveredMemory(RetrievedMemory m, List<String> cards) {
+(int, int) _lineSpan(int start, int end, int n, int i) {
+  final span = end - start + 1;
+  if (n <= 0 || span <= 0) return (start, end);
+  final a = start + (i * span) ~/ n;
+  final b = start + ((i + 1) * span) ~/ n - 1;
+  return (a, a > b ? a : b);
+}
+
+List<RetrievedMemory> _uncoveredMemory(RetrievedMemory m, List<String> cards) {
   final lines = [
     for (final raw in m.content.split('\n'))
       if (raw.trim().isNotEmpty) raw,
   ];
-  if (lines.isEmpty) return m;
+  if (lines.isEmpty) return [m];
   final keptIdx = [
     for (var i = 0; i < lines.length; i++)
       if (!_lineCoveredByCards(lines[i], cards)) i,
   ];
-  if (keptIdx.isEmpty) return null;
+  if (keptIdx.isEmpty) return const [];
   if (keptIdx.length == lines.length) {
-    if (_ragCoveredByJournal(m.content, cards)) return null;
-    return m;
+    if (_ragCoveredByJournal(m.content, cards)) return const [];
+    return [m];
   }
-  var start = m.positionStart;
-  var end = m.positionEnd;
-  if (end - start + 1 == lines.length) {
-    start = m.positionStart + keptIdx.first;
-    end = m.positionStart + keptIdx.last;
+  final runs = <List<int>>[
+    [keptIdx.first],
+  ];
+  for (var i = 1; i < keptIdx.length; i++) {
+    if (keptIdx[i] == runs.last.last + 1) {
+      runs.last.add(keptIdx[i]);
+    } else {
+      runs.add([keptIdx[i]]);
+    }
   }
-  return RetrievedMemory(
-    content: [for (final i in keptIdx) lines[i]].join('\n'),
-    characterId: m.characterId,
-    sessionId: m.sessionId,
-    positionStart: start,
-    positionEnd: end,
-    score: m.score,
-  );
+  final n = lines.length;
+  return [
+    for (final run in runs)
+      RetrievedMemory(
+        content: [for (final i in run) lines[i]].join('\n'),
+        characterId: m.characterId,
+        sessionId: m.sessionId,
+        positionStart: _lineSpan(
+          m.positionStart,
+          m.positionEnd,
+          n,
+          run.first,
+        ).$1,
+        positionEnd: _lineSpan(m.positionStart, m.positionEnd, n, run.last).$2,
+        score: m.score,
+      ),
+  ];
 }
 
 bool _ragCoveredByJournal(String ragContent, List<String> cards) {

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -410,20 +410,45 @@ List<String> _coverWords(String s) {
   return line.split(' ');
 }
 
-bool _nearCover(String card, String window) {
-  final a = _coverWords(card);
-  final b = _coverWords(window);
+bool _lineCovers(List<String> a, List<String> b) {
   if (a.isEmpty || b.isEmpty) return false;
   final shorter = a.length <= b.length ? a : b;
   final longer = a.length <= b.length ? b : a;
   if (!shorter.any(_isDistinctive)) return false;
-  return longer.toSet().containsAll(shorter);
+  if (!longer.toSet().containsAll(shorter)) return false;
+  final shortD = {
+    for (final w in shorter)
+      if (_isDistinctive(w)) w,
+  };
+  final longD = {
+    for (final w in longer)
+      if (_isDistinctive(w)) w,
+  };
+  return longD.difference(shortD).isEmpty;
+}
+
+bool _nearCover(String card, String window) {
+  final cardLines = [
+    for (final raw in card.split('\n'))
+      if (raw.trim().isNotEmpty) _coverWords(raw),
+  ];
+  final winLines = [
+    for (final raw in window.split('\n'))
+      if (raw.trim().isNotEmpty) _coverWords(raw),
+  ];
+  for (final c in cardLines) {
+    for (final w in winLines) {
+      if (_lineCovers(c, w)) return true;
+    }
+  }
+  return false;
 }
 
 /// Drop RAG windows a THIS-BEAT injected journal gist already covers.
 /// Receipt/position overlap is excludingPositions at the call site.
-/// Content cover is whole-token subset plus a distinctive word
-/// (length ≥ 5, not journal boilerplate). key is not inside keyboard.
+/// Content cover is whole-token subset, a distinctive word on the
+/// shorter side, and no extra distinctive leftover on the longer.
+/// A prefix card does not cover a bigger fact. key is not keyboard.
 /// Empty [journalCardContents] means Journal is off or no gist.
 List<RetrievedMemory> dropCoveredRagWindows(
   List<RetrievedMemory> memories,

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -380,6 +380,7 @@ Set<String> coverContentTokens(String s) =>
 String _normalizeCoverLine(String s) {
   var t = s.toLowerCase().replaceFirst(_kSpeakerPrefix, '');
   t = t.replaceAll(_kNonWord, ' ');
+  t = _foldPlaceCompounds(t);
   final kept = <String>[
     for (final w in t.split(_kSpaces))
       if (w.isNotEmpty &&
@@ -402,9 +403,6 @@ const _kJournalBoilerplate = {
   'remember',
 };
 
-/// Same-beat restatement. Not an extra fact. One closed set.
-const _kCoverParaphrase = {'lives', 'hidden', 'creaked'};
-
 bool _isDistinctive(String w) =>
     w.length >= 5 && !_kJournalBoilerplate.contains(w);
 
@@ -412,6 +410,46 @@ List<String> _coverWords(String s) {
   final line = _normalizeCoverLine(s);
   if (line.isEmpty) return const [];
   return line.split(' ');
+}
+
+/// Tightest span in [longer] that contains every token of [shorter].
+(int, int)? _minCoverWindow(List<String> longer, List<String> shorter) {
+  final need = <String, int>{};
+  for (final w in shorter) {
+    need[w] = (need[w] ?? 0) + 1;
+  }
+  var missing = shorter.length;
+  final got = <String, int>{};
+  var bestL = 0;
+  var bestR = longer.length;
+  var found = false;
+  var l = 0;
+  for (var r = 0; r < longer.length; r++) {
+    final w = longer[r];
+    final n = need[w];
+    if (n != null) {
+      final g = (got[w] ?? 0) + 1;
+      got[w] = g;
+      if (g <= n) missing--;
+    }
+    while (missing == 0 && l <= r) {
+      found = true;
+      if (r - l < bestR - bestL) {
+        bestL = l;
+        bestR = r;
+      }
+      final u = longer[l];
+      final nu = need[u];
+      if (nu != null) {
+        final g = got[u]!;
+        if (g <= nu) missing++;
+        got[u] = g - 1;
+      }
+      l++;
+    }
+  }
+  if (!found) return null;
+  return (bestL, bestR);
 }
 
 bool _lineCovers(List<String> a, List<String> b) {
@@ -428,17 +466,19 @@ bool _lineCovers(List<String> a, List<String> b) {
     for (final w in longer)
       if (_isDistinctive(w)) w,
   };
-  final leftover = {
-    for (final w in longer.toSet().difference(shorter.toSet()))
-      if (!_kCoverParaphrase.contains(w)) w,
-  };
+  final leftover = longer.toSet().difference(shorter.toSet());
   final distinctiveLeftover = longD.difference(shortD);
   if (leftover.isEmpty && distinctiveLeftover.isEmpty) return true;
-  // Paraphrase leftovers (lives / hidden / creaked) do not count.
-  // Short leftover on a complete gist is still the same beat (sat).
-  // Distinctive leftover is an extra fact (burned, lighthouse, swing).
   if (leftover.isEmpty) return true;
-  return leftover.every((w) => !_isDistinctive(w)) && shortD.length >= 3;
+  final span = _minCoverWindow(longer, shorter);
+  if (span == null) return false;
+  // Suffix leftover is an extra fact (burned, creaked, died, sat).
+  if (longer.sublist(span.$2 + 1).isNotEmpty) return false;
+  // Distinctive prefix leftover is an extra fact (lighthouse … gist).
+  if (longer.sublist(0, span.$1).any(_isDistinctive)) return false;
+  // Interior leftover is same-beat restatement (lives / tucked / buried).
+  // Short prefix leftover is the same beat (I sat on porch).
+  return true;
 }
 
 bool _nearCover(String card, String window) {

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -384,7 +384,8 @@ String _normalizeCoverLine(String s) {
     for (final w in t.split(_kSpaces))
       if (w.isNotEmpty &&
           !_kFunctionWords.contains(w) &&
-          !_kTimeFiller.contains(w))
+          !_kTimeFiller.contains(w) &&
+          !_kJournalBoilerplate.contains(w))
         w,
   ];
   return kept.join(' ');
@@ -414,6 +415,8 @@ bool _lineCovers(List<String> a, List<String> b) {
   if (a.isEmpty || b.isEmpty) return false;
   final shorter = a.length <= b.length ? a : b;
   final longer = a.length <= b.length ? b : a;
+  if (!shorter.any(_isDistinctive)) return false;
+  if (!longer.toSet().containsAll(shorter)) return false;
   final shortD = {
     for (final w in shorter)
       if (_isDistinctive(w)) w,
@@ -422,15 +425,13 @@ bool _lineCovers(List<String> a, List<String> b) {
     for (final w in longer)
       if (_isDistinctive(w)) w,
   };
-  final distinctiveLeftover = longD.difference(shortD);
-  // Same-beat gist: three shared distinctive tokens. Extra words
-  // (creaked, lives) do not re-inject the flowerpot fact.
-  if (shortD.intersection(longD).length >= 3) return true;
-  if (!shorter.any(_isDistinctive)) return false;
-  if (!longer.toSet().containsAll(shorter)) return false;
   final leftover = longer.toSet().difference(shorter.toSet());
-  // Stem leftover: died/gone/fell/hid/ran count even when length < 5.
-  return leftover.isEmpty && distinctiveLeftover.isEmpty;
+  final distinctiveLeftover = longD.difference(shortD);
+  if (leftover.isEmpty && distinctiveLeftover.isEmpty) return true;
+  // One leftover word on a complete gist is same-beat paraphrase
+  // (that creaked, lives). Two leftover words are an extra fact
+  // (swing creaked). key is not keyboard. A stem does not cover died.
+  return leftover.length == 1 && shortD.length >= 3;
 }
 
 bool _nearCover(String card, String window) {
@@ -482,21 +483,27 @@ RetrievedMemory? _uncoveredMemory(RetrievedMemory m, List<String> cards) {
       if (raw.trim().isNotEmpty) raw,
   ];
   if (lines.isEmpty) return m;
-  final kept = [
-    for (final line in lines)
-      if (!_lineCoveredByCards(line, cards)) line,
+  final keptIdx = [
+    for (var i = 0; i < lines.length; i++)
+      if (!_lineCoveredByCards(lines[i], cards)) i,
   ];
-  if (kept.isEmpty) return null;
-  if (kept.length == lines.length) {
+  if (keptIdx.isEmpty) return null;
+  if (keptIdx.length == lines.length) {
     if (_ragCoveredByJournal(m.content, cards)) return null;
     return m;
   }
+  var start = m.positionStart;
+  var end = m.positionEnd;
+  if (end - start + 1 == lines.length) {
+    start = m.positionStart + keptIdx.first;
+    end = m.positionStart + keptIdx.last;
+  }
   return RetrievedMemory(
-    content: kept.join('\n'),
+    content: [for (final i in keptIdx) lines[i]].join('\n'),
     characterId: m.characterId,
     sessionId: m.sessionId,
-    positionStart: m.positionStart,
-    positionEnd: m.positionEnd,
+    positionStart: start,
+    positionEnd: end,
     score: m.score,
   );
 }

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -293,21 +293,14 @@ const _kCoverFiller = {
   'tomorrow',
 };
 
-/// Place compounds count as ONE token so {front, porch} is not cover.
-const _kPlaceCompounds = [
-  'front porch',
-  'back porch',
-  'front yard',
-  'back yard',
-];
+/// Place-adjective + place-noun is ONE token so {side, porch} or
+/// {front, lawn} is not cover. Not a hardcoded pair list.
+final _kPlaceCompound = RegExp(
+  r'\b(front|back|side)\s+(porch|yard|lawn|deck|stoop)\b',
+);
 
-String _foldPlaceCompounds(String s) {
-  var out = s.toLowerCase();
-  for (final phrase in _kPlaceCompounds) {
-    out = out.replaceAll(phrase, phrase.replaceAll(' ', ''));
-  }
-  return out;
-}
+String _foldPlaceCompounds(String s) =>
+    s.toLowerCase().replaceAllMapped(_kPlaceCompound, (m) => '${m[1]}${m[2]}');
 
 Set<String> coverContentTokens(String s) =>
     itemNameTokens(_foldPlaceCompounds(s)).difference(_kCoverFiller);
@@ -385,7 +378,7 @@ String rememberedLineFromWindow(String content) {
   ];
   if (lines.isEmpty) return content.trim();
   String body(String line) {
-    final m = RegExp(r'^[^:\n]{1,40}:\s+(.*)').firstMatch(line);
+    final m = RegExp(r'^[^:\n]{1,40}:\s*(.*)').firstMatch(line);
     return (m != null ? m.group(1)! : line).trim();
   }
 

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -33,7 +33,13 @@
 ///    relevance order — chronology decides how survivors are SHOWN, never
 ///    which memories survive.
 ///
-/// 2. **The receipt.** Every decision the retrieval makes — found, deduped
+/// 2. **Gist-first cue + cover drop.** The query is composed from emotion,
+///    fixation, the top hot journal line, and last words — not the last-3
+///    live lines alone. Extra RAG windows drop when a journal card already
+///    covers the beat. The labeled "Exact earlier lines" dump is gone as
+///    the normal path; verbatim rides only a quote-reach.
+///
+/// 3. **The receipt.** Every decision the retrieval makes — found, deduped
 ///    against the journal, trimmed for budget, injected — was a debugPrint
 ///    and nothing else. [buildRagReceipt] compresses those decisions into a
 ///    metadata map stamped on the turn's message, which is what the sidebar
@@ -44,6 +50,7 @@
 library;
 
 import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/chat/pockets.dart' show itemNameTokens;
 import 'package:front_porch_ai/services/memory_service.dart'
     show RetrievedMemory;
 
@@ -123,6 +130,120 @@ String formatRagLine(String content, {int? day, required bool otherChat}) {
       ? '(Day $day) '
       : '';
   return '- $stamp$content';
+}
+
+/// Cue-composed RAG / journal-cold query. Not the last-3 live lines alone —
+/// those teach the embedder to retrieve the scene that is still on screen.
+/// Pack/budget/age floor stay with retrieve(); this only shapes the query.
+String composeRagQuery({
+  String emotion = '',
+  String fixation = '',
+  String hotJournalLine = '',
+  String lastWords = '',
+}) {
+  final parts = <String>[];
+  final e = emotion.trim();
+  if (e.isNotEmpty) parts.add('feeling $e');
+  final f = fixation.trim();
+  if (f.isNotEmpty) parts.add('on the mind: $f');
+  final h = hotJournalLine.trim();
+  if (h.isNotEmpty) parts.add('remembered: $h');
+  final w = lastWords.trim();
+  if (w.isNotEmpty) parts.add(w);
+  return parts.join('\n');
+}
+
+/// The live beat's words: the latest line (promptText, so photo markers
+/// survive) plus any nearby photo captions. Not a last-3 transcript dump.
+String lastWordsFromMessages(List<ChatMessage> messages) {
+  if (messages.isEmpty) return '';
+  final last = messages.last;
+  final parts = <String>['${last.sender}: ${last.promptText}'];
+  final floor = (messages.length - 4).clamp(0, messages.length);
+  for (var i = messages.length - 1; i >= floor; i--) {
+    final m = messages[i];
+    if (identical(m, last)) continue;
+    final t = m.promptText;
+    if (t.contains('[shared a photo:')) {
+      parts.add('${m.sender}: $t');
+    }
+  }
+  return parts.join('\n');
+}
+
+/// Lexical "they want the exact words" — remember / said / vows / etc.
+/// The 0.45 expand/RAG floor still gates retrieve(); this only chooses the
+/// quote frame vs the remembered-fact frame.
+bool isReachingForQuote(String lastWords) {
+  final t = lastWords.toLowerCase();
+  return RegExp(
+    r'\b(remember|said|told|vows|promised|quoted?|exactly)\b',
+  ).hasMatch(t);
+}
+
+/// Drop RAG windows a journal card already covers (token overlap ≥ 2).
+/// Position-overlap with expanded receipts is handled separately by
+/// [RetrievedMemory.excludingPositions]. Not uniqueness-by-shape.
+List<RetrievedMemory> dropCoveredRagWindows(
+  List<RetrievedMemory> memories,
+  Iterable<String> journalCardContents,
+) {
+  final cardTokenSets = [
+    for (final c in journalCardContents) itemNameTokens(c),
+  ].where((s) => s.length >= 2).toList();
+  if (cardTokenSets.isEmpty) return memories;
+  return [
+    for (final m in memories)
+      if (!_ragCoveredByJournal(m.content, cardTokenSets)) m,
+  ];
+}
+
+bool _ragCoveredByJournal(String ragContent, List<Set<String>> cardTokenSets) {
+  final rag = itemNameTokens(ragContent);
+  if (rag.length < 2) return false;
+  for (final card in cardTokenSets) {
+    if (rag.intersection(card).length >= 2) return true;
+  }
+  return false;
+}
+
+/// Normal path: one uncovered window (a fact that left history). Quote-reach
+/// keeps the uncovered set — retrieve() already floored them at 0.45.
+List<RetrievedMemory> capRagWindows(
+  List<RetrievedMemory> uncovered, {
+  required bool reachingForQuote,
+}) {
+  if (uncovered.isEmpty || reachingForQuote) return uncovered;
+  return [uncovered.first];
+}
+
+/// Remembered-fact frame — the default. Not "exact earlier lines".
+const String kRagRememberedHeader =
+    '[Remembered from earlier (already happened — not happening now, '
+    'do not replay as the scene):\n';
+
+/// Quote frame — only when [isReachingForQuote] is true.
+const String kRagQuoteHeader =
+    '[Words they are reaching for, from earlier (already happened — '
+    'quote only if asked):\n';
+
+/// Build the memories block. Day stamps stay display-only; packing order
+/// is the caller's (score-descending). Display order is chronological.
+String buildRagMemoriesBlock({
+  required List<RetrievedMemory> memories,
+  required String currentSessionId,
+  required Map<RetrievedMemory, int?> days,
+  required bool reachingForQuote,
+}) {
+  if (memories.isEmpty) return '';
+  String lineFor(RetrievedMemory m) => formatRagLine(
+    m.content,
+    day: days[m],
+    otherChat: m.sessionId != currentSessionId,
+  );
+  final header = reachingForQuote ? kRagQuoteHeader : kRagRememberedHeader;
+  return '\n$header'
+      '${chronologicalRagOrder(memories, currentSessionId).map(lineFor).join('\n')}]\n';
 }
 
 /// Receipt status strings (wire format — persist in message metadata).

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -412,12 +412,6 @@ List<String> _coverWords(String s) {
   return line.split(' ');
 }
 
-bool _isExtraFactLeftover(String w) {
-  if (!_isDistinctive(w)) return true;
-  if (w.length >= 7) return true;
-  return w.endsWith('ned');
-}
-
 bool _lineCovers(List<String> card, List<String> window) {
   if (card.isEmpty || window.isEmpty) return false;
   if (!card.any(_isDistinctive)) return false;
@@ -432,10 +426,8 @@ bool _lineCovers(List<String> card, List<String> window) {
   };
   final leftover = window.toSet().difference(card.toSet());
   final distinctiveLeftover = longD.difference(shortD);
-  if (leftover.isEmpty && distinctiveLeftover.isEmpty) return true;
-  // Kind, not position. Short leftover and long distinctive leftover
-  // are extra facts. Length 5-6 distinctive leftover is restatement.
-  return leftover.isNotEmpty && leftover.every((w) => !_isExtraFactLeftover(w));
+  // Joe lock: DROP only when leftover is empty. Anything with leftover KEEP.
+  return leftover.isEmpty && distinctiveLeftover.isEmpty;
 }
 
 bool _nearCover(String card, String window) {

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -381,13 +381,11 @@ String _normalizeCoverLine(String s) {
   var t = s.toLowerCase().replaceFirst(_kSpeakerPrefix, '');
   t = t.replaceAll(_kNonWord, ' ');
   t = _foldPlaceCompounds(t);
+  // Time filler and journal boilerplate stay as leftover tokens.
+  // Stripping them made leftover-empty DROP gist+safe / gist+yesterday.
   final kept = <String>[
     for (final w in t.split(_kSpaces))
-      if (w.isNotEmpty &&
-          !_kFunctionWords.contains(w) &&
-          !_kTimeFiller.contains(w) &&
-          !_kJournalBoilerplate.contains(w))
-        w,
+      if (w.isNotEmpty && !_kFunctionWords.contains(w)) w,
   ];
   return kept.join(' ');
 }

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -293,14 +293,18 @@ const _kCoverFiller = {
   'tomorrow',
 };
 
-/// Place-adjective + place-noun is ONE token so {side, porch} or
-/// {front, lawn} is not cover. Not a hardcoded pair list.
-final _kPlaceCompound = RegExp(
-  r'\b(front|back|side)\s+(porch|yard|lawn|deck|stoop)\b',
-);
+/// Any token immediately before a place noun is ONE token
+/// (screened porch, wraparound deck) so {screened, porch} is not cover.
+/// Articles stay articles — "the porch" does not become theporch.
+final _kPlaceNounCompound = RegExp(r'\b(\w+)\s+(porch|yard|lawn|deck|stoop)\b');
+const _kNoFoldBeforePlace = {'the', 'a', 'an'};
 
 String _foldPlaceCompounds(String s) =>
-    s.toLowerCase().replaceAllMapped(_kPlaceCompound, (m) => '${m[1]}${m[2]}');
+    s.toLowerCase().replaceAllMapped(_kPlaceNounCompound, (m) {
+      final prep = m[1]!;
+      if (_kNoFoldBeforePlace.contains(prep)) return m[0]!;
+      return '$prep${m[2]}';
+    });
 
 Set<String> coverContentTokens(String s) =>
     itemNameTokens(_foldPlaceCompounds(s)).difference(_kCoverFiller);

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -412,73 +412,30 @@ List<String> _coverWords(String s) {
   return line.split(' ');
 }
 
-/// Tightest span in [longer] that contains every token of [shorter].
-(int, int)? _minCoverWindow(List<String> longer, List<String> shorter) {
-  final need = <String, int>{};
-  for (final w in shorter) {
-    need[w] = (need[w] ?? 0) + 1;
-  }
-  var missing = shorter.length;
-  final got = <String, int>{};
-  var bestL = 0;
-  var bestR = longer.length;
-  var found = false;
-  var l = 0;
-  for (var r = 0; r < longer.length; r++) {
-    final w = longer[r];
-    final n = need[w];
-    if (n != null) {
-      final g = (got[w] ?? 0) + 1;
-      got[w] = g;
-      if (g <= n) missing--;
-    }
-    while (missing == 0 && l <= r) {
-      found = true;
-      if (r - l < bestR - bestL) {
-        bestL = l;
-        bestR = r;
-      }
-      final u = longer[l];
-      final nu = need[u];
-      if (nu != null) {
-        final g = got[u]!;
-        if (g <= nu) missing++;
-        got[u] = g - 1;
-      }
-      l++;
-    }
-  }
-  if (!found) return null;
-  return (bestL, bestR);
+bool _isExtraFactLeftover(String w) {
+  if (!_isDistinctive(w)) return true;
+  if (w.length >= 7) return true;
+  return w.endsWith('ned');
 }
 
-bool _lineCovers(List<String> a, List<String> b) {
-  if (a.isEmpty || b.isEmpty) return false;
-  final shorter = a.length <= b.length ? a : b;
-  final longer = a.length <= b.length ? b : a;
-  if (!shorter.any(_isDistinctive)) return false;
-  if (!longer.toSet().containsAll(shorter)) return false;
+bool _lineCovers(List<String> card, List<String> window) {
+  if (card.isEmpty || window.isEmpty) return false;
+  if (!card.any(_isDistinctive)) return false;
+  if (!window.toSet().containsAll(card)) return false;
   final shortD = {
-    for (final w in shorter)
+    for (final w in card)
       if (_isDistinctive(w)) w,
   };
   final longD = {
-    for (final w in longer)
+    for (final w in window)
       if (_isDistinctive(w)) w,
   };
-  final leftover = longer.toSet().difference(shorter.toSet());
+  final leftover = window.toSet().difference(card.toSet());
   final distinctiveLeftover = longD.difference(shortD);
   if (leftover.isEmpty && distinctiveLeftover.isEmpty) return true;
-  if (leftover.isEmpty) return true;
-  final span = _minCoverWindow(longer, shorter);
-  if (span == null) return false;
-  // Suffix leftover is an extra fact (burned, creaked, died, sat).
-  if (longer.sublist(span.$2 + 1).isNotEmpty) return false;
-  // Distinctive prefix leftover is an extra fact (lighthouse … gist).
-  if (longer.sublist(0, span.$1).any(_isDistinctive)) return false;
-  // Interior leftover is same-beat restatement (lives / tucked / buried).
-  // Short prefix leftover is the same beat (I sat on porch).
-  return true;
+  // Kind, not position. Short leftover and long distinctive leftover
+  // are extra facts. Length 5-6 distinctive leftover is restatement.
+  return leftover.isNotEmpty && leftover.every((w) => !_isExtraFactLeftover(w));
 }
 
 bool _nearCover(String card, String window) {

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -390,21 +390,41 @@ String _normalizeCoverLine(String s) {
   return kept.join(' ');
 }
 
+/// Journal-mood leftovers. Length ≥ 5 is not enough if the word is one
+/// of these — "felt safe" / "still think" must not cover a longer beat.
+const _kJournalBoilerplate = {
+  'felt',
+  'safe',
+  'still',
+  'think',
+  'about',
+  'remember',
+};
+
+bool _isDistinctive(String w) =>
+    w.length >= 5 && !_kJournalBoilerplate.contains(w);
+
+List<String> _coverWords(String s) {
+  final line = _normalizeCoverLine(s);
+  if (line.isEmpty) return const [];
+  return line.split(' ');
+}
+
 bool _nearCover(String card, String window) {
-  final a = _normalizeCoverLine(card);
-  final b = _normalizeCoverLine(window);
+  final a = _coverWords(card);
+  final b = _coverWords(window);
   if (a.isEmpty || b.isEmpty) return false;
   final shorter = a.length <= b.length ? a : b;
   final longer = a.length <= b.length ? b : a;
-  if (shorter.split(' ').length < 2) return false;
-  return longer.contains(shorter);
+  if (!shorter.any(_isDistinctive)) return false;
+  return longer.toSet().containsAll(shorter);
 }
 
 /// Drop RAG windows a THIS-BEAT injected journal gist already covers.
 /// Receipt/position overlap is excludingPositions at the call site.
-/// Content cover is a near-substring of the normalized card and window,
-/// not leftover 2-token overlap. Empty [journalCardContents] means
-/// Journal is off or no gist injected — do not cover-drop.
+/// Content cover is whole-token subset plus a distinctive word
+/// (length ≥ 5, not journal boilerplate). key is not inside keyboard.
+/// Empty [journalCardContents] means Journal is off or no gist.
 List<RetrievedMemory> dropCoveredRagWindows(
   List<RetrievedMemory> memories,
   Iterable<String> journalCardContents,

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -414,8 +414,6 @@ bool _lineCovers(List<String> a, List<String> b) {
   if (a.isEmpty || b.isEmpty) return false;
   final shorter = a.length <= b.length ? a : b;
   final longer = a.length <= b.length ? b : a;
-  if (!shorter.any(_isDistinctive)) return false;
-  if (!longer.toSet().containsAll(shorter)) return false;
   final shortD = {
     for (final w in shorter)
       if (_isDistinctive(w)) w,
@@ -424,7 +422,15 @@ bool _lineCovers(List<String> a, List<String> b) {
     for (final w in longer)
       if (_isDistinctive(w)) w,
   };
-  return longD.difference(shortD).isEmpty;
+  final distinctiveLeftover = longD.difference(shortD);
+  // Same-beat gist: three shared distinctive tokens. Extra words
+  // (creaked, lives) do not re-inject the flowerpot fact.
+  if (shortD.intersection(longD).length >= 3) return true;
+  if (!shorter.any(_isDistinctive)) return false;
+  if (!longer.toSet().containsAll(shorter)) return false;
+  final leftover = longer.toSet().difference(shorter.toSet());
+  // Stem leftover: died/gone/fell/hid/ran count even when length < 5.
+  return leftover.isEmpty && distinctiveLeftover.isEmpty;
 }
 
 bool _nearCover(String card, String window) {
@@ -436,9 +442,16 @@ bool _nearCover(String card, String window) {
     for (final raw in window.split('\n'))
       if (raw.trim().isNotEmpty) _coverWords(raw),
   ];
-  for (final c in cardLines) {
-    for (final w in winLines) {
-      if (_lineCovers(c, w)) return true;
+  if (winLines.isEmpty) return false;
+  return winLines.every((w) => cardLines.any((c) => _lineCovers(c, w)));
+}
+
+bool _lineCoveredByCards(String line, List<String> cards) {
+  final w = _coverWords(line);
+  for (final card in cards) {
+    for (final raw in card.split('\n')) {
+      if (raw.trim().isEmpty) continue;
+      if (_lineCovers(_coverWords(raw), w)) return true;
     }
   }
   return false;
@@ -446,10 +459,8 @@ bool _nearCover(String card, String window) {
 
 /// Drop RAG windows a THIS-BEAT injected journal gist already covers.
 /// Receipt/position overlap is excludingPositions at the call site.
-/// Content cover is whole-token subset, a distinctive word on the
-/// shorter side, and no extra distinctive leftover on the longer.
-/// A prefix card does not cover a bigger fact. key is not keyboard.
-/// Empty [journalCardContents] means Journal is off or no gist.
+/// Covered lines are stripped; a span with an uncovered line keeps that
+/// line. Empty [journalCardContents] means Journal is off or no gist.
 List<RetrievedMemory> dropCoveredRagWindows(
   List<RetrievedMemory> memories,
   Iterable<String> journalCardContents,
@@ -461,8 +472,33 @@ List<RetrievedMemory> dropCoveredRagWindows(
   if (cards.isEmpty) return memories;
   return [
     for (final m in memories)
-      if (!_ragCoveredByJournal(m.content, cards)) m,
+      if (_uncoveredMemory(m, cards) case final kept?) kept,
   ];
+}
+
+RetrievedMemory? _uncoveredMemory(RetrievedMemory m, List<String> cards) {
+  final lines = [
+    for (final raw in m.content.split('\n'))
+      if (raw.trim().isNotEmpty) raw,
+  ];
+  if (lines.isEmpty) return m;
+  final kept = [
+    for (final line in lines)
+      if (!_lineCoveredByCards(line, cards)) line,
+  ];
+  if (kept.isEmpty) return null;
+  if (kept.length == lines.length) {
+    if (_ragCoveredByJournal(m.content, cards)) return null;
+    return m;
+  }
+  return RetrievedMemory(
+    content: kept.join('\n'),
+    characterId: m.characterId,
+    sessionId: m.sessionId,
+    positionStart: m.positionStart,
+    positionEnd: m.positionEnd,
+    score: m.score,
+  );
 }
 
 bool _ragCoveredByJournal(String ragContent, List<String> cards) {

--- a/lib/services/chat/rag_injection.dart
+++ b/lib/services/chat/rag_injection.dart
@@ -171,26 +171,117 @@ String lastWordsFromMessages(List<ChatMessage> messages) {
   return parts.join('\n');
 }
 
-/// Lexical "they want the exact words" — remember / said / vows / etc.
-/// The 0.45 expand/RAG floor still gates retrieve(); this only chooses the
-/// quote frame vs the remembered-fact frame.
+/// True only when they ASKED for the words — "remember what you said",
+/// "what did I promise", "exact words", "vows?" as a question.
+/// Spoken report ("I told you the tomatoes came in", "she said the
+/// cicadas") is not quote-reach and must not dump every RAG window.
 bool isReachingForQuote(String lastWords) {
   final t = lastWords.toLowerCase();
-  return RegExp(
-    r'\b(remember|said|told|vows|promised|quoted?|exactly)\b',
-  ).hasMatch(t);
+  if (t.trim().isEmpty) return false;
+  if (RegExp(
+    r'\bwhat did (you|i|we|they|she|he) (say|tell|promise)\b',
+  ).hasMatch(t)) {
+    return true;
+  }
+  if (RegExp(r'\b(exact(ly)? words|word for word)\b').hasMatch(t)) {
+    return true;
+  }
+  if (RegExp(
+    r'\b(what you said|what i said|what you promised|what i promised)\b',
+  ).hasMatch(t)) {
+    return true;
+  }
+  if (RegExp(r'\bremember\b').hasMatch(t)) {
+    if (t.contains('?')) return true;
+    if (RegExp(
+      r'\bremember (what|when|where|how|who|the|our|my|your|that)\b',
+    ).hasMatch(t)) {
+      return true;
+    }
+  }
+  if (RegExp(r'\bvows\b').hasMatch(t) && t.contains('?')) return true;
+  return false;
 }
 
-/// Drop RAG windows a journal card already covers (token overlap ≥ 2).
-/// Position-overlap with expanded receipts is handled separately by
+/// Narrative filler that [itemNameTokens] still keeps (≥3 chars). Cover
+/// overlap must be content (flowerpot / lighthouse), not still/think/about.
+const _kCoverFiller = {
+  'still',
+  'think',
+  'about',
+  'just',
+  'like',
+  'very',
+  'really',
+  'then',
+  'when',
+  'what',
+  'this',
+  'that',
+  'with',
+  'from',
+  'have',
+  'been',
+  'were',
+  'they',
+  'them',
+  'their',
+  'there',
+  'here',
+  'some',
+  'more',
+  'than',
+  'into',
+  'over',
+  'also',
+  'only',
+  'even',
+  'much',
+  'such',
+  'being',
+  'because',
+  'would',
+  'could',
+  'should',
+  'did',
+  'does',
+  'dont',
+  'not',
+  'but',
+  'and',
+  'for',
+  'the',
+  'you',
+  'she',
+  'him',
+  'her',
+  'his',
+  'was',
+  'are',
+  'had',
+  'has',
+  'who',
+  'how',
+  'why',
+  'our',
+  'its',
+};
+
+Set<String> coverContentTokens(String s) =>
+    itemNameTokens(s).difference(_kCoverFiller);
+
+/// Drop RAG windows a THIS-BEAT injected journal gist already covers
+/// (any shared content token: lighthouse, flowerpot). Empty
+/// [journalCardContents] means Journal is off or no gist injected — do
+/// not cover-drop. Position-overlap with expanded receipts is
 /// [RetrievedMemory.excludingPositions]. Not uniqueness-by-shape.
 List<RetrievedMemory> dropCoveredRagWindows(
   List<RetrievedMemory> memories,
   Iterable<String> journalCardContents,
 ) {
   final cardTokenSets = [
-    for (final c in journalCardContents) itemNameTokens(c),
-  ].where((s) => s.length >= 2).toList();
+    for (final c in journalCardContents) coverContentTokens(c),
+  ].where((s) => s.isNotEmpty).toList();
   if (cardTokenSets.isEmpty) return memories;
   return [
     for (final m in memories)
@@ -199,10 +290,10 @@ List<RetrievedMemory> dropCoveredRagWindows(
 }
 
 bool _ragCoveredByJournal(String ragContent, List<Set<String>> cardTokenSets) {
-  final rag = itemNameTokens(ragContent);
-  if (rag.length < 2) return false;
+  final rag = coverContentTokens(ragContent);
+  if (rag.isEmpty) return false;
   for (final card in cardTokenSets) {
-    if (rag.intersection(card).length >= 2) return true;
+    if (rag.intersection(card).isNotEmpty) return true;
   }
   return false;
 }

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -22,14 +22,16 @@
 // front/back/side, a pair list, or a colon that requires a space, goes red.
 // Screened/covered/wraparound must KEEP. the/a/an stay filler (no theporch).
 //
-// Cover-drop locks (near-substring, not leftover 2-token overlap): a
-// source-scan for shared-content-tokens ≥ 2 as the cover rule MUST FAIL.
-// Shared place (front-garden / back-balcony / side-driveway / screened-porch)
-// KEEPS. Same-beat flowerpot gist DROPS because the card names the
-// flowerpot in the window — not because of 2-token overlap. Function
+// Cover-drop locks (whole-token subset plus a distinctive word, not leftover
+// 2-token overlap): a source-scan for raw contains() of one token in another
+// (key inside keyboard) MUST FAIL. Mood-only stems (felt/safe, still/think)
+// do not cover a longer beat. Shared place (front-garden / back-balcony /
+// side-driveway / screened-porch) KEEPS. Same-beat flowerpot gist DROPS
+// because the card names the flowerpot — flowerpot is distinctive. Function
 // words are one closed set (his/her/that/on/in/at do not mint compounds).
 // garden/balcony/driveway must not appear on the setting-noun / cover-filler
-// place list. Refuse leftover-intersection greens as stand-alone.
+// place list. Refuse leftover-intersection and raw-contains greens as
+// stand-alone.
 
 import 'dart:io';
 
@@ -181,6 +183,13 @@ const kBackBalconySwing = 'Nia: the back balcony swing creaked tonight';
 const kSideDrivewayFeeling = 'I felt safe on the side driveway tonight';
 const kSideDrivewaySwing = 'Nia: the side driveway swing creaked tonight';
 const kHallwaySpareKey = 'Nia: the spare key lives in the hallway drawer';
+const kSpareKeyShort = 'I still think about the spare key';
+const kSpareKeyboard =
+    'Nia: I still think about the spare keyboard in the attic';
+const kFeltSafeTonight = 'I felt safe tonight';
+const kGardenKeyWindow =
+    'Nia: I felt safe on the front garden until the spare key went missing';
+const kStillThinkAboutIt = 'I still think about it';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
@@ -1161,8 +1170,23 @@ void main() {
       nearSlice.contains('longer.contains(shorter)'),
       isFalse,
       reason:
-          'unanchored contains() is the key⊂keyboard hole — cover is '
+          'unanchored contains() is the key-inside-keyboard hole — cover is '
           'whole-token subset plus a distinctive word',
+    );
+    expect(
+      nearSlice.contains('.contains('),
+      isFalse,
+      reason:
+          'a raw contains() of one token in another (key inside keyboard) '
+          'MUST FAIL this pin — cover is whole-token set membership '
+          '(containsAll), not unanchored substring of key inside keyboard',
+    );
+    expect(
+      'keyboard'.contains('key'),
+      isTrue,
+      reason:
+          'this is the hole a raw contains() would take — that match is '
+          'not a green. Product must not treat key as inside keyboard.',
     );
     expect(
       src.contains('_kJournalBoilerplate') && src.contains('containsAll'),
@@ -1341,6 +1365,192 @@ void main() {
       );
     },
   );
+
+  test(
+    'LOCK: spare key does not cover-drop spare keyboard — whole tokens only',
+    () async {
+      expect(
+        'keyboard'.contains('key'),
+        isTrue,
+        reason:
+            'raw contains() of "key" inside "keyboard" is the hole — if '
+            'that were cover this window would drop. That contains is '
+            'not a green.',
+      );
+      final card = await seedOverflowSession(
+        sessionId: 'sess-gistlock-keyboard',
+        charDbId: 'char-gistlock-keyboard',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-keyboard'),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kSpareKeyShort),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.canned = [
+        RetrievedMemory(
+          content: kSpareKeyboard,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-keyboard',
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so cover-drop is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains("Nia's private journal"),
+        reason: 'the spare-key gist must inject or cover-drop was never tested',
+      );
+      expect(prompt, contains(kRagRememberedHeader.trim()));
+      expect(
+        prompt,
+        contains('keyboard'),
+        reason:
+            'whole tokens only — "spare key" must NOT drop "spare '
+            'keyboard". A raw contains() of key inside keyboard goes red.',
+      );
+      expect(prompt, contains('attic'));
+    },
+  );
+
+  test('LOCK: mood-only stems do not cover garden/key or flowerpot', () async {
+    const cases = [
+      {
+        'tag': 'felt/safe',
+        'feeling': kFeltSafeTonight,
+        'window': kGardenKeyWindow,
+        'kept': 'garden',
+      },
+      {
+        'tag': 'still/think',
+        'feeling': kStillThinkAboutIt,
+        'window': kFactWindow,
+        'kept': 'flowerpot',
+      },
+    ];
+    for (var i = 0; i < cases.length; i++) {
+      final c = cases[i];
+      final tag = c['tag']!;
+      final feeling = c['feeling']!;
+      final window = c['window']!;
+      final kept = c['kept']!;
+      final sessionId = 'sess-gistlock-moodstem-$i';
+      final card = await seedOverflowSession(
+        sessionId: sessionId,
+        charDbId: 'char-gistlock-moodstem-$i',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: Value(sessionId),
+          characterId: Value(card.stableGroupId),
+          content: Value(feeling),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: window,
+          characterId: 'Nia',
+          sessionId: sessionId,
+          positionStart: 0,
+          positionEnd: 1,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so cover-drop is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(feeling),
+        reason: 'the $tag mood card must inject or cover-drop was never tested',
+      );
+      expect(prompt, contains(kRagRememberedHeader.trim()));
+      expect(
+        prompt,
+        contains(kept),
+        reason:
+            'mood-only $tag stems do not cover — "$feeling" must NOT '
+            'drop the $kept window',
+      );
+    }
+
+    final flowerCard = await seedOverflowSession(
+      sessionId: 'sess-gistlock-moodstem-flower',
+      charDbId: 'char-gistlock-moodstem-flower',
+      emotion: kEmotion,
+      fixation: kFixation,
+    );
+    await db.insertJournalCard(
+      JournalMemoriesCompanion(
+        sessionId: const Value('sess-gistlock-moodstem-flower'),
+        characterId: Value(flowerCard.stableGroupId),
+        content: const Value(kGist),
+        category: const Value('about_us'),
+        heat: const Value(0.9),
+      ),
+    );
+    memory.retrieveCalls = 0;
+    memory.canned = [
+      RetrievedMemory(
+        content: kFactWindow,
+        characterId: 'Nia',
+        sessionId: 'sess-gistlock-moodstem-flower',
+        positionStart: 0,
+        positionEnd: 1,
+        score: 0.9,
+      ),
+    ];
+    llm.chatPrompts.clear();
+    await chat.sendMessage(kSit);
+    expect(
+      memory.retrieveCalls,
+      greaterThan(0),
+      reason: 'retrieve ran — a skip would fake the cover-drop',
+    );
+    expect(llm.chatPrompts, isNotEmpty);
+    final flower = llm.chatPrompts.last;
+    expect(
+      flower,
+      contains(kGist),
+      reason: 'same-beat flowerpot gist must inject',
+    );
+    expect(
+      flower,
+      isNot(contains(kRagRememberedHeader.trim())),
+      reason:
+          'same-beat flowerpot gist still DROPS — flowerpot is '
+          'distinctive. Mood-stem KEEP above must not disable real cover.',
+    );
+  });
 
   test('LOCK: function words are one closed set — his/her/that/on/in/at', () {
     final src = File('lib/services/chat/rag_injection.dart').readAsStringSync();

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -1214,6 +1214,13 @@ void main() {
           'card does not cover a bigger fact',
     );
     expect(
+      src.contains('_uncoveredMemory') && src.contains('leftover'),
+      isTrue,
+      reason:
+          'short extras count as leftover; covered lines are stripped '
+          'so an uncovered swing line survives the span',
+    );
+    expect(
       src.contains(r"card.split('\n')"),
       isTrue,
       reason:

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -1196,6 +1196,13 @@ void main() {
           'felt/safe/still/think/about/remember) and be a whole-token subset',
     );
     expect(
+      src.contains('longD.difference(shortD)'),
+      isTrue,
+      reason:
+          'longer must have no extra distinctive leftover — a prefix '
+          'card does not cover a bigger fact',
+    );
+    expect(
       nearSlice.contains('.intersection('),
       isFalse,
       reason:

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -37,11 +37,10 @@
 // greens as stand-alone.
 //
 // Short leftover is ANY extra content token on the longer side —
-// died/gone/fell/hid/ran count even when length < 5. "the spare key"
-// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat is interior
-// leftover (lives / tucked / buried) — no verb list. Suffix leftover
-// is an extra fact (burned, lighthouse, creaked, died, sat). Covered
-// lines strip into contiguous runs; each run remaps its span.
+// died/gone/fell/hid/ran count even when length < 5. Leftover kind,
+// not position: short leftover and long distinctive leftover are extra
+// facts. Length 5-6 distinctive leftover is restatement. Covered lines
+// strip into contiguous runs; each run remaps its span.
 
 import 'dart:io';
 
@@ -1271,11 +1270,17 @@ void main() {
           'died/gone/fell/hid/ran count even when length < 5',
     );
     expect(
-      src.contains('_minCoverWindow') && src.contains('leftover'),
+      src.contains('_isExtraFactLeftover') && src.contains('leftover'),
       isTrue,
       reason:
-          'same-beat is interior leftover; suffix leftover is an extra fact. '
-          'No paraphrase verb list',
+          'leftover kind, not position: short leftover and long distinctive '
+          'leftover are extra facts. Length 5-6 distinctive leftover is '
+          'restatement. No paraphrase verb list',
+    );
+    expect(
+      src.contains('_minCoverWindow'),
+      isFalse,
+      reason: 'interior-vs-suffix is a ship bug — position is not kind',
     );
     expect(
       src.contains('_kCoverParaphrase') || src.contains('shortD.length >= 3'),

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -226,6 +226,17 @@ const kFlowerpotAndSwing =
     'Nia: the spare key under the third flowerpot and the swing creaked';
 const kKeyboardOnFlowerpot =
     'Nia: the spare keyboard sits on the third flowerpot';
+const kGistBurned =
+    'Nia: I still think about the spare key under the third flowerpot burned';
+const kGistLighthouse =
+    'Nia: I still think about the spare key under the third flowerpot lighthouse';
+const kThirdFlowerpotLighthouse = 'Nia: the third flowerpot lighthouse';
+const kLivesHidden =
+    'Nia: the spare key lives hidden under the third flowerpot';
+const kThreeLineGap =
+    'Nia: the porch swing creaked tonight\n'
+    'Nia: I still think about the spare key under the third flowerpot\n'
+    'Nia: I sat on the front garden';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -1262,6 +1273,13 @@ void main() {
       reason:
           'leftover==1 on a 3-distinctive gist treats burned / lighthouse '
           'as paraphrase — leftover kind, not leftover count',
+    );
+    expect(
+      src.contains('leftover.length == 2'),
+      isFalse,
+      reason:
+          'flipping leftover==1 to leftover==2 is fake-green for burned / '
+          'lighthouse KEEP and lives-hidden DROP — leftover kind, not count',
     );
     expect(
       src.contains('shortD.intersection(longD).length >= 3'),
@@ -2358,4 +2376,393 @@ void main() {
       );
     },
   );
+
+  test(
+    'LOCK: leftover kind — burned / lighthouse KEEP; lives hidden DROPS',
+    () async {
+      Set<String> bodyTokens(String s) =>
+          coverContentTokens(s.replaceFirst(RegExp(r'^[^:\n]{1,40}:\s*'), ''));
+      expect(
+        bodyTokens(kGistBurned).difference(bodyTokens(kGist)),
+        {'burned'},
+        reason:
+            'burned is leftover count 1 — leftover==1 would DROP it. That '
+            'count is not a green. Distinctive leftover is an extra fact',
+      );
+      expect(
+        bodyTokens(kGistLighthouse).difference(bodyTokens(kGist)),
+        {'lighthouse'},
+        reason:
+            'lighthouse is leftover count 1 on the 3-distinctive gist — '
+            'leftover==1 would DROP it. That count is not a green',
+      );
+      expect(
+        bodyTokens(
+          kThirdFlowerpotLighthouse,
+        ).difference(bodyTokens(kThirdFlowerpot)),
+        {'lighthouse'},
+        reason:
+            'third-flowerpot × lighthouse is leftover count 1 — leftover==1 '
+            'without the shortD>=3 gate would DROP it. That count is not a green',
+      );
+      expect(
+        bodyTokens(kLivesHidden).difference(bodyTokens(kGist)),
+        {'lives', 'hidden'},
+        reason:
+            'lives+hidden is leftover count 2 — leftover==1 would KEEP it. '
+            'leftover==2 would DROP it. That flip is fake-green; DROP is '
+            'paraphrase kind (lives / hidden), not leftover==2',
+      );
+
+      const cases = [
+        {
+          'tag': 'flowerpot gist burned',
+          'card': kGist,
+          'window': kGistBurned,
+          'kept': 'burned',
+          'drop': false,
+        },
+        {
+          'tag': 'flowerpot gist lighthouse',
+          'card': kGist,
+          'window': kGistLighthouse,
+          'kept': 'lighthouse',
+          'drop': false,
+        },
+        {
+          'tag': 'third-flowerpot lighthouse',
+          'card': kThirdFlowerpot,
+          'window': kThirdFlowerpotLighthouse,
+          'kept': 'lighthouse',
+          'drop': false,
+        },
+        {
+          'tag': 'lives hidden',
+          'card': kGist,
+          'window': kLivesHidden,
+          'kept': 'hidden',
+          'drop': true,
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']! as String;
+        final cardText = c['card']! as String;
+        final window = c['window']! as String;
+        final kept = c['kept']! as String;
+        final drop = c['drop']! as bool;
+        final sessionId = 'sess-gistlock-leftoverkind-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-leftoverkind-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: Value(cardText),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason:
+              'cues are present — retrieve must run so leftover kind is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(cardText),
+          reason:
+              'the "$cardText" card must inject or leftover kind was '
+              'never tested',
+        );
+        if (drop) {
+          expect(
+            prompt,
+            isNot(contains(kRagRememberedHeader.trim())),
+            reason:
+                'same-beat leftover is a closed paraphrase set '
+                '(lives / hidden / creaked), not leftover==1 and not '
+                'leftover==2. "$tag" must DROP. Flipping ==1 to ==2 is '
+                'fake-green — DROP is kind, not count',
+          );
+          expect(
+            prompt,
+            isNot(contains(window)),
+            reason:
+                'lives hidden still DROPS — "$window" must not reach the prompt',
+          );
+        } else {
+          expect(prompt, contains(kRagRememberedHeader.trim()));
+          expect(
+            prompt,
+            contains(kept),
+            reason:
+                'distinctive leftover is an extra fact — "$tag" must KEEP '
+                '"$kept". leftover==1 on a 3-distinctive gist treats '
+                'burned / lighthouse as paraphrase and goes red here',
+          );
+        }
+      }
+    },
+  );
+
+  test('LOCK: stripped windows split into contiguous kept runs', () async {
+    const gapStart = 10;
+    const flowerpotPos = 11;
+    const gardenPos = 12;
+    final gapped = RetrievedMemory(
+      content: kThreeLineGap,
+      characterId: 'Nia',
+      sessionId: 'sess-gistlock-runs',
+      positionStart: gapStart,
+      positionEnd: gardenPos,
+      score: 0.9,
+    );
+    final gapKept = dropCoveredRagWindows([gapped], [kGist]);
+    expect(
+      gapKept,
+      hasLength(2),
+      reason:
+          'keep 0 and 2 of a 3-line span must be two runs — first-to-last '
+          'is one window that still owns the middle pos',
+    );
+    expect(gapKept.map((m) => m.positionStart).toList(), [gapStart, gardenPos]);
+    expect(
+      gapKept.any(
+        (m) => m.positionStart <= flowerpotPos && m.positionEnd >= flowerpotPos,
+      ),
+      isFalse,
+      reason:
+          'keep 0 and 2 of a 3-line span does NOT keep the middle pos. '
+          'first-to-last remaps onto 10–12 and that is the hole',
+    );
+    expect(
+      gapKept.first.content,
+      contains('swing'),
+      reason: 'run 0 is the kept swing',
+    );
+    expect(gapKept.first.content, isNot(contains('flowerpot')));
+    expect(
+      RetrievedMemory.excludingPositions(gapKept, {
+        flowerpotPos,
+      }, currentSessionId: 'sess-gistlock-runs'),
+      hasLength(2),
+      reason:
+          'excludingPositions on the flowerpot slice must not eat the '
+          'kept swing — each run remaps its own span',
+    );
+    expect(
+      RetrievedMemory.excludingPositions(
+        [gapped],
+        {flowerpotPos},
+        currentSessionId: 'sess-gistlock-runs',
+      ),
+      isEmpty,
+      reason:
+          'the unstripped 10–12 span still overlaps the flowerpot line — '
+          'split runs are what keep the swing',
+    );
+
+    const wideStart = 10;
+    const wideEnd = 13;
+    final wide = RetrievedMemory(
+      content: kGistPlusSwing,
+      characterId: 'Nia',
+      sessionId: 'sess-gistlock-widespan',
+      positionStart: wideStart,
+      positionEnd: wideEnd,
+      score: 0.9,
+    );
+    final wideKept = dropCoveredRagWindows([wide], [kGist]);
+    expect(wideKept, hasLength(1));
+    expect(
+      wideKept.first.positionStart,
+      12,
+      reason:
+          'span 10–13 is 4 messages / 2 lines — kept swing remaps via '
+          'line span onto 12–13, not the flowerpot 10–11',
+    );
+    expect(wideKept.first.positionEnd, 13);
+    expect(wideKept.first.content, contains(kSwingBody));
+    expect(wideKept.first.content, isNot(contains('flowerpot')));
+    expect(
+      RetrievedMemory.excludingPositions(wideKept, {
+        wideStart,
+        wideStart + 1,
+      }, currentSessionId: 'sess-gistlock-widespan'),
+      hasLength(1),
+      reason:
+          'message span ≠ line count — excludingPositions on the '
+          'flowerpot slice must not eat the remapped swing',
+    );
+    expect(
+      RetrievedMemory.excludingPositions(
+        [wide],
+        {wideStart, wideStart + 1},
+        currentSessionId: 'sess-gistlock-widespan',
+      ),
+      isEmpty,
+      reason: 'the unstripped 10–13 span still overlaps the flowerpot slice',
+    );
+
+    const sessionId = 'sess-gistlock-runs-god';
+    final card = await seedOverflowSession(
+      sessionId: sessionId,
+      charDbId: 'char-gistlock-runs-god',
+      emotion: kEmotion,
+      fixation: kFixation,
+    );
+    await db.insertJournalCard(
+      JournalMemoriesCompanion(
+        sessionId: const Value(sessionId),
+        characterId: Value(card.stableGroupId),
+        content: const Value(kGist),
+        category: const Value('about_us'),
+        heat: const Value(0.9),
+      ),
+    );
+    memory.canned = [
+      RetrievedMemory(
+        content: kThreeLineGap,
+        characterId: 'Nia',
+        sessionId: sessionId,
+        positionStart: gapStart,
+        positionEnd: gardenPos,
+        score: 0.9,
+      ),
+    ];
+
+    await chat.sendMessage('remember what you said about the swing?');
+
+    expect(
+      memory.retrieveCalls,
+      greaterThan(0),
+      reason: 'quote-reach must run so both kept runs reach the receipt',
+    );
+    expect(llm.chatPrompts, isNotEmpty);
+    final prompt = llm.chatPrompts.last;
+    expect(
+      prompt,
+      contains(kGist),
+      reason: 'the flowerpot gist must inject or run-split was never tested',
+    );
+    expect(prompt, contains(kRagQuoteHeader.trim()));
+    expect(
+      prompt,
+      contains('swing'),
+      reason: 'keep 0 of a 3-line span must still inject the swing run',
+    );
+    expect(
+      prompt,
+      contains('garden'),
+      reason: 'keep 2 of a 3-line span must still inject the garden run',
+    );
+    expect(
+      prompt,
+      isNot(contains(kThreeLineGap)),
+      reason:
+          'the raw 3-line span must not reach the prompt — middle '
+          'flowerpot line is stripped',
+    );
+
+    final receipt = chat.lastRagReceipt;
+    expect(receipt, isNotNull);
+    final injected = receipt!['injected'] as List;
+    expect(
+      injected,
+      hasLength(2),
+      reason: 'quote-reach keeps both remapped runs',
+    );
+    final poses = [for (final row in injected) (row as Map)['pos'] as int];
+    expect(poses, containsAll([gapStart, gardenPos]));
+    expect(
+      poses,
+      isNot(contains(flowerpotPos)),
+      reason:
+          'keep 0 and 2 of a 3-line span does NOT keep the middle pos '
+          'on the god-path receipt',
+    );
+    for (final row in injected) {
+      final preview = (row as Map)['preview'] as String;
+      expect(
+        preview,
+        isNot(contains('flowerpot')),
+        reason:
+            'receipt preview is a kept run, not the stripped flowerpot line',
+      );
+    }
+
+    const wideSession = 'sess-gistlock-widespan-god';
+    final wideCard = await seedOverflowSession(
+      sessionId: wideSession,
+      charDbId: 'char-gistlock-widespan-god',
+      emotion: kEmotion,
+      fixation: kFixation,
+    );
+    await db.insertJournalCard(
+      JournalMemoriesCompanion(
+        sessionId: const Value(wideSession),
+        characterId: Value(wideCard.stableGroupId),
+        content: const Value(kGist),
+        category: const Value('about_us'),
+        heat: const Value(0.9),
+      ),
+    );
+    memory.retrieveCalls = 0;
+    memory.canned = [
+      RetrievedMemory(
+        content: kGistPlusSwing,
+        characterId: 'Nia',
+        sessionId: wideSession,
+        positionStart: wideStart,
+        positionEnd: wideEnd,
+        score: 0.9,
+      ),
+    ];
+    llm.chatPrompts.clear();
+    await chat.sendMessage(kSit);
+    expect(memory.retrieveCalls, greaterThan(0));
+    expect(llm.chatPrompts, isNotEmpty);
+    final widePrompt = llm.chatPrompts.last;
+    expect(widePrompt, contains(kGist));
+    expect(widePrompt, contains(kRagRememberedHeader.trim()));
+    expect(widePrompt, contains(kSwingBody));
+    expect(widePrompt, isNot(contains(kGistPlusSwing)));
+    final wideReceipt = chat.lastRagReceipt;
+    expect(wideReceipt, isNotNull);
+    final wideRow = (wideReceipt!['injected'] as List).first as Map;
+    expect(
+      wideRow['pos'],
+      12,
+      reason:
+          'span ≠ line count remaps the kept swing onto pos 12, not '
+          'the flowerpot slice at 10',
+    );
+    expect(wideRow['pos'], isNot(equals(wideStart)));
+    final widePreview = wideRow['preview'] as String;
+    expect(widePreview, contains('swing'));
+    expect(widePreview, isNot(contains('flowerpot')));
+  });
 }

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -12,6 +12,10 @@
 // GREEN is the query / header / skip / journal-inject shape. Refused as
 // stand-alone greens: rag_receipt exists, score ≥ 0.45, contains the last
 // user line, a MemoryService that always returns a plant.
+//
+// New locks (source-scan journal expand, place-compound cover, speaker
+// prefix): still refuse those stand-alone greens. Journal lastWords is
+// scanned at the buildJournalBlock call, not composeRagQuery.
 
 import 'dart:io';
 
@@ -132,6 +136,10 @@ const kSit = 'Evening. Mind if I sit?';
 const kFactWindow =
     'You: the spare key lives under the third flowerpot\n'
     'Nia: I still think about the spare key under the third flowerpot';
+const kFrontPorchFeeling = 'I felt safe on the front porch tonight';
+const kFrontPorchSwing = 'Nia: the front porch swing creaked tonight';
+const kSwingLine = 'Nia: the swing creaked';
+const kSwingBody = 'the swing creaked';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -390,6 +398,295 @@ void main() {
         isNot(contains('You: the spare key lives under the third flowerpot')),
         reason:
             'plain path injects one remembered line, not the You:/Nia: window',
+      );
+    },
+  );
+
+  test(
+    'LOCK 1: journal expand lastWords is lastSpoken — scan the call, not composeRagQuery',
+    () {
+      final blocks = File(
+        'lib/services/chat/chat_service_generation_blocks.dart',
+      ).readAsStringSync();
+      final composeCall = blocks.indexOf('t.ragQuery = composeRagQuery(');
+      expect(
+        composeCall,
+        greaterThanOrEqualTo(0),
+        reason: 'composeRagQuery must still exist — this lock is not that call',
+      );
+      final composeSlice = blocks.substring(
+        composeCall,
+        (composeCall + 280).clamp(0, blocks.length),
+      );
+      expect(
+        composeSlice.contains('lastWords: lastWordsFromMessages(_messages)'),
+        isTrue,
+        reason:
+            'composeRagQuery keeps lastWords (captions ride the search). '
+            'Do not scan this call for journal expand.',
+      );
+
+      final journalCall = blocks.indexOf(
+        '_journalInjection.buildJournalBlock(',
+      );
+      expect(
+        journalCall,
+        greaterThanOrEqualTo(0),
+        reason: 'the journal expand call site must exist',
+      );
+      expect(
+        journalCall,
+        greaterThan(composeCall),
+        reason: 'scan the journal call itself, after composeRagQuery',
+      );
+      final journalSlice = blocks.substring(
+        journalCall,
+        (journalCall + 900).clamp(0, blocks.length),
+      );
+      expect(
+        journalSlice.contains(
+          'lastWords: lastSpokenLineFromMessages(_messages)',
+        ),
+        isTrue,
+        reason:
+            'journal expand lastWords is lastSpokenLineFromMessages — '
+            'never caption lastWords',
+      );
+      expect(
+        journalSlice.contains('lastWordsFromMessages'),
+        isFalse,
+        reason:
+            'caption lastWords must not ride the journal expand call. '
+            'A file-wide lastSpoken hit on composeRagQuery is not this lock.',
+      );
+    },
+  );
+
+  test('LOCK 1: caption + sit-down must not expand journal verbatim', () async {
+    final card = await seedOverflowSession(
+      sessionId: 'sess-gistlock-expand',
+      charDbId: 'char-gistlock-expand',
+      emotion: kEmotion,
+      fixation: kFixation,
+    );
+    await db.insertJournalCard(
+      JournalMemoriesCompanion(
+        sessionId: const Value('sess-gistlock-expand'),
+        characterId: Value(card.stableGroupId),
+        content: const Value(kGist),
+        category: const Value('about_us'),
+        heat: const Value(0.9),
+        sourceMessageIds: const Value('[0,1]'),
+      ),
+    );
+
+    final photoMsg = chat.messages.lastWhere((m) => m.isUser);
+    photoMsg.activeMetadata ??= {};
+    photoMsg.activeMetadata!['is_user_image'] = true;
+    photoMsg.activeMetadata!['image_caption'] = 'remember our beach day';
+
+    final captionMsgs = [
+      ChatMessage(
+        text: 'look',
+        sender: 'You',
+        isUser: true,
+        metadata: {
+          'is_user_image': true,
+          'image_caption': 'remember our beach day',
+        },
+      ),
+      ChatMessage(text: kSit, sender: 'You', isUser: true),
+    ];
+    expect(
+      isReachingForQuote(lastWordsFromMessages(captionMsgs)),
+      isTrue,
+      reason: 'caption lastWords WOULD expand if journal used it',
+    );
+    expect(
+      isReachingForQuote(lastSpokenLineFromMessages(captionMsgs)),
+      isFalse,
+      reason: 'spoken sit-down is not quote-reach',
+    );
+
+    await chat.sendMessage(kSit);
+
+    expect(llm.chatPrompts, isNotEmpty);
+    final prompt = llm.chatPrompts.last;
+    expect(
+      prompt,
+      contains(kGist),
+      reason: 'the gist card must still inject — expand-off is not journal-off',
+    );
+    expect(
+      prompt,
+      isNot(contains('exact words')),
+      reason:
+          'caption "remember our beach day" + spoken sit-down must not '
+          'expand — journal lastWords is lastSpoken, not captions',
+    );
+  });
+
+  test('LOCK 2: feeling × front-porch swing does not cover-drop', () async {
+    final card = await seedOverflowSession(
+      sessionId: 'sess-gistlock-compound',
+      charDbId: 'char-gistlock-compound',
+      emotion: kEmotion,
+      fixation: kFixation,
+    );
+    await db.insertJournalCard(
+      JournalMemoriesCompanion(
+        sessionId: const Value('sess-gistlock-compound'),
+        characterId: Value(card.stableGroupId),
+        content: const Value(kFrontPorchFeeling),
+        category: const Value('about_us'),
+        heat: const Value(0.9),
+      ),
+    );
+    memory.canned = [
+      RetrievedMemory(
+        content: kFrontPorchSwing,
+        characterId: 'Nia',
+        sessionId: 'sess-gistlock-compound',
+        positionStart: 0,
+        positionEnd: 0,
+        score: 0.9,
+      ),
+    ];
+
+    await chat.sendMessage(kSit);
+
+    expect(
+      memory.retrieveCalls,
+      greaterThan(0),
+      reason: 'cues are present — retrieve must run so cover-drop is real',
+    );
+    expect(llm.chatPrompts, isNotEmpty);
+    final prompt = llm.chatPrompts.last;
+    expect(
+      prompt,
+      contains(kFrontPorchFeeling),
+      reason: 'the feeling card must inject or cover-drop was never tested',
+    );
+    expect(prompt, contains(kRagRememberedHeader.trim()));
+    expect(
+      prompt,
+      contains('swing'),
+      reason:
+          'front porch is one token — feeling × front-porch swing must '
+          'not cover-drop the swing fact',
+    );
+  });
+
+  test(
+    'LOCK 2: same-beat flowerpot gist still cover-drops that window',
+    () async {
+      final card = await seedOverflowSession(
+        sessionId: 'sess-gistlock-cover',
+        charDbId: 'char-gistlock-cover',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-cover'),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.canned = [
+        RetrievedMemory(
+          content: kFactWindow,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-cover',
+          positionStart: 0,
+          positionEnd: 1,
+          score: 0.9,
+        ),
+      ];
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'retrieve ran — a skip would fake the cover-drop',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(kGist),
+        reason: 'same-beat flowerpot gist must inject',
+      );
+      expect(
+        prompt,
+        isNot(contains(kRagRememberedHeader.trim())),
+        reason:
+            'same-beat flowerpot gist still drops the covered RAG window '
+            '— place-compound folding must not disable real cover',
+      );
+      expect(
+        prompt,
+        isNot(contains('You: the spare key lives under the third flowerpot')),
+      );
+    },
+  );
+
+  test(
+    'LOCK 3: plain path strips speaker prefix; quote-reach keeps the raw window',
+    () async {
+      await seedOverflowSession(
+        sessionId: 'sess-gistlock-prefix',
+        charDbId: 'char-gistlock-prefix',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      memory.canned = [
+        RetrievedMemory(
+          content: kSwingLine,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-prefix',
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so the line is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final plain = llm.chatPrompts.last;
+      expect(plain, contains(kRagRememberedHeader.trim()));
+      expect(
+        plain,
+        contains(kSwingBody),
+        reason: 'plain path keeps the remembered body',
+      );
+      expect(
+        plain,
+        isNot(contains(kSwingLine)),
+        reason:
+            'plain path strips the speaker prefix on a single line — '
+            'result is "the swing creaked", not "Nia: the swing creaked"',
+      );
+
+      await chat.sendMessage('remember what you said about the swing?');
+
+      expect(memory.retrieveCalls, greaterThan(1));
+      expect(llm.chatPrompts.length, greaterThan(1));
+      final quoted = llm.chatPrompts.last;
+      expect(quoted, contains(kRagQuoteHeader.trim()));
+      expect(
+        quoted,
+        contains(kSwingLine),
+        reason: 'quote-reach keeps the raw window, prefix included',
       );
     },
   );

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -35,6 +35,13 @@
 // stay off the setting-noun / cover-filler place list, and loved/worry
 // are not a mood-cover list. Refuse leftover-intersection and raw-contains
 // greens as stand-alone.
+//
+// Short leftover is ANY extra content token on the longer side —
+// died/gone/fell/hid/ran count even when length < 5. "the spare key"
+// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat 3 shared
+// distinctive tokens still DROPS (flowerpot gist + "that creaked";
+// two-line lives-under + gist). Covered lines are stripped, not the
+// whole span — flowerpot gist line + "the swing creaked" KEEPS swing.
 
 import 'dart:io';
 
@@ -204,6 +211,17 @@ const kLovedFlowerpot = 'Nia: I loved the spare key under the third flowerpot';
 const kWorry = 'I worry';
 const kWorryFlowerpot =
     'Nia: I worry about the spare key under the third flowerpot';
+const kThirdFlowerpot = 'third flowerpot';
+const kSpareKeyDied = 'Nia: the spare key died';
+const kSpareKeyGone = 'Nia: the spare key is gone';
+const kSpareKeyHid = 'Nia: the spare key hid';
+const kSpareKeyRan = 'Nia: the spare key ran';
+const kThirdFlowerpotFell = 'Nia: the third flowerpot fell';
+const kGistThatCreaked =
+    'Nia: I still think about the spare key under the third flowerpot that creaked';
+const kGistPlusSwing =
+    'Nia: I still think about the spare key under the third flowerpot\n'
+    'Nia: the swing creaked';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -1221,6 +1239,20 @@ void main() {
           'so an uncovered swing line survives the span',
     );
     expect(
+      src.contains('leftover.isEmpty'),
+      isTrue,
+      reason:
+          'leftover is ANY extra content token on the longer side — '
+          'died/gone/fell/hid/ran count even when length < 5',
+    );
+    expect(
+      src.contains('shortD.intersection(longD).length >= 3'),
+      isTrue,
+      reason:
+          'same-beat: 3 shared distinctive tokens still DROPS extras '
+          '(creaked / lives-under). This is not 2-token leftover overlap',
+    );
+    expect(
       src.contains(r"card.split('\n')"),
       isTrue,
       reason:
@@ -1803,6 +1835,253 @@ void main() {
         reason:
             'same-beat flowerpot gist still DROPS — no extra distinctive '
             'leftover. Prefix/mood KEEP above must not disable real cover.',
+      );
+    },
+  );
+
+  test(
+    'LOCK: leftover is any extra content token — died/gone/fell/hid/ran KEEP',
+    () async {
+      const cases = [
+        {
+          'tag': 'died',
+          'card': kFixation,
+          'window': kSpareKeyDied,
+          'kept': 'died',
+        },
+        {
+          'tag': 'gone',
+          'card': kFixation,
+          'window': kSpareKeyGone,
+          'kept': 'gone',
+        },
+        {
+          'tag': 'fell',
+          'card': kThirdFlowerpot,
+          'window': kThirdFlowerpotFell,
+          'kept': 'fell',
+        },
+        {
+          'tag': 'hid',
+          'card': kFixation,
+          'window': kSpareKeyHid,
+          'kept': 'hid',
+        },
+        {
+          'tag': 'ran',
+          'card': kFixation,
+          'window': kSpareKeyRan,
+          'kept': 'ran',
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']!;
+        final cardText = c['card']!;
+        final window = c['window']!;
+        final kept = c['kept']!;
+        final sessionId = 'sess-gistlock-shortleftover-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-shortleftover-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: Value(cardText),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'cues are present — retrieve must run so cover-drop is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(cardText),
+          reason:
+              'the "$cardText" card must inject or leftover KEEP was '
+              'never tested',
+        );
+        expect(prompt, contains(kRagRememberedHeader.trim()));
+        expect(
+          prompt,
+          contains(kept),
+          reason:
+              'leftover is ANY extra content token — "$tag" counts even '
+              'when length < 5. "$cardText" must KEEP "$kept". A length>=5 '
+              'distinctive-only leftover rule goes red here.',
+        );
+      }
+    },
+  );
+
+  test(
+    'LOCK: same-beat 3 distinctive tokens still DROPS extras and lives-under',
+    () async {
+      const cases = [
+        {
+          'tag': 'that creaked',
+          'window': kGistThatCreaked,
+          'absent': 'that creaked',
+        },
+        {
+          'tag': 'two-line lives-under',
+          'window': kFactWindow,
+          'absent': 'You: the spare key lives under the third flowerpot',
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']!;
+        final window = c['window']!;
+        final absent = c['absent']!;
+        final sessionId = 'sess-gistlock-samebeat3-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-samebeat3-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: const Value(kGist),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 1,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'retrieve ran — a skip would fake the cover-drop',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(kGist),
+          reason: 'same-beat flowerpot gist must inject',
+        );
+        expect(
+          prompt,
+          isNot(contains(kRagRememberedHeader.trim())),
+          reason:
+              'same-beat: 3 shared distinctive tokens still DROPS. '
+              'Flowerpot gist x $tag must not re-inject the covered window',
+        );
+        expect(
+          prompt,
+          isNot(contains(absent)),
+          reason:
+              'same-beat flowerpot gist x $tag DROPS — "$absent" must '
+              'not reach the prompt',
+        );
+      }
+    },
+  );
+
+  test(
+    'LOCK: covered lines are stripped — flowerpot gist + swing KEEPS swing',
+    () async {
+      final card = await seedOverflowSession(
+        sessionId: 'sess-gistlock-linestrip',
+        charDbId: 'char-gistlock-linestrip',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-linestrip'),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.canned = [
+        RetrievedMemory(
+          content: kGistPlusSwing,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-linestrip',
+          positionStart: 0,
+          positionEnd: 1,
+          score: 0.9,
+        ),
+      ];
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so line-strip is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(kGist),
+        reason: 'the flowerpot gist must inject or line-strip was never tested',
+      );
+      expect(
+        prompt,
+        contains(kRagRememberedHeader.trim()),
+        reason:
+            'covered lines are stripped, not the whole span — the swing '
+            'line must still inject as a remembered fact',
+      );
+      expect(
+        prompt,
+        contains(kSwingBody),
+        reason:
+            'flowerpot gist line + "the swing creaked" KEEPS the swing. '
+            'Dropping the whole span goes red here.',
+      );
+      expect(
+        prompt,
+        isNot(contains(kGistPlusSwing)),
+        reason:
+            'the covered flowerpot line is stripped — the raw two-line '
+            'span must not reach the prompt',
       );
     },
   );

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -16,6 +16,10 @@
 // New locks (source-scan journal expand, place-compound cover, speaker
 // prefix): still refuse those stand-alone greens. Journal lastWords is
 // scanned at the buildJournalBlock call, not composeRagQuery.
+//
+// Adj+noun place fold (front/back/side + porch/yard/lawn/deck/stoop) and
+// optional-space speaker strip are god-path locks here. A pair list of
+// front/back porch/yard, or a colon that requires a space, goes red.
 
 import 'dart:io';
 
@@ -140,6 +144,13 @@ const kFrontPorchFeeling = 'I felt safe on the front porch tonight';
 const kFrontPorchSwing = 'Nia: the front porch swing creaked tonight';
 const kSwingLine = 'Nia: the swing creaked';
 const kSwingBody = 'the swing creaked';
+const kSidePorchFeeling = 'I felt safe on the side porch tonight';
+const kSidePorchSwing = 'Nia: the side porch swing creaked tonight';
+const kFrontLawnFeeling = 'I felt safe on the front lawn tonight';
+const kFrontLawnSwing = 'Nia: the front lawn swing creaked tonight';
+const kSwingTight = 'Nia:the swing';
+const kSwingSpaced = 'Nia: the swing';
+const kSwingBare = 'the swing';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -687,6 +698,179 @@ void main() {
         quoted,
         contains(kSwingLine),
         reason: 'quote-reach keeps the raw window, prefix included',
+      );
+    },
+  );
+
+  test('LOCK 2: place fold is adj+noun, not a pair list', () {
+    final src = File('lib/services/chat/rag_injection.dart').readAsStringSync();
+    expect(
+      src.contains(r'(front|back|side)\s+(porch|yard|lawn|deck|stoop)'),
+      isTrue,
+      reason:
+          'place fold is adj+noun (front/back/side + porch/yard/lawn/'
+          'deck/stoop) — not two more hardcoded pairs',
+    );
+    expect(
+      src.contains("'front porch':") || src.contains('"front porch":'),
+      isFalse,
+      reason: 'must not be a pair-list of specific compounds',
+    );
+  });
+
+  test(
+    'LOCK 2: side-porch and front-lawn feelings do not cover-drop a swing',
+    () async {
+      const cases = [
+        {
+          'tag': 'side porch',
+          'feeling': kSidePorchFeeling,
+          'swing': kSidePorchSwing,
+        },
+        {
+          'tag': 'front lawn',
+          'feeling': kFrontLawnFeeling,
+          'swing': kFrontLawnSwing,
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']!;
+        final feeling = c['feeling']!;
+        final swing = c['swing']!;
+        final sessionId = 'sess-gistlock-adjnoun-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-adjnoun-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: Value(feeling),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: swing,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'cues are present — retrieve must run so cover-drop is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(feeling),
+          reason:
+              'the $tag feeling card must inject or cover-drop was never tested',
+        );
+        expect(prompt, contains(kRagRememberedHeader.trim()));
+        expect(
+          prompt,
+          contains('swing'),
+          reason:
+              '$tag is adj+noun — feeling × $tag swing must not cover-drop '
+              'the swing fact. A pair list of front/back porch/yard goes red.',
+        );
+      }
+    },
+  );
+
+  test(
+    'LOCK 3: optional colon space strips Nia:the swing; quote-reach stays raw',
+    () async {
+      await seedOverflowSession(
+        sessionId: 'sess-gistlock-colon',
+        charDbId: 'char-gistlock-colon',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+
+      Future<String> sitWith(String raw) async {
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: raw,
+            characterId: 'Nia',
+            sessionId: 'sess-gistlock-colon',
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+        await chat.sendMessage(kSit);
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'cues are present — retrieve must run so the line is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        return llm.chatPrompts.last;
+      }
+
+      final tight = await sitWith(kSwingTight);
+      expect(tight, contains(kRagRememberedHeader.trim()));
+      expect(
+        tight,
+        contains(kSwingBare),
+        reason: 'plain path keeps the remembered body',
+      );
+      expect(
+        tight,
+        isNot(contains(kSwingTight)),
+        reason:
+            'optional space after the colon — "Nia:the swing" must become '
+            '"the swing", same as "Nia: the swing"',
+      );
+      final spaced = await sitWith(kSwingSpaced);
+      expect(spaced, contains(kRagRememberedHeader.trim()));
+      expect(spaced, contains(kSwingBare));
+      expect(
+        spaced,
+        isNot(contains(kSwingSpaced)),
+        reason: '"Nia: the swing" strips to "the swing" on the plain path',
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: kSwingTight,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-colon',
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
+      await chat.sendMessage('remember what you said about the swing?');
+      expect(memory.retrieveCalls, greaterThan(0));
+      expect(llm.chatPrompts, isNotEmpty);
+      final quoted = llm.chatPrompts.last;
+      expect(quoted, contains(kRagQuoteHeader.trim()));
+      expect(
+        quoted,
+        contains(kSwingTight),
+        reason:
+            'quote-reach keeps the raw window, including Nia:the (no space)',
       );
     },
   );

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -38,10 +38,11 @@
 //
 // Short leftover is ANY extra content token on the longer side —
 // died/gone/fell/hid/ran count even when length < 5. "the spare key"
-// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat 3 shared
-// distinctive tokens still DROPS (flowerpot gist + "that creaked";
-// two-line lives-under + gist). Covered lines are stripped, not the
-// whole span — flowerpot gist line + "the swing creaked" KEEPS swing.
+// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat is one
+// leftover word on a 3-distinctive gist (flowerpot gist + "that
+// creaked"; two-line lives-under + gist). Two leftover words are an
+// extra fact (swing creaked; spare keyboard on the flowerpot). Covered
+// lines are stripped and the span remaps onto the kept lines.
 
 import 'dart:io';
 
@@ -1246,11 +1247,25 @@ void main() {
           'died/gone/fell/hid/ran count even when length < 5',
     );
     expect(
-      src.contains('shortD.intersection(longD).length >= 3'),
+      src.contains('leftover.length == 1') &&
+          src.contains('shortD.length >= 3'),
       isTrue,
       reason:
-          'same-beat: 3 shared distinctive tokens still DROPS extras '
-          '(creaked / lives-under). This is not 2-token leftover overlap',
+          'same-beat: one leftover word on a 3-distinctive gist still '
+          'drops (that creaked / lives). Two leftover words are an extra '
+          'fact. This is not 2-token leftover overlap or a 3-token shortcut',
+    );
+    expect(
+      src.contains('shortD.intersection(longD).length >= 3'),
+      isFalse,
+      reason:
+          'the 3-distinctive shortcut ignores extra facts and key vs '
+          'keyboard — leftover count is the same-beat gate',
+    );
+    expect(
+      src.contains('keptIdx') && src.contains('end - start + 1'),
+      isTrue,
+      reason: 'stripped windows remap positionStart/End onto the kept lines',
     );
     expect(
       src.contains(r"card.split('\n')"),

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -223,6 +223,10 @@ const kGistThatCreaked =
 const kGistPlusSwing =
     'Nia: I still think about the spare key under the third flowerpot\n'
     'Nia: the swing creaked';
+const kFlowerpotAndSwing =
+    'Nia: the spare key under the third flowerpot and the swing creaked';
+const kKeyboardOnFlowerpot =
+    'Nia: the spare keyboard sits on the third flowerpot';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -2097,6 +2101,254 @@ void main() {
         reason:
             'the covered flowerpot line is stripped — the raw two-line '
             'span must not reach the prompt',
+      );
+    },
+  );
+
+  test(
+    'LOCK: two leftover words STAY — swing creaked / spare keyboard',
+    () async {
+      Set<String> distinctive(String s) => {
+        for (final w in coverContentTokens(s))
+          if (w.length >= 5 &&
+              !const {
+                'felt',
+                'safe',
+                'still',
+                'think',
+                'about',
+                'remember',
+              }.contains(w))
+            w,
+      };
+      expect(
+        distinctive(kGist).intersection(distinctive(kFlowerpotAndSwing)).length,
+        greaterThanOrEqualTo(3),
+        reason:
+            '3 shared distinctive tokens is the shortcut hole — that '
+            'match is not a green. Leftover count 2 (swing + creaked) '
+            'must KEEP',
+      );
+      expect(
+        distinctive(
+          kGist,
+        ).intersection(distinctive(kKeyboardOnFlowerpot)).length,
+        greaterThanOrEqualTo(3),
+        reason:
+            'spare+third+flowerpot is the 3-token shortcut hole — key '
+            'is not keyboard. That intersection is not a green',
+      );
+      expect(
+        'keyboard'.contains('key'),
+        isTrue,
+        reason:
+            'raw contains() of key inside keyboard is the other hole — '
+            'that match is not a green',
+      );
+
+      const cases = [
+        {
+          'tag': 'flowerpot and the swing creaked',
+          'window': kFlowerpotAndSwing,
+          'kept': 'swing',
+        },
+        {
+          'tag': 'spare keyboard sits on the third flowerpot',
+          'window': kKeyboardOnFlowerpot,
+          'kept': 'keyboard',
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']!;
+        final window = c['window']!;
+        final kept = c['kept']!;
+        final sessionId = 'sess-gistlock-twoleftover-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-twoleftover-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: const Value(kGist),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason:
+              'cues are present — retrieve must run so leftover KEEP is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(kGist),
+          reason:
+              'the flowerpot gist must inject or leftover KEEP was never tested',
+        );
+        expect(prompt, contains(kRagRememberedHeader.trim()));
+        expect(
+          prompt,
+          contains(kept),
+          reason:
+              'same-beat is leftover count 1, not a 3-distinctive shortcut. '
+              'Two leftover words STAY — "$tag" must KEEP "$kept". '
+              'Reverting to intersection>=3 drops this extra fact.',
+        );
+      }
+    },
+  );
+
+  test(
+    'LOCK: stripped span remaps pos — receipt skips the flowerpot line',
+    () async {
+      const sessionId = 'sess-gistlock-remap';
+      const flowerpotPos = 2;
+      const swingPos = 3;
+      final card = await seedOverflowSession(
+        sessionId: sessionId,
+        charDbId: 'char-gistlock-remap',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value(sessionId),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      final canned = RetrievedMemory(
+        content: kGistPlusSwing,
+        characterId: 'Nia',
+        sessionId: sessionId,
+        positionStart: flowerpotPos,
+        positionEnd: swingPos,
+        score: 0.9,
+      );
+      memory.canned = [canned];
+
+      final remapped = dropCoveredRagWindows([canned], [kGist]);
+      expect(remapped, hasLength(1));
+      expect(
+        remapped.first.positionStart,
+        swingPos,
+        reason:
+            'span 2–3 matches the two-line window — kept swing remaps '
+            'onto pos 3, not the stripped flowerpot pos 2',
+      );
+      expect(remapped.first.positionEnd, swingPos);
+      expect(remapped.first.content, contains(kSwingBody));
+      expect(remapped.first.content, isNot(contains('flowerpot')));
+      expect(
+        RetrievedMemory.excludingPositions(remapped, {
+          flowerpotPos,
+        }, currentSessionId: sessionId),
+        hasLength(1),
+        reason:
+            'receipt / excludingPositions no longer treat the removed '
+            'flowerpot pos as this retrieval',
+      );
+      expect(
+        RetrievedMemory.excludingPositions(
+          [canned],
+          {flowerpotPos},
+          currentSessionId: sessionId,
+        ),
+        isEmpty,
+        reason:
+            'the unstripped 2–3 span still overlaps the flowerpot line — '
+            'remap is what keeps the swing',
+      );
+      final receiptFromRemap = buildRagReceipt(
+        found: 1,
+        journalDeduped: 0,
+        budgetTrimmed: 0,
+        injected: remapped,
+        days: {remapped.first: null},
+        currentSessionId: sessionId,
+      );
+      expect(
+        ((receiptFromRemap['injected'] as List).single as Map)['pos'],
+        swingPos,
+        reason: 'receipt pos is the remapped swing line, not flowerpot pos 2',
+      );
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so remap is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(kGist),
+        reason: 'the flowerpot gist must inject or remap was never tested',
+      );
+      expect(
+        prompt,
+        contains(kRagRememberedHeader.trim()),
+        reason: 'the swing line must still inject as a remembered fact',
+      );
+      expect(prompt, contains(kSwingBody));
+      expect(prompt, isNot(contains(kGistPlusSwing)));
+
+      final receipt = chat.lastRagReceipt;
+      expect(
+        receipt,
+        isNotNull,
+        reason: 'a kept swing line must stamp a receipt on the god path',
+      );
+      final injected = receipt!['injected'] as List;
+      expect(injected, isNotEmpty);
+      final row = injected.first as Map;
+      expect(
+        row['pos'],
+        swingPos,
+        reason:
+            'god-path receipt must report the remapped swing pos — the '
+            'removed flowerpot pos is no longer this retrieval',
+      );
+      expect(
+        row['pos'],
+        isNot(equals(flowerpotPos)),
+        reason: 'unstripped pos 2 on the receipt is the regression',
+      );
+      final preview = row['preview'] as String;
+      expect(preview, contains('swing'));
+      expect(
+        preview,
+        isNot(contains('flowerpot')),
+        reason:
+            'receipt preview is the kept swing line, not the stripped '
+            'flowerpot span',
       );
     },
   );

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -17,9 +17,9 @@
 // prefix): still refuse those stand-alone greens. Journal lastWords is
 // scanned at the buildJournalBlock call, not composeRagQuery.
 //
-// Adj+noun place fold (front/back/side + porch/yard/lawn/deck/stoop) and
-// optional-space speaker strip are god-path locks here. A pair list of
-// front/back porch/yard, or a colon that requires a space, goes red.
+// Any-token-before-place-noun fold (porch/yard/lawn/deck/stoop) and
+// optional-space speaker strip are god-path locks here. An adj list of
+// front/back/side, a pair list, or a colon that requires a space, goes red.
 
 import 'dart:io';
 
@@ -148,6 +148,8 @@ const kSidePorchFeeling = 'I felt safe on the side porch tonight';
 const kSidePorchSwing = 'Nia: the side porch swing creaked tonight';
 const kFrontLawnFeeling = 'I felt safe on the front lawn tonight';
 const kFrontLawnSwing = 'Nia: the front lawn swing creaked tonight';
+const kScreenedPorchFeeling = 'I felt safe on the screened porch tonight';
+const kScreenedPorchSwing = 'Nia: the screened porch swing creaked tonight';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
@@ -702,14 +704,19 @@ void main() {
     },
   );
 
-  test('LOCK 2: place fold is adj+noun, not a pair list', () {
+  test('LOCK 2: place fold is any token before a place noun', () {
     final src = File('lib/services/chat/rag_injection.dart').readAsStringSync();
     expect(
-      src.contains(r'(front|back|side)\s+(porch|yard|lawn|deck|stoop)'),
+      src.contains(r'(\w+)\s+(porch|yard|lawn|deck|stoop)'),
       isTrue,
       reason:
-          'place fold is adj+noun (front/back/side + porch/yard/lawn/'
-          'deck/stoop) — not two more hardcoded pairs',
+          'fold ANY token immediately before porch/yard/lawn/deck/stoop '
+          '— not an adj list and not a pair list',
+    );
+    expect(
+      src.contains(r'(front|back|side)'),
+      isFalse,
+      reason: 'must not be an adj list of front/back/side (or screened)',
     );
     expect(
       src.contains("'front porch':") || src.contains('"front porch":'),
@@ -731,6 +738,11 @@ void main() {
           'tag': 'front lawn',
           'feeling': kFrontLawnFeeling,
           'swing': kFrontLawnSwing,
+        },
+        {
+          'tag': 'screened porch',
+          'feeling': kScreenedPorchFeeling,
+          'swing': kScreenedPorchSwing,
         },
       ];
       for (var i = 0; i < cases.length; i++) {

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -36,13 +36,9 @@
 // are not a mood-cover list. Refuse leftover-intersection and raw-contains
 // greens as stand-alone.
 //
-// Short leftover is ANY extra content token on the longer side —
-// died/gone/fell/hid/ran count even when length < 5. Leftover kind,
-// not position: short leftover and long distinctive leftover are extra
-// facts (any slot). Length 5-6 distinctive leftover is restatement
-// (any slot). leftover-empty is same-beat DROP. endsWith ned so burned
-// stays extra fact vs tucked/buried. Covered lines strip into
-// contiguous runs; each run remaps its span.
+// Joe lock: DROP only when leftover is empty. Anything with leftover
+// KEEP. No length band, position, paraphrase list, or ned exception.
+// Covered lines strip into contiguous runs; each run remaps its span.
 
 import 'dart:io';
 
@@ -160,6 +156,8 @@ const kGist = 'I still think about the spare key under the third flowerpot';
 const kEmotion = 'wistful';
 const kFixation = 'the spare key';
 const kSit = 'Evening. Mind if I sit?';
+const kGistWindow =
+    'Nia: I still think about the spare key under the third flowerpot';
 const kFactWindow =
     'You: the spare key lives under the third flowerpot\n'
     'Nia: I still think about the spare key under the third flowerpot';
@@ -495,7 +493,7 @@ void main() {
 
       memory.canned = [
         RetrievedMemory(
-          content: kFactWindow,
+          content: kGistWindow,
           characterId: 'Nia',
           sessionId: 'sess-gistlock-caption',
           positionStart: 0,
@@ -727,7 +725,7 @@ void main() {
       );
       memory.canned = [
         RetrievedMemory(
-          content: kFactWindow,
+          content: kGistWindow,
           characterId: 'Nia',
           sessionId: 'sess-gistlock-cover',
           positionStart: 0,
@@ -1108,7 +1106,7 @@ void main() {
     memory.retrieveCalls = 0;
     memory.canned = [
       RetrievedMemory(
-        content: kFactWindow,
+        content: kGistWindow,
         characterId: 'Nia',
         sessionId: 'sess-gistlock-anytoken-flower',
         positionStart: 0,
@@ -1294,12 +1292,11 @@ void main() {
           'died/gone/fell/hid/ran count even when length < 5',
     );
     expect(
-      src.contains('_isExtraFactLeftover') && src.contains('leftover'),
-      isTrue,
+      src.contains('_isExtraFactLeftover') || src.contains("endsWith('ned')"),
+      isFalse,
       reason:
-          'leftover kind, not position: short leftover and long distinctive '
-          'leftover are extra facts. Length 5-6 distinctive leftover is '
-          'restatement. No paraphrase verb list',
+          'Joe lock: leftover-empty only. No length-as-kind, no ned, '
+          'no extra-fact leftover helper',
     );
     expect(
       src.contains('_minCoverWindow'),
@@ -1342,16 +1339,13 @@ void main() {
         isFalse,
         reason:
             'no verb list — "$w" must not appear as a product string. '
-            'Length 5-6 distinctive leftover DROPS and long leftover KEEPS '
-            'without naming hidden/tucked/buried/stays/rests/lives',
+            'leftover-empty DROPS and leftover KEEP without naming those words',
       );
     }
     expect(
-      src.contains("endsWith('ned')"),
-      isTrue,
-      reason:
-          'burned (6) stays extra fact vs tucked/buried — kind uses '
-          "endsWith('ned'), not a burned list",
+      src.contains("endsWith('ned')") || src.contains('_isExtraFactLeftover'),
+      isFalse,
+      reason: 'no ned exception and no length-as-kind helper',
     );
     expect(
       src.contains('_kTimeFiller') &&
@@ -1587,7 +1581,7 @@ void main() {
       memory.retrieveCalls = 0;
       memory.canned = [
         RetrievedMemory(
-          content: kFactWindow,
+          content: kGistWindow,
           characterId: 'Nia',
           sessionId: 'sess-gistlock-flower-why',
           positionStart: 0,
@@ -1780,7 +1774,7 @@ void main() {
     memory.retrieveCalls = 0;
     memory.canned = [
       RetrievedMemory(
-        content: kFactWindow,
+        content: kGistWindow,
         characterId: 'Nia',
         sessionId: 'sess-gistlock-moodstem-flower',
         positionStart: 0,
@@ -1995,7 +1989,7 @@ void main() {
       memory.retrieveCalls = 0;
       memory.canned = [
         RetrievedMemory(
-          content: kFactWindow,
+          content: kGistWindow,
           characterId: 'Nia',
           sessionId: 'sess-gistlock-prefixleftover-flower',
           positionStart: 0,
@@ -2126,89 +2120,80 @@ void main() {
     },
   );
 
-  test(
-    'LOCK: same-beat 3 distinctive tokens still DROPS extras and lives-under',
-    () async {
-      const cases = [
-        {
-          'tag': 'two-line lives-under',
-          'window': kFactWindow,
-          'absent': 'You: the spare key lives under the third flowerpot',
-        },
-        {
-          'tag': 'tucked under',
-          'window': 'Nia: the spare key tucked under the third flowerpot',
-          'absent': 'tucked',
-        },
-        {'tag': 'buried under', 'window': kBuriedUnder, 'absent': 'buried'},
-        {'tag': 'stays under', 'window': kStaysUnder, 'absent': 'stays'},
-        {'tag': 'rests under', 'window': kRestsUnder, 'absent': 'rests'},
-      ];
-      for (var i = 0; i < cases.length; i++) {
-        final c = cases[i];
-        final tag = c['tag']!;
-        final window = c['window']!;
-        final absent = c['absent']!;
-        final sessionId = 'sess-gistlock-samebeat3-$i';
-        final card = await seedOverflowSession(
+  test('LOCK: leftover-empty only — tucked / lives-under KEEP', () async {
+    const cases = [
+      {
+        'tag': 'two-line lives-under',
+        'window': kFactWindow,
+        'absent': 'lives',
+      },
+      {
+        'tag': 'tucked under',
+        'window': 'Nia: the spare key tucked under the third flowerpot',
+        'absent': 'tucked',
+      },
+      {'tag': 'buried under', 'window': kBuriedUnder, 'absent': 'buried'},
+      {'tag': 'stays under', 'window': kStaysUnder, 'absent': 'stays'},
+      {'tag': 'rests under', 'window': kRestsUnder, 'absent': 'rests'},
+    ];
+    for (var i = 0; i < cases.length; i++) {
+      final c = cases[i];
+      final tag = c['tag']!;
+      final window = c['window']!;
+      final absent = c['absent']!;
+      final sessionId = 'sess-gistlock-samebeat3-$i';
+      final card = await seedOverflowSession(
+        sessionId: sessionId,
+        charDbId: 'char-gistlock-samebeat3-$i',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: Value(sessionId),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: window,
+          characterId: 'Nia',
           sessionId: sessionId,
-          charDbId: 'char-gistlock-samebeat3-$i',
-          emotion: kEmotion,
-          fixation: kFixation,
-        );
-        await db.insertJournalCard(
-          JournalMemoriesCompanion(
-            sessionId: Value(sessionId),
-            characterId: Value(card.stableGroupId),
-            content: const Value(kGist),
-            category: const Value('about_us'),
-            heat: const Value(0.9),
-          ),
-        );
-        memory.retrieveCalls = 0;
-        memory.canned = [
-          RetrievedMemory(
-            content: window,
-            characterId: 'Nia',
-            sessionId: sessionId,
-            positionStart: 0,
-            positionEnd: 1,
-            score: 0.9,
-          ),
-        ];
-        llm.chatPrompts.clear();
+          positionStart: 0,
+          positionEnd: 1,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
 
-        await chat.sendMessage(kSit);
+      await chat.sendMessage(kSit);
 
-        expect(
-          memory.retrieveCalls,
-          greaterThan(0),
-          reason: 'retrieve ran — a skip would fake the cover-drop',
-        );
-        expect(llm.chatPrompts, isNotEmpty);
-        final prompt = llm.chatPrompts.last;
-        expect(
-          prompt,
-          contains(kGist),
-          reason: 'same-beat flowerpot gist must inject',
-        );
-        expect(
-          prompt,
-          isNot(contains(kRagRememberedHeader.trim())),
-          reason:
-              'same-beat: 3 shared distinctive tokens still DROPS. '
-              'Flowerpot gist x $tag must not re-inject the covered window',
-        );
-        expect(
-          prompt,
-          isNot(contains(absent)),
-          reason:
-              'same-beat flowerpot gist x $tag DROPS — "$absent" must '
-              'not reach the prompt',
-        );
-      }
-    },
-  );
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'retrieve ran — a skip would fake the cover-drop',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(kGist),
+        reason: 'same-beat flowerpot gist must inject',
+      );
+      expect(prompt, contains(kRagRememberedHeader.trim()));
+      expect(
+        prompt,
+        contains(absent),
+        reason:
+            'leftover-empty only — "$tag" has leftover so KEEP. '
+            '"$absent" must reach the prompt',
+      );
+    }
+  });
 
   test(
     'LOCK: covered lines are stripped — flowerpot gist + swing KEEPS swing',
@@ -2526,7 +2511,7 @@ void main() {
   );
 
   test(
-    'LOCK: leftover kind — burned / lighthouse KEEP; lives hidden DROPS',
+    'LOCK: leftover-empty only — burned / lighthouse / lives hidden KEEP',
     () async {
       Set<String> bodyTokens(String s) =>
           coverContentTokens(s.replaceFirst(RegExp(r'^[^:\n]{1,40}:\s*'), ''));
@@ -2589,7 +2574,7 @@ void main() {
           'card': kGist,
           'window': kLivesHidden,
           'kept': 'hidden',
-          'drop': true,
+          'drop': false,
         },
         {
           'tag': 'that creaked',
@@ -2678,16 +2663,13 @@ void main() {
             prompt,
             isNot(contains(kRagRememberedHeader.trim())),
             reason:
-                'same-beat is leftover-empty or length 5-6 distinctive '
-                'leftover (any slot) — no closed paraphrase/verb list. '
-                '"$tag" must DROP. A verb list of lives/hidden/creaked '
-                'or leftover==1/==2 is fake-green',
+                'leftover-empty only — "$tag" must DROP only if leftover '
+                'is empty. A length band or verb list is fake-green',
           );
           expect(
             prompt,
             isNot(contains(window)),
-            reason:
-                'lives hidden still DROPS — "$window" must not reach the prompt',
+            reason: 'leftover-empty only — "$window" must not reach the prompt',
           );
         } else {
           expect(prompt, contains(kRagRememberedHeader.trim()));
@@ -3011,263 +2993,257 @@ void main() {
     },
   );
 
-  test(
-    'LOCK: leftover kind any slot — suffix hidden DROP; interior burned KEEP; prefix hid KEEP',
-    () async {
-      Set<String> bodyTokens(String s) =>
-          coverContentTokens(s.replaceFirst(RegExp(r'^[^:\n]{1,40}:\s*'), ''));
-      expect(
-        bodyTokens(kSuffixHidden).difference(bodyTokens(kGist)),
-        {'hidden'},
-        reason:
-            'suffix hidden is the 9e61 hole — suffix leftover used to KEEP. '
-            'Length 5-6 distinctive leftover is restatement, any slot',
-      );
-      expect(
-        bodyTokens(kInteriorBurned).difference(bodyTokens(kGist)),
-        {'burned'},
-        reason:
-            'interior burned is the 9e61 hole — interior leftover used to '
-            'DROP. endsWith ned keeps burned as an extra fact, any slot',
-      );
-      expect(
-        bodyTokens(kPrefixHid).difference(bodyTokens(kGist)),
-        {'hid'},
-        reason:
-            'prefix hid is the 9e61 hole — short prefix used to DROP. '
-            'Short leftover is an extra fact, any slot',
-      );
-      expect(
-        bodyTokens(kPrefixHidden).difference(bodyTokens(kGist)),
-        {'hidden'},
-        reason:
-            'prefix hidden is the 9e61 hole — distinctive prefix used to '
-            'KEEP. Length 5-6 distinctive leftover is restatement, any slot',
-      );
+  test('LOCK: leftover-empty only — any leftover KEEP, any slot', () async {
+    Set<String> bodyTokens(String s) =>
+        coverContentTokens(s.replaceFirst(RegExp(r'^[^:\n]{1,40}:\s*'), ''));
+    expect(
+      bodyTokens(kSuffixHidden).difference(bodyTokens(kGist)),
+      {'hidden'},
+      reason:
+          'suffix hidden is the 9e61 hole — suffix leftover used to KEEP. '
+          'Length 5-6 distinctive leftover is restatement, any slot',
+    );
+    expect(
+      bodyTokens(kInteriorBurned).difference(bodyTokens(kGist)),
+      {'burned'},
+      reason:
+          'interior burned is the 9e61 hole — interior leftover used to '
+          'DROP. endsWith ned keeps burned as an extra fact, any slot',
+    );
+    expect(
+      bodyTokens(kPrefixHid).difference(bodyTokens(kGist)),
+      {'hid'},
+      reason:
+          'prefix hid is the 9e61 hole — short prefix used to DROP. '
+          'Short leftover is an extra fact, any slot',
+    );
+    expect(
+      bodyTokens(kPrefixHidden).difference(bodyTokens(kGist)),
+      {'hidden'},
+      reason:
+          'prefix hidden is the 9e61 hole — distinctive prefix used to '
+          'KEEP. Length 5-6 distinctive leftover is restatement, any slot',
+    );
 
-      const cases = [
-        {
-          'tag': 'suffix hidden',
-          'card': kGist,
-          'window': kSuffixHidden,
-          'kept': 'hidden',
-          'drop': true,
-        },
-        {
-          'tag': 'suffix tucked',
-          'card': kGist,
-          'window': kSuffixTucked,
-          'kept': 'tucked',
-          'drop': true,
-        },
-        {
-          'tag': 'suffix buried',
-          'card': kGist,
-          'window': kSuffixBuried,
-          'kept': 'buried',
-          'drop': true,
-        },
-        {
-          'tag': 'suffix stays',
-          'card': kGist,
-          'window': kSuffixStays,
-          'kept': 'stays',
-          'drop': true,
-        },
-        {
-          'tag': 'suffix rests',
-          'card': kGist,
-          'window': kSuffixRests,
-          'kept': 'rests',
-          'drop': true,
-        },
-        {
-          'tag': 'suffix lives',
-          'card': kGist,
-          'window': kSuffixLives,
-          'kept': 'lives',
-          'drop': true,
-        },
-        {
-          'tag': 'suffix lives-hidden',
-          'card': kGist,
-          'window': kSuffixLivesHidden,
-          'kept': 'hidden',
-          'drop': true,
-        },
-        {
-          'tag': 'interior burned',
-          'card': kGist,
-          'window': kInteriorBurned,
-          'kept': 'burned',
-          'drop': false,
-        },
-        {
-          'tag': 'interior lighthouse',
-          'card': kGist,
-          'window': kInteriorLighthouse,
-          'kept': 'lighthouse',
-          'drop': false,
-        },
-        {
-          'tag': 'interior creaked',
-          'card': kGist,
-          'window': kInteriorCreaked,
-          'kept': 'creaked',
-          'drop': false,
-        },
-        {
-          'tag': 'interior died',
-          'card': kGist,
-          'window': kInteriorDied,
-          'kept': 'died',
-          'drop': false,
-        },
-        {
-          'tag': 'interior sat',
-          'card': kGist,
-          'window': kInteriorSat,
-          'kept': 'sat',
-          'drop': false,
-        },
-        {
-          'tag': 'interior fell',
-          'card': kGist,
-          'window': kInteriorFell,
-          'kept': 'fell',
-          'drop': false,
-        },
-        {
-          'tag': 'interior hid',
-          'card': kGist,
-          'window': kInteriorHid,
-          'kept': 'hid',
-          'drop': false,
-        },
-        {
-          'tag': 'prefix hid',
-          'card': kGist,
-          'window': kPrefixHid,
-          'kept': 'hid',
-          'drop': false,
-        },
-        {
-          'tag': 'prefix sat',
-          'card': kGist,
-          'window': kPrefixSat,
-          'kept': 'sat',
-          'drop': false,
-        },
-        {
-          'tag': 'prefix died',
-          'card': kGist,
-          'window': kPrefixDied,
-          'kept': 'died',
-          'drop': false,
-        },
-        {
-          'tag': 'prefix hidden',
-          'card': kGist,
-          'window': kPrefixHidden,
-          'kept': 'hidden',
-          'drop': true,
-        },
-        {
-          'tag': 'prefix tucked',
-          'card': kGist,
-          'window': kPrefixTucked,
-          'kept': 'tucked',
-          'drop': true,
-        },
-        {
-          'tag': 'sat-on-porch',
-          'card': kThePorchSwing,
-          'window': kSatOnPorch,
-          'kept': 'sat',
-          'drop': false,
-        },
-      ];
-      for (var i = 0; i < cases.length; i++) {
-        final c = cases[i];
-        final tag = c['tag']! as String;
-        final cardText = c['card']! as String;
-        final window = c['window']! as String;
-        final kept = c['kept']! as String;
-        final drop = c['drop']! as bool;
-        final sessionId = 'sess-gistlock-anyslot-$i';
-        final card = await seedOverflowSession(
+    const cases = [
+      {
+        'tag': 'suffix hidden',
+        'card': kGist,
+        'window': kSuffixHidden,
+        'kept': 'hidden',
+        'drop': false,
+      },
+      {
+        'tag': 'suffix tucked',
+        'card': kGist,
+        'window': kSuffixTucked,
+        'kept': 'tucked',
+        'drop': false,
+      },
+      {
+        'tag': 'suffix buried',
+        'card': kGist,
+        'window': kSuffixBuried,
+        'kept': 'buried',
+        'drop': false,
+      },
+      {
+        'tag': 'suffix stays',
+        'card': kGist,
+        'window': kSuffixStays,
+        'kept': 'stays',
+        'drop': false,
+      },
+      {
+        'tag': 'suffix rests',
+        'card': kGist,
+        'window': kSuffixRests,
+        'kept': 'rests',
+        'drop': false,
+      },
+      {
+        'tag': 'suffix lives',
+        'card': kGist,
+        'window': kSuffixLives,
+        'kept': 'lives',
+        'drop': false,
+      },
+      {
+        'tag': 'suffix lives-hidden',
+        'card': kGist,
+        'window': kSuffixLivesHidden,
+        'kept': 'hidden',
+        'drop': false,
+      },
+      {
+        'tag': 'interior burned',
+        'card': kGist,
+        'window': kInteriorBurned,
+        'kept': 'burned',
+        'drop': false,
+      },
+      {
+        'tag': 'interior lighthouse',
+        'card': kGist,
+        'window': kInteriorLighthouse,
+        'kept': 'lighthouse',
+        'drop': false,
+      },
+      {
+        'tag': 'interior creaked',
+        'card': kGist,
+        'window': kInteriorCreaked,
+        'kept': 'creaked',
+        'drop': false,
+      },
+      {
+        'tag': 'interior died',
+        'card': kGist,
+        'window': kInteriorDied,
+        'kept': 'died',
+        'drop': false,
+      },
+      {
+        'tag': 'interior sat',
+        'card': kGist,
+        'window': kInteriorSat,
+        'kept': 'sat',
+        'drop': false,
+      },
+      {
+        'tag': 'interior fell',
+        'card': kGist,
+        'window': kInteriorFell,
+        'kept': 'fell',
+        'drop': false,
+      },
+      {
+        'tag': 'interior hid',
+        'card': kGist,
+        'window': kInteriorHid,
+        'kept': 'hid',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix hid',
+        'card': kGist,
+        'window': kPrefixHid,
+        'kept': 'hid',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix sat',
+        'card': kGist,
+        'window': kPrefixSat,
+        'kept': 'sat',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix died',
+        'card': kGist,
+        'window': kPrefixDied,
+        'kept': 'died',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix hidden',
+        'card': kGist,
+        'window': kPrefixHidden,
+        'kept': 'hidden',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix tucked',
+        'card': kGist,
+        'window': kPrefixTucked,
+        'kept': 'tucked',
+        'drop': false,
+      },
+      {
+        'tag': 'sat-on-porch',
+        'card': kThePorchSwing,
+        'window': kSatOnPorch,
+        'kept': 'sat',
+        'drop': false,
+      },
+    ];
+    for (var i = 0; i < cases.length; i++) {
+      final c = cases[i];
+      final tag = c['tag']! as String;
+      final cardText = c['card']! as String;
+      final window = c['window']! as String;
+      final kept = c['kept']! as String;
+      final drop = c['drop']! as bool;
+      final sessionId = 'sess-gistlock-anyslot-$i';
+      final card = await seedOverflowSession(
+        sessionId: sessionId,
+        charDbId: 'char-gistlock-anyslot-$i',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: Value(sessionId),
+          characterId: Value(card.stableGroupId),
+          content: Value(cardText),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: window,
+          characterId: 'Nia',
           sessionId: sessionId,
-          charDbId: 'char-gistlock-anyslot-$i',
-          emotion: kEmotion,
-          fixation: kFixation,
-        );
-        await db.insertJournalCard(
-          JournalMemoriesCompanion(
-            sessionId: Value(sessionId),
-            characterId: Value(card.stableGroupId),
-            content: Value(cardText),
-            category: const Value('about_us'),
-            heat: const Value(0.9),
-          ),
-        );
-        memory.retrieveCalls = 0;
-        memory.canned = [
-          RetrievedMemory(
-            content: window,
-            characterId: 'Nia',
-            sessionId: sessionId,
-            positionStart: 0,
-            positionEnd: 0,
-            score: 0.9,
-          ),
-        ];
-        llm.chatPrompts.clear();
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
 
-        await chat.sendMessage(kSit);
+      await chat.sendMessage(kSit);
 
-        expect(
-          memory.retrieveCalls,
-          greaterThan(0),
-          reason:
-              'cues are present — retrieve must run so leftover kind is real',
-        );
-        expect(llm.chatPrompts, isNotEmpty);
-        final prompt = llm.chatPrompts.last;
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so leftover kind is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(cardText),
+        reason:
+            'the "$cardText" card must inject or leftover kind was '
+            'never tested',
+      );
+      if (drop) {
         expect(
           prompt,
-          contains(cardText),
+          isNot(contains(kRagRememberedHeader.trim())),
           reason:
-              'the "$cardText" card must inject or leftover kind was '
-              'never tested',
+              'leftover-empty only — "$tag" must DROP only if leftover '
+              'is empty. A length band or verb list is fake-green',
         );
-        if (drop) {
-          expect(
-            prompt,
-            isNot(contains(kRagRememberedHeader.trim())),
-            reason:
-                'position is not kind — length 5-6 distinctive leftover '
-                'is restatement in any slot. "$tag" must DROP. A suffix-KEEP '
-                'or prefix-KEEP rule, or a hidden/tucked verb list, is '
-                'fake-green',
-          );
-          expect(
-            prompt,
-            isNot(contains(window)),
-            reason: '"$tag" still DROPS — "$window" must not reach the prompt',
-          );
-        } else {
-          expect(prompt, contains(kRagRememberedHeader.trim()));
-          expect(
-            prompt,
-            contains(kept),
-            reason:
-                'position is not kind — short leftover and long distinctive '
-                'leftover are extra facts in any slot. "$tag" must KEEP '
-                '"$kept". Interior-DROP, short-prefix-DROP, or sat-on-porch '
-                'DROP goes red here',
-          );
-        }
+        expect(
+          prompt,
+          isNot(contains(window)),
+          reason: '"$tag" still DROPS — "$window" must not reach the prompt',
+        );
+      } else {
+        expect(prompt, contains(kRagRememberedHeader.trim()));
+        expect(
+          prompt,
+          contains(kept),
+          reason:
+              'position is not kind — short leftover and long distinctive '
+              'leftover are extra facts in any slot. "$tag" must KEEP '
+              '"$kept". Interior-DROP, short-prefix-DROP, or sat-on-porch '
+              'DROP goes red here',
+        );
       }
-    },
-  );
+    }
+  });
 }

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -161,6 +161,10 @@ const kFrontStepsFeeling = 'I felt safe on the front steps tonight';
 const kFrontStepsSwing = 'Nia: the front steps swing creaked tonight';
 const kBackPatioFeeling = 'I felt safe on the back patio tonight';
 const kBackPatioSwing = 'Nia: the back patio swing creaked tonight';
+const kFrontWalkFeeling = 'I felt safe on the front walk tonight';
+const kFrontWalkSwing = 'Nia: the front walk swing creaked tonight';
+const kBackPathFeeling = 'I felt safe on the back path tonight';
+const kBackPathSwing = 'Nia: the back path swing creaked tonight';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
@@ -742,7 +746,11 @@ void main() {
           'set MUST FAIL — the product must not be that restricted list',
     );
     expect(
-      src.contains("'this'") && src.contains("'on'"),
+      src.contains("'this'") &&
+          src.contains("'my'") &&
+          src.contains("'our'") &&
+          src.contains("'your'") &&
+          src.contains("'on'"),
       isTrue,
       reason:
           'this/my/our/your/on stay particles — do not fold thisporch/onporch',
@@ -750,7 +758,8 @@ void main() {
     expect(
       src.contains("'steps'") &&
           src.contains("'patio'") &&
-          src.contains("'walk'"),
+          src.contains("'walk'") &&
+          src.contains("'path'"),
       isTrue,
       reason: 'setting nouns are cover filler — not a longer fold-noun list',
     );
@@ -789,6 +798,16 @@ void main() {
           'tag': 'back patio',
           'feeling': kBackPatioFeeling,
           'swing': kBackPatioSwing,
+        },
+        {
+          'tag': 'front walk',
+          'feeling': kFrontWalkFeeling,
+          'swing': kFrontWalkSwing,
+        },
+        {
+          'tag': 'back path',
+          'feeling': kBackPathFeeling,
+          'swing': kBackPathSwing,
         },
       ];
       for (var i = 0; i < cases.length; i++) {

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -1134,7 +1134,7 @@ void main() {
     },
   );
 
-  test('LOCK: cover-drop is near-substring, not leftover 2-token overlap', () {
+  test('LOCK: cover-drop is whole-token subset plus a distinctive word', () {
     final src = File('lib/services/chat/rag_injection.dart').readAsStringSync();
     final dropAt = src.indexOf('List<RetrievedMemory> dropCoveredRagWindows');
     expect(
@@ -1159,10 +1159,17 @@ void main() {
     );
     expect(
       nearSlice.contains('longer.contains(shorter)'),
+      isFalse,
+      reason:
+          'unanchored contains() is the key⊂keyboard hole — cover is '
+          'whole-token subset plus a distinctive word',
+    );
+    expect(
+      src.contains('_kJournalBoilerplate') && src.contains('containsAll'),
       isTrue,
       reason:
-          'cover is a near-substring — longer.contains(shorter) after '
-          'normalize. A leftover-token intersection is not this lock.',
+          'shorter must have a distinctive token (length ≥ 5, not '
+          'felt/safe/still/think/about/remember) and be a whole-token subset',
     );
     expect(
       nearSlice.contains('.intersection('),

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -38,11 +38,10 @@
 //
 // Short leftover is ANY extra content token on the longer side —
 // died/gone/fell/hid/ran count even when length < 5. "the spare key"
-// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat is one
-// leftover word on a 3-distinctive gist (flowerpot gist + "that
-// creaked"; two-line lives-under + gist). Two leftover words are an
-// extra fact (swing creaked; spare keyboard on the flowerpot). Covered
-// lines are stripped and the span remaps onto the kept lines.
+// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat leftover is
+// a closed paraphrase set (lives / hidden / creaked), not leftover==1.
+// Distinctive leftover is an extra fact (burned, lighthouse, swing).
+// Covered lines strip into contiguous runs; each run remaps its span.
 
 import 'dart:io';
 
@@ -1251,13 +1250,18 @@ void main() {
           'died/gone/fell/hid/ran count even when length < 5',
     );
     expect(
-      src.contains('leftover.length == 1') &&
-          src.contains('shortD.length >= 3'),
+      src.contains('_kCoverParaphrase') && src.contains('shortD.length >= 3'),
       isTrue,
       reason:
-          'same-beat: one leftover word on a 3-distinctive gist still '
-          'drops (that creaked / lives). Two leftover words are an extra '
-          'fact. This is not 2-token leftover overlap or a 3-token shortcut',
+          'same-beat leftover is a closed paraphrase set (lives / hidden / '
+          'creaked), not leftover==1. Distinctive leftover is an extra fact',
+    );
+    expect(
+      src.contains('leftover.length == 1'),
+      isFalse,
+      reason:
+          'leftover==1 on a 3-distinctive gist treats burned / lighthouse '
+          'as paraphrase — leftover kind, not leftover count',
     );
     expect(
       src.contains('shortD.intersection(longD).length >= 3'),
@@ -1267,9 +1271,11 @@ void main() {
           'keyboard — leftover count is the same-beat gate',
     );
     expect(
-      src.contains('keptIdx') && src.contains('end - start + 1'),
+      src.contains('_lineSpan') && src.contains('keptIdx'),
       isTrue,
-      reason: 'stripped windows remap positionStart/End onto the kept lines',
+      reason:
+          'each kept run remaps onto its own line span, including when '
+          'message span ≠ line count. first-to-last is the middle-pos hole',
     );
     expect(
       src.contains(r"card.split('\n')"),

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -22,16 +22,19 @@
 // front/back/side, a pair list, or a colon that requires a space, goes red.
 // Screened/covered/wraparound must KEEP. the/a/an stay filler (no theporch).
 //
-// Cover-drop locks (whole-token subset plus a distinctive word, not leftover
-// 2-token overlap): a source-scan for raw contains() of one token in another
-// (key inside keyboard) MUST FAIL. Mood-only stems (felt/safe, still/think)
-// do not cover a longer beat. Shared place (front-garden / back-balcony /
-// side-driveway / screened-porch) KEEPS. Same-beat flowerpot gist DROPS
-// because the card names the flowerpot — flowerpot is distinctive. Function
-// words are one closed set (his/her/that/on/in/at do not mint compounds).
-// garden/balcony/driveway must not appear on the setting-noun / cover-filler
-// place list. Refuse leftover-intersection and raw-contains greens as
-// stand-alone.
+// Cover-drop locks (per-line whole-token subset AND shorter has a
+// distinctive token AND longer has no extra distinctive leftover): a
+// source-scan for raw contains() of one token in another (key inside
+// keyboard) MUST FAIL. Mood-only stems (felt/safe, still/think, loved,
+// worry) do not cover a longer beat. A prefix card (front garden, porch
+// swing) does not cover a bigger fact. Shared place (front-garden /
+// back-balcony / side-driveway / screened-porch) KEEPS. Same-beat
+// flowerpot gist DROPS because the card names the flowerpot — flowerpot
+// is distinctive. Function words are one closed set (his/her/that/on/in/at
+// do not mint compounds). No garden/loved list — garden/balcony/driveway
+// stay off the setting-noun / cover-filler place list, and loved/worry
+// are not a mood-cover list. Refuse leftover-intersection and raw-contains
+// greens as stand-alone.
 
 import 'dart:io';
 
@@ -193,6 +196,14 @@ const kStillThinkAboutIt = 'I still think about it';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
+const kFrontGardenPrefix = 'the front garden';
+const kPorchSwingCard = 'The porch swing.';
+const kPorchSwingFlowerpot = 'Nia: the porch swing creaked by the flowerpot';
+const kLovedIt = 'I loved it';
+const kLovedFlowerpot = 'Nia: I loved the spare key under the third flowerpot';
+const kWorry = 'I worry';
+const kWorryFlowerpot =
+    'Nia: I worry about the spare key under the third flowerpot';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -1203,6 +1214,20 @@ void main() {
           'card does not cover a bigger fact',
     );
     expect(
+      src.contains(r"card.split('\n')"),
+      isTrue,
+      reason:
+          'cover is per-line whole-token subset — not a blob compare of '
+          'the whole window',
+    );
+    expect(
+      src.contains("'loved'") || src.contains("'worry'"),
+      isFalse,
+      reason:
+          'do not add a garden/loved list — cover is leftover-distinctive, '
+          'not a mood-word list',
+    );
+    expect(
       nearSlice.contains('.intersection('),
       isFalse,
       reason:
@@ -1630,6 +1655,147 @@ void main() {
         reason:
             'do not grow the fold-noun / place list with garden / balcony / '
             'driveway — adding them must fail this pin',
+      );
+    },
+  );
+
+  test(
+    'LOCK: prefix front-garden / porch-swing / loved / worry keep; flowerpot drops',
+    () async {
+      const cases = [
+        {
+          'tag': 'front garden',
+          'card': kFrontGardenPrefix,
+          'window': kFrontGardenSwing,
+          'kept': 'swing',
+        },
+        {
+          'tag': 'porch swing',
+          'card': kPorchSwingCard,
+          'window': kPorchSwingFlowerpot,
+          'kept': 'flowerpot',
+        },
+        {
+          'tag': 'I loved it',
+          'card': kLovedIt,
+          'window': kLovedFlowerpot,
+          'kept': 'flowerpot',
+        },
+        {
+          'tag': 'I worry',
+          'card': kWorry,
+          'window': kWorryFlowerpot,
+          'kept': 'flowerpot',
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']!;
+        final cardText = c['card']!;
+        final window = c['window']!;
+        final kept = c['kept']!;
+        final sessionId = 'sess-gistlock-prefixleftover-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-prefixleftover-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: Value(cardText),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'cues are present — retrieve must run so cover-drop is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(cardText),
+          reason:
+              'the $tag prefix/mood card must inject or cover-drop was '
+              'never tested',
+        );
+        expect(prompt, contains(kRagRememberedHeader.trim()));
+        expect(
+          prompt,
+          contains(kept),
+          reason:
+              '"$tag" is a prefix/mood card — it must NOT cover a bigger '
+              'fact. Longer still has leftover distinctive "$kept". No '
+              'garden/loved list. Reverting leftover-distinctive goes red.',
+        );
+      }
+
+      final flowerCard = await seedOverflowSession(
+        sessionId: 'sess-gistlock-prefixleftover-flower',
+        charDbId: 'char-gistlock-prefixleftover-flower',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-prefixleftover-flower'),
+          characterId: Value(flowerCard.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: kFactWindow,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-prefixleftover-flower',
+          positionStart: 0,
+          positionEnd: 1,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
+      await chat.sendMessage(kSit);
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'retrieve ran — a skip would fake the cover-drop',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final flower = llm.chatPrompts.last;
+      expect(
+        flower,
+        contains(kGist),
+        reason: 'same-beat flowerpot gist must inject',
+      );
+      expect(
+        flower,
+        isNot(contains(kRagRememberedHeader.trim())),
+        reason:
+            'same-beat flowerpot gist still DROPS — no extra distinctive '
+            'leftover. Prefix/mood KEEP above must not disable real cover.',
       );
     },
   );

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -38,7 +38,11 @@
 //
 // Joe lock: DROP only when leftover is empty. Anything with leftover
 // KEEP. No length band, position, paraphrase list, or ned exception.
-// Covered lines strip into contiguous runs; each run remaps its span.
+// hidden/tucked/buried/stays/rests/lives/lives-hidden KEEP in prefix,
+// interior, AND suffix. Two-line lives-under: lives line KEEP, exact
+// gist line still strips. sat-on-porch KEEP. this/my/our/your-porch
+// swing DROP (function words do not mint leftover). Covered lines
+// strip into contiguous runs; each run remaps its span.
 
 import 'dart:io';
 
@@ -267,6 +271,19 @@ const kPrefixSat = 'Nia: sat the spare key under the third flowerpot';
 const kPrefixDied = 'Nia: died the spare key under the third flowerpot';
 const kPrefixHidden = 'Nia: hidden the spare key under the third flowerpot';
 const kPrefixTucked = 'Nia: tucked the spare key under the third flowerpot';
+const kPrefixBuried = 'Nia: buried the spare key under the third flowerpot';
+const kPrefixStays = 'Nia: stays the spare key under the third flowerpot';
+const kPrefixRests = 'Nia: rests the spare key under the third flowerpot';
+const kPrefixLives = 'Nia: lives the spare key under the third flowerpot';
+const kPrefixLivesHidden =
+    'Nia: lives hidden the spare key under the third flowerpot';
+const kInteriorHidden = 'Nia: the spare key hidden under the third flowerpot';
+const kInteriorTucked = 'Nia: the spare key tucked under the third flowerpot';
+const kInteriorLives = 'Nia: the spare key lives under the third flowerpot';
+const kThisPorchSwing = 'Nia: this porch swing creaked tonight';
+const kMyPorchSwing = 'Nia: my porch swing creaked tonight';
+const kOurPorchSwing = 'Nia: our porch swing creaked tonight';
+const kYourPorchSwing = 'Nia: your porch swing creaked tonight';
 const kSatOnPorch = 'I sat on porch; the swing creaked tonight';
 
 void main() {
@@ -1418,7 +1435,36 @@ void main() {
       isFalse,
       reason:
           'flipping leftover==1 to leftover==2 is fake-green for burned / '
-          'lighthouse KEEP and lives-hidden DROP — leftover kind, not count',
+          'lighthouse KEEP and lives-hidden KEEP — leftover-empty only, '
+          'not leftover count as kind',
+    );
+    expect(
+      src.contains('leftover.every(') || src.contains('leftover.every ('),
+      isFalse,
+      reason:
+          'leftover.every(kind) is leftover-kind / paraphrase — DROP is '
+          'leftover.isEmpty only, not a per-token closed set',
+    );
+    expect(
+      src.contains('w.length >= 7') ||
+          src.contains('w.length>=7') ||
+          src.contains('length >= 7'),
+      isFalse,
+      reason:
+          'length >= 7 as extra-fact / restatement is length-as-kind. '
+          'Joe lock has no length band',
+    );
+    expect(
+      src.contains('_isSuffixLeftover') ||
+          src.contains('_isInteriorLeftover') ||
+          src.contains('_isPrefixLeftover') ||
+          src.contains('_leftoverSlot') ||
+          src.contains('_kLeftoverParaphrase') ||
+          src.contains('_kCoverKind'),
+      isFalse,
+      reason:
+          'suffix vs interior vs prefix must not be the kind rule. '
+          'Position helpers / a new closed kind list MUST FAIL',
     );
     expect(
       src.contains('shortD.intersection(longD).length >= 3'),
@@ -2120,27 +2166,20 @@ void main() {
     },
   );
 
-  test('LOCK: leftover-empty only — tucked / lives-under KEEP', () async {
+  test('LOCK: leftover-empty only — interior hidden/tucked/buried/stays/rests/lives KEEP', () async {
     const cases = [
-      {
-        'tag': 'two-line lives-under',
-        'window': kFactWindow,
-        'absent': 'lives',
-      },
-      {
-        'tag': 'tucked under',
-        'window': 'Nia: the spare key tucked under the third flowerpot',
-        'absent': 'tucked',
-      },
-      {'tag': 'buried under', 'window': kBuriedUnder, 'absent': 'buried'},
-      {'tag': 'stays under', 'window': kStaysUnder, 'absent': 'stays'},
-      {'tag': 'rests under', 'window': kRestsUnder, 'absent': 'rests'},
+      {'tag': 'interior hidden', 'window': kInteriorHidden, 'kept': 'hidden'},
+      {'tag': 'interior tucked', 'window': kInteriorTucked, 'kept': 'tucked'},
+      {'tag': 'interior buried', 'window': kBuriedUnder, 'kept': 'buried'},
+      {'tag': 'interior stays', 'window': kStaysUnder, 'kept': 'stays'},
+      {'tag': 'interior rests', 'window': kRestsUnder, 'kept': 'rests'},
+      {'tag': 'interior lives', 'window': kInteriorLives, 'kept': 'lives'},
     ];
     for (var i = 0; i < cases.length; i++) {
       final c = cases[i];
       final tag = c['tag']!;
       final window = c['window']!;
-      final absent = c['absent']!;
+      final kept = c['kept']!;
       final sessionId = 'sess-gistlock-samebeat3-$i';
       final card = await seedOverflowSession(
         sessionId: sessionId,
@@ -2187,12 +2226,84 @@ void main() {
       expect(prompt, contains(kRagRememberedHeader.trim()));
       expect(
         prompt,
-        contains(absent),
+        contains(kept),
         reason:
-            'leftover-empty only — "$tag" has leftover so KEEP. '
-            '"$absent" must reach the prompt',
+            'leftover-empty only — interior "$tag" has leftover so KEEP. '
+            '"$kept" must reach the prompt. A paraphrase list or length/'
+            'position kind rule goes red here',
       );
     }
+  });
+
+  test('LOCK: leftover-empty only — two-line lives-under keeps lives, strips gist', () async {
+    final card = await seedOverflowSession(
+      sessionId: 'sess-gistlock-livesunder',
+      charDbId: 'char-gistlock-livesunder',
+      emotion: kEmotion,
+      fixation: kFixation,
+    );
+    await db.insertJournalCard(
+      JournalMemoriesCompanion(
+        sessionId: const Value('sess-gistlock-livesunder'),
+        characterId: Value(card.stableGroupId),
+        content: const Value(kGist),
+        category: const Value('about_us'),
+        heat: const Value(0.9),
+      ),
+    );
+    memory.retrieveCalls = 0;
+    memory.canned = [
+      RetrievedMemory(
+        content: kFactWindow,
+        characterId: 'Nia',
+        sessionId: 'sess-gistlock-livesunder',
+        positionStart: 0,
+        positionEnd: 1,
+        score: 0.9,
+      ),
+    ];
+    llm.chatPrompts.clear();
+
+    await chat.sendMessage(kSit);
+
+    expect(
+      memory.retrieveCalls,
+      greaterThan(0),
+      reason: 'retrieve ran — a skip would fake the cover-drop',
+    );
+    expect(llm.chatPrompts, isNotEmpty);
+    final prompt = llm.chatPrompts.last;
+    expect(
+      prompt,
+      contains(kGist),
+      reason: 'same-beat flowerpot gist must inject',
+    );
+    expect(
+      prompt,
+      contains(kRagRememberedHeader.trim()),
+      reason: 'the lives line has leftover so it must still inject as RAG',
+    );
+    expect(
+      prompt,
+      contains('the spare key lives under the third flowerpot'),
+      reason:
+          'two-line lives-under: the lives line KEEPS (plain path strips '
+          'the You: prefix). Whole-window DROP of lives-under goes red here',
+    );
+    expect(
+      prompt,
+      isNot(contains(kFactWindow)),
+      reason:
+          'exact gist line still strips — the two-line blob must not '
+          'survive as one remembered window',
+    );
+    expect(
+      prompt,
+      isNot(contains(kGistWindow)),
+      reason:
+          'the exact gist line still strips from the RAG window. '
+          'Keeping both lines is leftover-empty failure',
+    );
   });
 
   test(
@@ -3160,6 +3271,48 @@ void main() {
         'drop': false,
       },
       {
+        'tag': 'prefix buried',
+        'card': kGist,
+        'window': kPrefixBuried,
+        'kept': 'buried',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix stays',
+        'card': kGist,
+        'window': kPrefixStays,
+        'kept': 'stays',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix rests',
+        'card': kGist,
+        'window': kPrefixRests,
+        'kept': 'rests',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix lives',
+        'card': kGist,
+        'window': kPrefixLives,
+        'kept': 'lives',
+        'drop': false,
+      },
+      {
+        'tag': 'prefix lives-hidden',
+        'card': kGist,
+        'window': kPrefixLivesHidden,
+        'kept': 'hidden',
+        'drop': false,
+      },
+      {
+        'tag': 'interior hidden',
+        'card': kGist,
+        'window': kInteriorHidden,
+        'kept': 'hidden',
+        'drop': false,
+      },
+      {
         'tag': 'sat-on-porch',
         'card': kThePorchSwing,
         'window': kSatOnPorch,
@@ -3244,6 +3397,75 @@ void main() {
               'DROP goes red here',
         );
       }
+    }
+  });
+
+  test('LOCK: leftover-empty only — this/my/our/your-porch swing still DROP', () async {
+    const cases = [
+      {'tag': 'this-porch swing', 'window': kThisPorchSwing},
+      {'tag': 'my-porch swing', 'window': kMyPorchSwing},
+      {'tag': 'our-porch swing', 'window': kOurPorchSwing},
+      {'tag': 'your-porch swing', 'window': kYourPorchSwing},
+    ];
+    for (var i = 0; i < cases.length; i++) {
+      final c = cases[i];
+      final tag = c['tag']!;
+      final window = c['window']!;
+      final sessionId = 'sess-gistlock-fnporch-$i';
+      final card = await seedOverflowSession(
+        sessionId: sessionId,
+        charDbId: 'char-gistlock-fnporch-$i',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: Value(sessionId),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kThePorchSwing),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: window,
+          characterId: 'Nia',
+          sessionId: sessionId,
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'retrieve ran — a skip would fake the cover-drop',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(kThePorchSwing),
+        reason: 'the porch-swing gist must inject or DROP was never tested',
+      );
+      expect(
+        prompt,
+        isNot(contains(kRagRememberedHeader.trim())),
+        reason:
+            'leftover-empty only — "$tag" has no leftover. Function words '
+            'do not mint leftover. "$tag" must still DROP',
+      );
+      expect(
+        prompt,
+        isNot(contains(window)),
+        reason: '"$tag" still DROPS — "$window" must not reach the prompt',
+      );
     }
   });
 }

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -20,6 +20,7 @@
 // Any-token-before-place-noun fold (porch/yard/lawn/deck/stoop) and
 // optional-space speaker strip are god-path locks here. An adj list of
 // front/back/side, a pair list, or a colon that requires a space, goes red.
+// Screened/covered/wraparound must KEEP. the/a/an stay filler (no theporch).
 
 import 'dart:io';
 
@@ -150,6 +151,12 @@ const kFrontLawnFeeling = 'I felt safe on the front lawn tonight';
 const kFrontLawnSwing = 'Nia: the front lawn swing creaked tonight';
 const kScreenedPorchFeeling = 'I felt safe on the screened porch tonight';
 const kScreenedPorchSwing = 'Nia: the screened porch swing creaked tonight';
+const kCoveredPorchFeeling = 'I felt safe on the covered porch tonight';
+const kCoveredPorchSwing = 'Nia: the covered porch swing creaked tonight';
+const kWraparoundPorchFeeling = 'I felt safe on the wraparound porch tonight';
+const kWraparoundPorchSwing = 'Nia: the wraparound porch swing creaked tonight';
+const kThePorchFeeling = 'I felt safe on the porch tonight';
+const kThePorchSwing = 'Nia: the porch swing creaked tonight';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
@@ -723,6 +730,19 @@ void main() {
       isFalse,
       reason: 'must not be a pair-list of specific compounds',
     );
+    expect(
+      src.contains(r'(front|back|side)\s+(porch|yard|lawn|deck|stoop)'),
+      isFalse,
+      reason:
+          'a source-scan that only looks for (front|back|side) as the fold '
+          'set MUST FAIL — the product must not be that restricted list',
+    );
+    expect(
+      src.contains("{'the', 'a', 'an'}"),
+      isTrue,
+      reason:
+          'the / a / an stay filler — do not fold "the porch" into theporch',
+    );
   });
 
   test(
@@ -805,6 +825,133 @@ void main() {
       }
     },
   );
+
+  test('LOCK 2: covered/wraparound keep; the/a/an stay filler', () async {
+    const cases = [
+      {
+        'tag': 'covered porch',
+        'feeling': kCoveredPorchFeeling,
+        'swing': kCoveredPorchSwing,
+      },
+      {
+        'tag': 'wraparound porch',
+        'feeling': kWraparoundPorchFeeling,
+        'swing': kWraparoundPorchSwing,
+      },
+      {
+        'tag': 'the porch',
+        'feeling': kThePorchFeeling,
+        'swing': kThePorchSwing,
+      },
+    ];
+    for (var i = 0; i < cases.length; i++) {
+      final c = cases[i];
+      final tag = c['tag']!;
+      final feeling = c['feeling']!;
+      final swing = c['swing']!;
+      final sessionId = 'sess-gistlock-anytoken-$i';
+      final card = await seedOverflowSession(
+        sessionId: sessionId,
+        charDbId: 'char-gistlock-anytoken-$i',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: Value(sessionId),
+          characterId: Value(card.stableGroupId),
+          content: Value(feeling),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: swing,
+          characterId: 'Nia',
+          sessionId: sessionId,
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so cover-drop is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(feeling),
+        reason:
+            'the $tag feeling card must inject or cover-drop was never tested',
+      );
+      expect(prompt, contains(kRagRememberedHeader.trim()));
+      expect(
+        prompt,
+        contains('swing'),
+        reason:
+            '$tag feeling × $tag swing must KEEP. Fold is ANY token '
+            'before a place noun, not an adj list of front/back/side. '
+            'the/a/an stay filler — do not cover-drop a swing fact.',
+      );
+    }
+
+    final card = await seedOverflowSession(
+      sessionId: 'sess-gistlock-anytoken-flower',
+      charDbId: 'char-gistlock-anytoken-flower',
+      emotion: kEmotion,
+      fixation: kFixation,
+    );
+    await db.insertJournalCard(
+      JournalMemoriesCompanion(
+        sessionId: const Value('sess-gistlock-anytoken-flower'),
+        characterId: Value(card.stableGroupId),
+        content: const Value(kGist),
+        category: const Value('about_us'),
+        heat: const Value(0.9),
+      ),
+    );
+    memory.retrieveCalls = 0;
+    memory.canned = [
+      RetrievedMemory(
+        content: kFactWindow,
+        characterId: 'Nia',
+        sessionId: 'sess-gistlock-anytoken-flower',
+        positionStart: 0,
+        positionEnd: 1,
+        score: 0.9,
+      ),
+    ];
+    llm.chatPrompts.clear();
+    await chat.sendMessage(kSit);
+    expect(
+      memory.retrieveCalls,
+      greaterThan(0),
+      reason: 'retrieve ran — a skip would fake the cover-drop',
+    );
+    expect(llm.chatPrompts, isNotEmpty);
+    final flower = llm.chatPrompts.last;
+    expect(
+      flower,
+      contains(kGist),
+      reason: 'same-beat flowerpot gist must inject',
+    );
+    expect(
+      flower,
+      isNot(contains(kRagRememberedHeader.trim())),
+      reason:
+          'same-beat flowerpot gist still drops the covered RAG window '
+          '— any-token place fold must not disable real cover',
+    );
+  });
 
   test(
     'LOCK 3: optional colon space strips Nia:the swing; quote-reach stays raw',

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -21,6 +21,15 @@
 // optional-space speaker strip are god-path locks here. An adj list of
 // front/back/side, a pair list, or a colon that requires a space, goes red.
 // Screened/covered/wraparound must KEEP. the/a/an stay filler (no theporch).
+//
+// Cover-drop locks (near-substring, not leftover 2-token overlap): a
+// source-scan for shared-content-tokens ≥ 2 as the cover rule MUST FAIL.
+// Shared place (front-garden / back-balcony / side-driveway / screened-porch)
+// KEEPS. Same-beat flowerpot gist DROPS because the card names the
+// flowerpot in the window — not because of 2-token overlap. Function
+// words are one closed set (his/her/that/on/in/at do not mint compounds).
+// garden/balcony/driveway must not appear on the setting-noun / cover-filler
+// place list. Refuse leftover-intersection greens as stand-alone.
 
 import 'dart:io';
 
@@ -171,6 +180,7 @@ const kBackBalconyFeeling = 'I felt safe on the back balcony tonight';
 const kBackBalconySwing = 'Nia: the back balcony swing creaked tonight';
 const kSideDrivewayFeeling = 'I felt safe on the side driveway tonight';
 const kSideDrivewaySwing = 'Nia: the side driveway swing creaked tonight';
+const kHallwaySpareKey = 'Nia: the spare key lives in the hallway drawer';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
@@ -787,6 +797,17 @@ void main() {
       reason:
           'function words are one closed set — his/off/at do not mint compounds',
     );
+    expect(
+      src.contains("'her'") &&
+          src.contains("'that'") &&
+          src.contains("'on'") &&
+          src.contains("'in'") &&
+          src.contains("'at'"),
+      isTrue,
+      reason:
+          'function words are one closed set — his/her/that/on/in/at '
+          'do not mint compounds',
+    );
   });
 
   test(
@@ -1109,6 +1130,282 @@ void main() {
         contains(kSwingTight),
         reason:
             'quote-reach keeps the raw window, including Nia:the (no space)',
+      );
+    },
+  );
+
+  test('LOCK: cover-drop is near-substring, not leftover 2-token overlap', () {
+    final src = File('lib/services/chat/rag_injection.dart').readAsStringSync();
+    final dropAt = src.indexOf('List<RetrievedMemory> dropCoveredRagWindows');
+    expect(
+      dropAt,
+      greaterThanOrEqualTo(0),
+      reason: 'dropCoveredRagWindows must still exist',
+    );
+    final nearAt = src.indexOf('bool _nearCover(');
+    expect(
+      nearAt,
+      greaterThanOrEqualTo(0),
+      reason:
+          'cover is _nearCover (near-substring of the normalized card '
+          'and window), not leftover tokens',
+    );
+    final coveredAt = src.indexOf('bool _ragCoveredByJournal(');
+    expect(coveredAt, greaterThanOrEqualTo(0));
+
+    final nearSlice = src.substring(
+      nearAt,
+      (nearAt + 500).clamp(0, src.length),
+    );
+    expect(
+      nearSlice.contains('longer.contains(shorter)'),
+      isTrue,
+      reason:
+          'cover is a near-substring — longer.contains(shorter) after '
+          'normalize. A leftover-token intersection is not this lock.',
+    );
+    expect(
+      nearSlice.contains('.intersection('),
+      isFalse,
+      reason:
+          'a source-scan for 2-token intersection as the cover rule '
+          'MUST FAIL — product must not use shared-content-tokens ≥ 2',
+    );
+
+    final coveredSlice = src.substring(
+      coveredAt,
+      (coveredAt + 280).clamp(0, src.length),
+    );
+    expect(
+      coveredSlice.contains('_nearCover('),
+      isTrue,
+      reason: '_ragCoveredByJournal must call _nearCover',
+    );
+    expect(
+      coveredSlice.contains('.intersection('),
+      isFalse,
+      reason:
+          'a source-scan for 2-token intersection as the cover rule '
+          'MUST FAIL',
+    );
+    expect(
+      RegExp(r'intersection\s*\(').hasMatch(coveredSlice),
+      isFalse,
+      reason:
+          'product must not use shared-content-tokens ≥ 2 as the cover rule',
+    );
+
+    final dropEnd = src.indexOf('List<RetrievedMemory> capRagWindows', dropAt);
+    final dropSlice = src.substring(
+      dropAt,
+      dropEnd > dropAt ? dropEnd : (dropAt + 900).clamp(0, src.length),
+    );
+    expect(
+      dropSlice.contains('coverContentTokens'),
+      isFalse,
+      reason:
+          'dropCoveredRagWindows must not score leftover token overlap. '
+          'coverContentTokens stays on rememberedLineFromWindow only.',
+    );
+    expect(
+      dropSlice.contains('.intersection('),
+      isFalse,
+      reason:
+          'a source-scan for 2-token intersection as the cover rule '
+          'MUST FAIL',
+    );
+  });
+
+  test(
+    'LOCK: leftover 2-token spare+key hallway KEEPS; flowerpot name DROPS',
+    () async {
+      final card = await seedOverflowSession(
+        sessionId: 'sess-gistlock-leftover2',
+        charDbId: 'char-gistlock-leftover2',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-leftover2'),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      expect(
+        coverContentTokens(
+          kHallwaySpareKey,
+        ).intersection(coverContentTokens(kGist)).length,
+        greaterThanOrEqualTo(2),
+        reason:
+            'hallway shares leftover tokens ≥ 2 with the flowerpot gist — '
+            'if 2-token overlap were cover this window would drop. That '
+            'intersection is not a green.',
+      );
+      memory.canned = [
+        RetrievedMemory(
+          content: kHallwaySpareKey,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-leftover2',
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so cover-drop is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final hallway = llm.chatPrompts.last;
+      expect(
+        hallway,
+        contains(kGist),
+        reason: 'the flowerpot gist must inject or cover-drop was never tested',
+      );
+      expect(hallway, contains(kRagRememberedHeader.trim()));
+      expect(
+        hallway,
+        contains('hallway'),
+        reason:
+            'shared leftover tokens ≥ 2 (spare+key) is NOT cover — the '
+            'hallway drawer window must KEEP. Reverting to 2-token '
+            'intersection as the cover rule goes red here.',
+      );
+
+      final flowerCard = await seedOverflowSession(
+        sessionId: 'sess-gistlock-flower-why',
+        charDbId: 'char-gistlock-flower-why',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-flower-why'),
+          characterId: Value(flowerCard.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.retrieveCalls = 0;
+      memory.canned = [
+        RetrievedMemory(
+          content: kFactWindow,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-flower-why',
+          positionStart: 0,
+          positionEnd: 1,
+          score: 0.9,
+        ),
+      ];
+      llm.chatPrompts.clear();
+      await chat.sendMessage(kSit);
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'retrieve ran — a skip would fake the cover-drop',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final flower = llm.chatPrompts.last;
+      expect(
+        flower,
+        contains(kGist),
+        reason: 'same-beat flowerpot gist must inject',
+      );
+      expect(
+        flower,
+        isNot(contains(kRagRememberedHeader.trim())),
+        reason:
+            'same-beat flowerpot gist DROPS because the card names the '
+            'flowerpot in the window (near-substring), not because of '
+            '2-token leftover overlap. The hallway pair above shares ≥2 '
+            'tokens and KEEPS — leftover intersection is not this drop.',
+      );
+      expect(
+        flower,
+        isNot(contains('You: the spare key lives under the third flowerpot')),
+      );
+    },
+  );
+
+  test('LOCK: function words are one closed set — his/her/that/on/in/at', () {
+    final src = File('lib/services/chat/rag_injection.dart').readAsStringSync();
+    final fnAt = src.indexOf('const _kFunctionWords = {');
+    expect(
+      fnAt,
+      greaterThanOrEqualTo(0),
+      reason:
+          'function words are one closed set — not grown one word at a time',
+    );
+    final fnEnd = src.indexOf('};', fnAt);
+    expect(fnEnd, greaterThan(fnAt));
+    final fn = src.substring(fnAt, fnEnd);
+    for (final w in ['his', 'her', 'that', 'on', 'in', 'at']) {
+      expect(
+        fn.contains("'$w'"),
+        isTrue,
+        reason:
+            "'$w' belongs in the closed function-word set — do not mint "
+            '${w}porch compounds',
+      );
+    }
+    expect(
+      src.contains('if (_kFunctionWords.contains(prep))'),
+      isTrue,
+      reason: 'place-fold consults the closed set — not a grown particle list',
+    );
+    expect(
+      src.contains('_kNoFoldBeforePlace'),
+      isFalse,
+      reason: 'do not grow a second no-fold list next to the closed set',
+    );
+  });
+
+  test(
+    'LOCK: garden/balcony/driveway must not sit on the setting-noun list',
+    () {
+      final src = File(
+        'lib/services/chat/rag_injection.dart',
+      ).readAsStringSync();
+      final fillerAt = src.indexOf('const _kCoverFiller = {');
+      expect(
+        fillerAt,
+        greaterThanOrEqualTo(0),
+        reason: 'the cover-filler / setting-noun list must still exist',
+      );
+      final fillerEnd = src.indexOf('};', fillerAt);
+      expect(fillerEnd, greaterThan(fillerAt));
+      final filler = src.substring(fillerAt, fillerEnd);
+      for (final w in ['garden', 'balcony', 'driveway']) {
+        expect(
+          filler.contains("'$w'"),
+          isFalse,
+          reason:
+              "'$w' must NOT appear on the setting-noun / cover-filler "
+              'place list. Adding it to that list must fail this pin.',
+        );
+      }
+      final foldAt = src.indexOf('_kPlaceNounCompound');
+      expect(foldAt, greaterThanOrEqualTo(0));
+      final foldSlice = src.substring(
+        foldAt,
+        (foldAt + 220).clamp(0, src.length),
+      );
+      expect(
+        foldSlice.contains('garden') ||
+            foldSlice.contains('balcony') ||
+            foldSlice.contains('driveway'),
+        isFalse,
+        reason:
+            'do not grow the fold-noun / place list with garden / balcony / '
+            'driveway — adding them must fail this pin',
       );
     },
   );

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -38,10 +38,10 @@
 //
 // Short leftover is ANY extra content token on the longer side —
 // died/gone/fell/hid/ran count even when length < 5. "the spare key"
-// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat leftover is
-// a closed paraphrase set (lives / hidden / creaked), not leftover==1.
-// Distinctive leftover is an extra fact (burned, lighthouse, swing).
-// Covered lines strip into contiguous runs; each run remaps its span.
+// KEEPS died/gone; "third flowerpot" KEEPS fell. Same-beat is interior
+// leftover (lives / tucked / buried) — no verb list. Suffix leftover
+// is an extra fact (burned, lighthouse, creaked, died, sat). Covered
+// lines strip into contiguous runs; each run remaps its span.
 
 import 'dart:io';
 
@@ -1261,11 +1261,18 @@ void main() {
           'died/gone/fell/hid/ran count even when length < 5',
     );
     expect(
-      src.contains('_kCoverParaphrase') && src.contains('shortD.length >= 3'),
+      src.contains('_minCoverWindow') && src.contains('leftover'),
       isTrue,
       reason:
-          'same-beat leftover is a closed paraphrase set (lives / hidden / '
-          'creaked), not leftover==1. Distinctive leftover is an extra fact',
+          'same-beat is interior leftover; suffix leftover is an extra fact. '
+          'No paraphrase verb list',
+    );
+    expect(
+      src.contains('_kCoverParaphrase') || src.contains('shortD.length >= 3'),
+      isFalse,
+      reason:
+          'the paraphrase set is a garden/loved list — delete it. '
+          'leftover.every(!distinctive) && shortD>=3 is leftover==1 for died/sat',
     );
     expect(
       src.contains('leftover.length == 1'),
@@ -1986,14 +1993,14 @@ void main() {
     () async {
       const cases = [
         {
-          'tag': 'that creaked',
-          'window': kGistThatCreaked,
-          'absent': 'that creaked',
-        },
-        {
           'tag': 'two-line lives-under',
           'window': kFactWindow,
           'absent': 'You: the spare key lives under the third flowerpot',
+        },
+        {
+          'tag': 'tucked under',
+          'window': 'Nia: the spare key tucked under the third flowerpot',
+          'absent': 'tucked',
         },
       ];
       for (var i = 0; i < cases.length; i++) {

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -165,6 +165,12 @@ const kFrontWalkFeeling = 'I felt safe on the front walk tonight';
 const kFrontWalkSwing = 'Nia: the front walk swing creaked tonight';
 const kBackPathFeeling = 'I felt safe on the back path tonight';
 const kBackPathSwing = 'Nia: the back path swing creaked tonight';
+const kFrontGardenFeeling = 'I felt safe on the front garden tonight';
+const kFrontGardenSwing = 'Nia: the front garden swing creaked tonight';
+const kBackBalconyFeeling = 'I felt safe on the back balcony tonight';
+const kBackBalconySwing = 'Nia: the back balcony swing creaked tonight';
+const kSideDrivewayFeeling = 'I felt safe on the side driveway tonight';
+const kSideDrivewaySwing = 'Nia: the side driveway swing creaked tonight';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
@@ -768,6 +774,19 @@ void main() {
       isFalse,
       reason: 'do not grow the fold noun list with steps/patio and stop',
     );
+    expect(
+      src.contains("'garden'") ||
+          src.contains("'balcony'") ||
+          src.contains("'driveway'"),
+      isFalse,
+      reason: 'do not add garden/balcony/driveway to a noun list',
+    );
+    expect(
+      src.contains("'his'") && src.contains("'off'") && src.contains("'at'"),
+      isTrue,
+      reason:
+          'function words are one closed set — his/off/at do not mint compounds',
+    );
   });
 
   test(
@@ -808,6 +827,21 @@ void main() {
           'tag': 'back path',
           'feeling': kBackPathFeeling,
           'swing': kBackPathSwing,
+        },
+        {
+          'tag': 'front garden',
+          'feeling': kFrontGardenFeeling,
+          'swing': kFrontGardenSwing,
+        },
+        {
+          'tag': 'back balcony',
+          'feeling': kBackBalconyFeeling,
+          'swing': kBackBalconySwing,
+        },
+        {
+          'tag': 'side driveway',
+          'feeling': kSideDrivewayFeeling,
+          'swing': kSideDrivewaySwing,
         },
       ];
       for (var i = 0; i < cases.length; i++) {

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -1424,6 +1424,14 @@ void main() {
           'must not sit as interior leftover between shared tokens',
     );
     expect(
+      normSlice.contains('_kTimeFiller') ||
+          normSlice.contains('_kJournalBoilerplate'),
+      isFalse,
+      reason:
+          'time filler and journal boilerplate must not strip cover leftover '
+          '— gist+safe / gist+yesterday are leftover KEEP',
+    );
+    expect(
       src.contains('leftover.length == 1'),
       isFalse,
       reason:
@@ -2166,30 +2174,90 @@ void main() {
     },
   );
 
-  test('LOCK: leftover-empty only — interior hidden/tucked/buried/stays/rests/lives KEEP', () async {
-    const cases = [
-      {'tag': 'interior hidden', 'window': kInteriorHidden, 'kept': 'hidden'},
-      {'tag': 'interior tucked', 'window': kInteriorTucked, 'kept': 'tucked'},
-      {'tag': 'interior buried', 'window': kBuriedUnder, 'kept': 'buried'},
-      {'tag': 'interior stays', 'window': kStaysUnder, 'kept': 'stays'},
-      {'tag': 'interior rests', 'window': kRestsUnder, 'kept': 'rests'},
-      {'tag': 'interior lives', 'window': kInteriorLives, 'kept': 'lives'},
-    ];
-    for (var i = 0; i < cases.length; i++) {
-      final c = cases[i];
-      final tag = c['tag']!;
-      final window = c['window']!;
-      final kept = c['kept']!;
-      final sessionId = 'sess-gistlock-samebeat3-$i';
+  test(
+    'LOCK: leftover-empty only — interior hidden/tucked/buried/stays/rests/lives KEEP',
+    () async {
+      const cases = [
+        {'tag': 'interior hidden', 'window': kInteriorHidden, 'kept': 'hidden'},
+        {'tag': 'interior tucked', 'window': kInteriorTucked, 'kept': 'tucked'},
+        {'tag': 'interior buried', 'window': kBuriedUnder, 'kept': 'buried'},
+        {'tag': 'interior stays', 'window': kStaysUnder, 'kept': 'stays'},
+        {'tag': 'interior rests', 'window': kRestsUnder, 'kept': 'rests'},
+        {'tag': 'interior lives', 'window': kInteriorLives, 'kept': 'lives'},
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']!;
+        final window = c['window']!;
+        final kept = c['kept']!;
+        final sessionId = 'sess-gistlock-samebeat3-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-samebeat3-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: const Value(kGist),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 1,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'retrieve ran — a skip would fake the cover-drop',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(kGist),
+          reason: 'same-beat flowerpot gist must inject',
+        );
+        expect(prompt, contains(kRagRememberedHeader.trim()));
+        expect(
+          prompt,
+          contains(kept),
+          reason:
+              'leftover-empty only — interior "$tag" has leftover so KEEP. '
+              '"$kept" must reach the prompt. A paraphrase list or length/'
+              'position kind rule goes red here',
+        );
+      }
+    },
+  );
+
+  test(
+    'LOCK: leftover-empty only — two-line lives-under keeps lives, strips gist',
+    () async {
       final card = await seedOverflowSession(
-        sessionId: sessionId,
-        charDbId: 'char-gistlock-samebeat3-$i',
+        sessionId: 'sess-gistlock-livesunder',
+        charDbId: 'char-gistlock-livesunder',
         emotion: kEmotion,
         fixation: kFixation,
       );
       await db.insertJournalCard(
         JournalMemoriesCompanion(
-          sessionId: Value(sessionId),
+          sessionId: const Value('sess-gistlock-livesunder'),
           characterId: Value(card.stableGroupId),
           content: const Value(kGist),
           category: const Value('about_us'),
@@ -2199,9 +2267,9 @@ void main() {
       memory.retrieveCalls = 0;
       memory.canned = [
         RetrievedMemory(
-          content: window,
+          content: kFactWindow,
           characterId: 'Nia',
-          sessionId: sessionId,
+          sessionId: 'sess-gistlock-livesunder',
           positionStart: 0,
           positionEnd: 1,
           score: 0.9,
@@ -2223,88 +2291,34 @@ void main() {
         contains(kGist),
         reason: 'same-beat flowerpot gist must inject',
       );
-      expect(prompt, contains(kRagRememberedHeader.trim()));
       expect(
         prompt,
-        contains(kept),
-        reason:
-            'leftover-empty only — interior "$tag" has leftover so KEEP. '
-            '"$kept" must reach the prompt. A paraphrase list or length/'
-            'position kind rule goes red here',
+        contains(kRagRememberedHeader.trim()),
+        reason: 'the lives line has leftover so it must still inject as RAG',
       );
-    }
-  });
-
-  test('LOCK: leftover-empty only — two-line lives-under keeps lives, strips gist', () async {
-    final card = await seedOverflowSession(
-      sessionId: 'sess-gistlock-livesunder',
-      charDbId: 'char-gistlock-livesunder',
-      emotion: kEmotion,
-      fixation: kFixation,
-    );
-    await db.insertJournalCard(
-      JournalMemoriesCompanion(
-        sessionId: const Value('sess-gistlock-livesunder'),
-        characterId: Value(card.stableGroupId),
-        content: const Value(kGist),
-        category: const Value('about_us'),
-        heat: const Value(0.9),
-      ),
-    );
-    memory.retrieveCalls = 0;
-    memory.canned = [
-      RetrievedMemory(
-        content: kFactWindow,
-        characterId: 'Nia',
-        sessionId: 'sess-gistlock-livesunder',
-        positionStart: 0,
-        positionEnd: 1,
-        score: 0.9,
-      ),
-    ];
-    llm.chatPrompts.clear();
-
-    await chat.sendMessage(kSit);
-
-    expect(
-      memory.retrieveCalls,
-      greaterThan(0),
-      reason: 'retrieve ran — a skip would fake the cover-drop',
-    );
-    expect(llm.chatPrompts, isNotEmpty);
-    final prompt = llm.chatPrompts.last;
-    expect(
-      prompt,
-      contains(kGist),
-      reason: 'same-beat flowerpot gist must inject',
-    );
-    expect(
-      prompt,
-      contains(kRagRememberedHeader.trim()),
-      reason: 'the lives line has leftover so it must still inject as RAG',
-    );
-    expect(
-      prompt,
-      contains('the spare key lives under the third flowerpot'),
-      reason:
-          'two-line lives-under: the lives line KEEPS (plain path strips '
-          'the You: prefix). Whole-window DROP of lives-under goes red here',
-    );
-    expect(
-      prompt,
-      isNot(contains(kFactWindow)),
-      reason:
-          'exact gist line still strips — the two-line blob must not '
-          'survive as one remembered window',
-    );
-    expect(
-      prompt,
-      isNot(contains(kGistWindow)),
-      reason:
-          'the exact gist line still strips from the RAG window. '
-          'Keeping both lines is leftover-empty failure',
-    );
-  });
+      expect(
+        prompt,
+        contains('the spare key lives under the third flowerpot'),
+        reason:
+            'two-line lives-under: the lives line KEEPS (plain path strips '
+            'the You: prefix). Whole-window DROP of lives-under goes red here',
+      );
+      expect(
+        prompt,
+        isNot(contains(kFactWindow)),
+        reason:
+            'exact gist line still strips — the two-line blob must not '
+            'survive as one remembered window',
+      );
+      expect(
+        prompt,
+        isNot(contains(kGistWindow)),
+        reason:
+            'the exact gist line still strips from the RAG window. '
+            'Keeping both lines is leftover-empty failure',
+      );
+    },
+  );
 
   test(
     'LOCK: covered lines are stripped — flowerpot gist + swing KEEPS swing',
@@ -3400,72 +3414,75 @@ void main() {
     }
   });
 
-  test('LOCK: leftover-empty only — this/my/our/your-porch swing still DROP', () async {
-    const cases = [
-      {'tag': 'this-porch swing', 'window': kThisPorchSwing},
-      {'tag': 'my-porch swing', 'window': kMyPorchSwing},
-      {'tag': 'our-porch swing', 'window': kOurPorchSwing},
-      {'tag': 'your-porch swing', 'window': kYourPorchSwing},
-    ];
-    for (var i = 0; i < cases.length; i++) {
-      final c = cases[i];
-      final tag = c['tag']!;
-      final window = c['window']!;
-      final sessionId = 'sess-gistlock-fnporch-$i';
-      final card = await seedOverflowSession(
-        sessionId: sessionId,
-        charDbId: 'char-gistlock-fnporch-$i',
-        emotion: kEmotion,
-        fixation: kFixation,
-      );
-      await db.insertJournalCard(
-        JournalMemoriesCompanion(
-          sessionId: Value(sessionId),
-          characterId: Value(card.stableGroupId),
-          content: const Value(kThePorchSwing),
-          category: const Value('about_us'),
-          heat: const Value(0.9),
-        ),
-      );
-      memory.retrieveCalls = 0;
-      memory.canned = [
-        RetrievedMemory(
-          content: window,
-          characterId: 'Nia',
-          sessionId: sessionId,
-          positionStart: 0,
-          positionEnd: 0,
-          score: 0.9,
-        ),
+  test(
+    'LOCK: leftover-empty only — this/my/our/your-porch swing still DROP',
+    () async {
+      const cases = [
+        {'tag': 'this-porch swing', 'window': kThisPorchSwing},
+        {'tag': 'my-porch swing', 'window': kMyPorchSwing},
+        {'tag': 'our-porch swing', 'window': kOurPorchSwing},
+        {'tag': 'your-porch swing', 'window': kYourPorchSwing},
       ];
-      llm.chatPrompts.clear();
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']!;
+        final window = c['window']!;
+        final sessionId = 'sess-gistlock-fnporch-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-fnporch-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: const Value(kThePorchSwing),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
 
-      await chat.sendMessage(kSit);
+        await chat.sendMessage(kSit);
 
-      expect(
-        memory.retrieveCalls,
-        greaterThan(0),
-        reason: 'retrieve ran — a skip would fake the cover-drop',
-      );
-      expect(llm.chatPrompts, isNotEmpty);
-      final prompt = llm.chatPrompts.last;
-      expect(
-        prompt,
-        contains(kThePorchSwing),
-        reason: 'the porch-swing gist must inject or DROP was never tested',
-      );
-      expect(
-        prompt,
-        isNot(contains(kRagRememberedHeader.trim())),
-        reason:
-            'leftover-empty only — "$tag" has no leftover. Function words '
-            'do not mint leftover. "$tag" must still DROP',
-      );
-      expect(
-        prompt,
-        isNot(contains(window)),
-        reason: '"$tag" still DROPS — "$window" must not reach the prompt',
-      );
-    }
-  });
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'retrieve ran — a skip would fake the cover-drop',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(kThePorchSwing),
+          reason: 'the porch-swing gist must inject or DROP was never tested',
+        );
+        expect(
+          prompt,
+          isNot(contains(kRagRememberedHeader.trim())),
+          reason:
+              'leftover-empty only — "$tag" has no leftover. Function words '
+              'do not mint leftover. "$tag" must still DROP',
+        );
+        expect(
+          prompt,
+          isNot(contains(window)),
+          reason: '"$tag" still DROPS — "$window" must not reach the prompt',
+        );
+      }
+    },
+  );
 }

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -1,0 +1,396 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Leftover gist-first recall locks on the REAL ChatService god path.
+//
+// Helper suites already pin composeRagQuery / dropCoveredRagWindows /
+// shouldRetrieveRag / lastSpokenLineFromMessages as leaves. Those stay green
+// if ChatService stops passing the scalars into retrieve, or starts using
+// photo captions for quote-ask. This file drives one real turn on an
+// arranged overflow transcript and spies retrieve's queryText.
+//
+// GREEN is the query / header / skip / journal-inject shape. Refused as
+// stand-alone greens: rag_receipt exists, score ≥ 0.45, contains the last
+// user line, a MemoryService that always returns a plant.
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:front_porch_ai/database/database.dart';
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/chat/chat.dart';
+import 'package:front_porch_ai/services/embedding_service.dart';
+import 'package:front_porch_ai/services/memory_service.dart';
+import 'package:front_porch_ai/services/services.dart';
+import 'package:front_porch_ai/utils/character_id.dart';
+
+void _setupPathProviderMock() {
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return Directory.systemTemp.createTempSync('fpai_gistlock_').path;
+        }
+        return null;
+      });
+}
+
+/// Records retrieve queryText. Default return is empty — a plant is never
+/// the green. Callers that need an injected block set [canned] explicitly
+/// to inspect the header / remembered line (quote-ask vs gist).
+class _QuerySpyMemory extends MemoryService {
+  _QuerySpyMemory(super.embedding, super.storage, super.db);
+
+  String? lastQuery;
+  int retrieveCalls = 0;
+  List<RetrievedMemory> canned = const [];
+
+  @override
+  bool get isOperational => true;
+
+  @override
+  Future<List<double>?> embedText(String text) async => null;
+
+  @override
+  Future<List<RetrievedMemory>> retrieve({
+    required String queryText,
+    required List<String> sourceCharacterIds,
+    required String currentSessionId,
+    int inContextStart = 0,
+    int limit = 5,
+    double minScore = MemoryService.kRagMinScore,
+    Map<String, double>? characterPriorities,
+    Set<String> sessionScopedCharacterIds = const {},
+  }) async {
+    retrieveCalls++;
+    lastQuery = queryText;
+    return canned;
+  }
+}
+
+class _ScriptedLlm extends LLMService {
+  final List<String> chatPrompts = [];
+
+  static const _reply =
+      '*She rocks slowly, the porch boards creaking under the runners, and '
+      'talks about the garden, the neighbours, the way the light moves '
+      'through the screen door in the late afternoon, unhurried. She lists '
+      'the tomatoes that came in early, the fence post that needs setting, '
+      'the dog two doors down that has learned to open the gate latch, the '
+      'smell of cut grass drifting from the corner lot, and the way the '
+      'cicadas start all at once as if someone threw a switch somewhere '
+      'down the street, and she keeps talking, easy and unhurried, letting '
+      'the evening stretch itself out as far as it will go.*';
+
+  @override
+  Stream<String> generateStream(GenerationParams params) async* {
+    final p = params.prompt;
+    if (params.systemPrompt != null) {
+      chatPrompts.add(p);
+      yield _reply;
+      return;
+    }
+    if (p.contains('current physical position and stance')) {
+      yield '{"posture": "none"}';
+      return;
+    }
+    if (p.contains('minutes_elapsed')) {
+      yield '{"minutes_elapsed": 5, "new_day": false}';
+      return;
+    }
+    if (p.contains('relationship_delta')) {
+      yield '{"relationship_delta":0,"trust_delta":0,'
+          '"bond_reason":"steady","trust_reason":"steady"}';
+      return;
+    }
+    if (p.contains('emotion_intensity')) {
+      yield '{"emotion":"neutral","emotion_intensity":"mild"}';
+      return;
+    }
+    if (p.contains('fixation_topic')) {
+      yield '{"fixation_topic":"none","proposed_objective":"none"}';
+      return;
+    }
+    yield '';
+  }
+
+  @override
+  bool get isReady => true;
+
+  @override
+  String get backendName => 'ScriptedLlm';
+}
+
+const kGist = 'I still think about the spare key under the third flowerpot';
+const kEmotion = 'wistful';
+const kFixation = 'the spare key';
+const kSit = 'Evening. Mind if I sit?';
+const kFactWindow =
+    'You: the spare key lives under the third flowerpot\n'
+    'Nia: I still think about the spare key under the third flowerpot';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  _setupPathProviderMock();
+
+  late AppDatabase db;
+  late StorageService storage;
+  late ChatService chat;
+  late _ScriptedLlm llm;
+  late _QuerySpyMemory memory;
+
+  setUp(() async {
+    HttpOverrides.global = null;
+    SharedPreferences.setMockInitialValues({
+      'update_auto_check': false,
+      'realism_default': false,
+      'rag_enabled': true,
+      'journal_enabled': true,
+      'context_size': 3072,
+    });
+    db = AppDatabase.forTesting();
+    storage = StorageService();
+    llm = _ScriptedLlm();
+    chat =
+        ChatService(
+            KoboldService(storage),
+            UserPersonaService(db),
+            storage,
+            WorldRepository(storage, db),
+          )
+          ..setDatabase(db)
+          ..setCharacterRepository(CharacterRepository(db, storage))
+          ..testLlmServiceOverride = llm;
+    await storage.initialized;
+    memory = _QuerySpyMemory(EmbeddingService(storage), storage, db);
+    chat.setMemoryService(memory);
+  });
+
+  tearDown(() async {
+    chat.dispose();
+    await db.close();
+  });
+
+  Future<CharacterCard> seedOverflowSession({
+    required String sessionId,
+    required String charDbId,
+    String emotion = '',
+    String fixation = '',
+  }) async {
+    final card = CharacterCard(
+      name: 'Nia',
+      description: 'Exists only inside the gist-first recall lock suite.',
+      firstMessage: 'The porch light hums in the dusk.',
+      frontPorchExtensions: FrontPorchExtensions(
+        realismEnabled: false,
+        needsSimEnabled: false,
+        chaosModeEnabled: false,
+      ),
+    )..dbId = charDbId;
+    await chat.setActiveCharacter(card);
+    await db.insertSession(
+      SessionsCompanion.insert(
+        id: sessionId,
+        characterId: Value(charDbId),
+        characterEmotion: Value(emotion),
+        activeFixation: Value(fixation),
+        realismEnabled: const Value(false),
+      ),
+    );
+    for (var i = 0; i < 24; i++) {
+      final isUser = i.isOdd;
+      await db.insertMessage(
+        MessagesCompanion.insert(
+          id: 'seed-$sessionId-$i',
+          sessionId: sessionId,
+          position: i,
+          sender: isUser ? 'You' : 'Nia',
+          isUser: isUser,
+          swipes: Value('["${_ScriptedLlm._reply.replaceAll('*', '')}"]'),
+        ),
+      );
+    }
+    await chat.loadSession(sessionId);
+    expect(chat.messages, hasLength(24), reason: 'the seed must load');
+    return card;
+  }
+
+  test(
+    'LOCK 5: composeRagQuery scalars actually reach retrieve on the god path',
+    () async {
+      const sessionId = 'sess-gistlock-scalars';
+      final card = await seedOverflowSession(
+        sessionId: sessionId,
+        charDbId: 'char-gistlock-scalars',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      expect(chat.characterEmotion, kEmotion);
+      expect(chat.relationshipService.activeFixation, kFixation);
+
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value(sessionId),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kGist),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason:
+            'the retrieval gate never opened — overflow seed did not drop, '
+            'so the scalars were never handed to retrieve',
+      );
+      final expected = composeRagQuery(
+        emotion: kEmotion,
+        fixation: kFixation,
+        hotJournalLine: kGist,
+        lastWords: 'User: $kSit',
+      );
+      expect(
+        memory.lastQuery,
+        expected,
+        reason:
+            'emotion + activeFixation + top hot journal + last spoken must '
+            'be the retrieve queryText. A last-3 dump, last-line-only, or '
+            'dropped scalar goes red here. Returning a plant is not green.',
+      );
+      expect(memory.lastQuery, isNot(equals('User: $kSit')));
+      expect(memory.lastQuery, contains('feeling $kEmotion'));
+      expect(memory.lastQuery, contains('on the mind: $kFixation'));
+      expect(memory.lastQuery, contains('remembered: $kGist'));
+      expect(memory.lastQuery, contains(kSit));
+    },
+  );
+
+  test(
+    'LOCK 4: cue-less sit-down skips retrieve; quote-reach still searches',
+    () async {
+      await seedOverflowSession(
+        sessionId: 'sess-gistlock-cueless',
+        charDbId: 'char-gistlock-cueless',
+      );
+      expect(chat.characterEmotion, isEmpty);
+      expect(chat.relationshipService.activeFixation, isEmpty);
+
+      await chat.sendMessage(kSit);
+      expect(
+        memory.retrieveCalls,
+        0,
+        reason: 'cue-less sit-down must not last-1 search',
+      );
+      expect(memory.lastQuery, isNull);
+
+      await chat.sendMessage('remember where the spare key lives?');
+      expect(
+        memory.retrieveCalls,
+        1,
+        reason:
+            'quote-reach still searches even with no emotion/fixation/journal',
+      );
+      expect(memory.lastQuery, contains('remember where the spare key lives?'));
+    },
+  );
+
+  test(
+    'LOCK 4: journal gist can still inject when retrieve is skipped',
+    () async {
+      final card = await seedOverflowSession(
+        sessionId: 'sess-gistlock-journal',
+        charDbId: 'char-gistlock-journal',
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-journal'),
+          characterId: Value(card.stableGroupId),
+          content: const Value(
+            'I set my car keys down — on the hallway table.',
+          ),
+          category: const Value('item'),
+          heat: const Value(0.1),
+          metadata: const Value('{"kind":"item","item":"car keys"}'),
+        ),
+      );
+
+      await chat.sendMessage('where did I put my keys?');
+
+      expect(
+        memory.retrieveCalls,
+        0,
+        reason: 'naming keys is not a RAG cue — retrieve stays skipped',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      expect(
+        llm.chatPrompts.last,
+        contains('hallway table'),
+        reason:
+            'cue-less skip is retrieve-only — a journal gist (cold item '
+            'card named this beat) must still inject',
+      );
+    },
+  );
+
+  test(
+    'LOCK 3: caption remember-our-beach-day + spoken sit is NOT quote-reach',
+    () async {
+      await seedOverflowSession(
+        sessionId: 'sess-gistlock-caption',
+        charDbId: 'char-gistlock-caption',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+
+      final photoMsg = chat.messages.lastWhere((m) => m.isUser);
+      photoMsg.activeMetadata ??= {};
+      photoMsg.activeMetadata!['is_user_image'] = true;
+      photoMsg.activeMetadata!['image_caption'] = 'remember our beach day';
+
+      memory.canned = [
+        RetrievedMemory(
+          content: kFactWindow,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-caption',
+          positionStart: 0,
+          positionEnd: 1,
+          score: 0.9,
+        ),
+      ];
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so the header is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(prompt, contains(kRagRememberedHeader.trim()));
+      expect(
+        prompt,
+        isNot(contains(kRagQuoteHeader.trim())),
+        reason:
+            'caption "remember our beach day" + spoken "$kSit" must not '
+            'trip quote-reach — last spoken line only',
+      );
+      expect(prompt, contains('spare key'));
+      expect(prompt, contains('flowerpot'));
+      expect(
+        prompt,
+        isNot(contains('You: the spare key lives under the third flowerpot')),
+        reason:
+            'plain path injects one remembered line, not the You:/Nia: window',
+      );
+    },
+  );
+}

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -41,8 +41,12 @@
 // hidden/tucked/buried/stays/rests/lives/lives-hidden KEEP in prefix,
 // interior, AND suffix. Two-line lives-under: lives line KEEP, exact
 // gist line still strips. sat-on-porch KEEP. this/my/our/your-porch
-// swing DROP (function words do not mint leftover). Covered lines
-// strip into contiguous runs; each run remaps its span.
+// swing DROP (function words do not mint leftover). gist+safe / felt /
+// remember and gist+yesterday / tomorrow / morning / evening KEEP —
+// time filler and journal boilerplate no longer strip leftover.
+// porch-swing × tomorrow KEEP. without vs under still DROPS;
+// function-word set stays 74. Covered lines strip into contiguous
+// runs; each run remaps its span.
 
 import 'dart:io';
 
@@ -285,6 +289,23 @@ const kMyPorchSwing = 'Nia: my porch swing creaked tonight';
 const kOurPorchSwing = 'Nia: our porch swing creaked tonight';
 const kYourPorchSwing = 'Nia: your porch swing creaked tonight';
 const kSatOnPorch = 'I sat on porch; the swing creaked tonight';
+const kGistSafe =
+    'Nia: I still think about the spare key under the third flowerpot safe';
+const kGistFelt =
+    'Nia: I still think about the spare key under the third flowerpot felt';
+const kGistRemember =
+    'Nia: I still think about the spare key under the third flowerpot remember';
+const kGistYesterday =
+    'Nia: I still think about the spare key under the third flowerpot yesterday';
+const kGistTomorrow =
+    'Nia: I still think about the spare key under the third flowerpot tomorrow';
+const kGistMorning =
+    'Nia: I still think about the spare key under the third flowerpot morning';
+const kGistEvening =
+    'Nia: I still think about the spare key under the third flowerpot evening';
+const kPorchSwingTomorrow = 'Nia: the porch swing creaked tomorrow';
+const kGistWithout =
+    'Nia: I still think about the spare key without the third flowerpot';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -1431,6 +1452,42 @@ void main() {
           'time filler and journal boilerplate must not strip cover leftover '
           '— gist+safe / gist+yesterday are leftover KEEP',
     );
+    final leftoverAt = src.indexOf(
+      'final leftover = window.toSet().difference',
+    );
+    expect(
+      leftoverAt,
+      greaterThanOrEqualTo(0),
+      reason: 'Joe lock leftover is set-difference of cover tokens',
+    );
+    final leftoverSlice = src.substring(
+      leftoverAt,
+      (leftoverAt + 280).clamp(0, src.length),
+    );
+    expect(
+      leftoverSlice.contains('_kTimeFiller') ||
+          leftoverSlice.contains('_kJournalBoilerplate') ||
+          leftoverSlice.contains('_kCoverFiller'),
+      isFalse,
+      reason:
+          'leftover must not be filtered by time/journal/cover filler — '
+          'those sets used to erase gist+safe / gist+yesterday',
+    );
+    expect(
+      leftoverSlice.contains('leftover.isEmpty'),
+      isTrue,
+      reason: 'DROP only when leftover is empty',
+    );
+    expect(
+      src.contains('leftover.where') ||
+          src.contains('leftover.difference(_kTimeFiller') ||
+          src.contains('leftover.difference(_kJournalBoilerplate') ||
+          src.contains('leftover.difference(_kCoverFiller'),
+      isFalse,
+      reason:
+          'leftover tokens must not be filtered by filler sets after '
+          'the set-difference',
+    );
     expect(
       src.contains('leftover.length == 1'),
       isFalse,
@@ -1878,6 +1935,15 @@ void main() {
         reason:
             "'$w' belongs in the closed function-word set — do not mint "
             '${w}porch compounds',
+      );
+    }
+    for (final w in ['without', 'under']) {
+      expect(
+        fn.contains("'$w'"),
+        isTrue,
+        reason:
+            "'$w' stays in the closed function-word set — without vs "
+            'under still DROPS. Do not grow or shrink the set to flip that pin',
       );
     }
     expect(
@@ -3482,6 +3548,155 @@ void main() {
           isNot(contains(window)),
           reason: '"$tag" still DROPS — "$window" must not reach the prompt',
         );
+      }
+    },
+  );
+
+  test(
+    'LOCK: leftover-empty only — time/journal leftover KEEP; without still DROP',
+    () async {
+      const cases = [
+        {
+          'tag': 'gist+safe',
+          'card': kGist,
+          'window': kGistSafe,
+          'kept': 'safe',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+felt',
+          'card': kGist,
+          'window': kGistFelt,
+          'kept': 'felt',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+remember',
+          'card': kGist,
+          'window': kGistRemember,
+          'kept': 'remember',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+yesterday',
+          'card': kGist,
+          'window': kGistYesterday,
+          'kept': 'yesterday',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+tomorrow',
+          'card': kGist,
+          'window': kGistTomorrow,
+          'kept': 'tomorrow',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+morning',
+          'card': kGist,
+          'window': kGistMorning,
+          'kept': 'morning',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+evening',
+          'card': kGist,
+          'window': kGistEvening,
+          'kept': 'evening',
+          'drop': false,
+        },
+        {
+          'tag': 'porch-swing × tomorrow',
+          'card': kThePorchSwing,
+          'window': kPorchSwingTomorrow,
+          'kept': 'tomorrow',
+          'drop': false,
+        },
+        {
+          'tag': 'without vs under',
+          'card': kGist,
+          'window': kGistWithout,
+          'kept': 'without',
+          'drop': true,
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']! as String;
+        final cardText = c['card']! as String;
+        final window = c['window']! as String;
+        final kept = c['kept']! as String;
+        final drop = c['drop']! as bool;
+        final sessionId = 'sess-gistlock-fillerleftover-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-fillerleftover-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: Value(cardText),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason: 'cues are present — retrieve must run so cover-drop is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(cardText),
+          reason:
+              'the "$cardText" card must inject or leftover KEEP/DROP was '
+              'never tested',
+        );
+        if (drop) {
+          expect(
+            prompt,
+            isNot(contains(kRagRememberedHeader.trim())),
+            reason:
+                'leftover-empty only — "$tag" must still DROP. Function '
+                'words do not mint leftover. Growing the set to KEEP '
+                'without goes red here',
+          );
+          expect(
+            prompt,
+            isNot(contains(window)),
+            reason: '"$tag" still DROPS — "$window" must not reach the prompt',
+          );
+        } else {
+          expect(prompt, contains(kRagRememberedHeader.trim()));
+          expect(
+            prompt,
+            contains(kept),
+            reason:
+                'time/journal leftover is leftover — "$tag" must KEEP '
+                '"$kept". Stripping leftover via _kTimeFiller / '
+                '_kJournalBoilerplate goes red here',
+          );
+        }
       }
     },
   );

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -219,6 +219,16 @@ const kSpareKeyRan = 'Nia: the spare key ran';
 const kThirdFlowerpotFell = 'Nia: the third flowerpot fell';
 const kGistThatCreaked =
     'Nia: I still think about the spare key under the third flowerpot that creaked';
+const kPotCreaked = 'Nia: the spare key under the third flowerpot creaked';
+const kGistDied =
+    'Nia: I still think about the spare key under the third flowerpot died';
+const kGistSat =
+    'Nia: I still think about the spare key under the third flowerpot sat';
+const kBuriedUnder = 'Nia: the spare key buried under the third flowerpot';
+const kStaysUnder = 'Nia: the spare key stays under the third flowerpot';
+const kRestsUnder = 'Nia: the spare key rests under the third flowerpot';
+const kHerPorchSwing = 'I sat on her porch swing';
+const kSatFrontPorchSwing = 'Nia: I sat on the front porch swing';
 const kGistPlusSwing =
     'Nia: I still think about the spare key under the third flowerpot\n'
     'Nia: the swing creaked';
@@ -1275,6 +1285,44 @@ void main() {
           'leftover.every(!distinctive) && shortD>=3 is leftover==1 for died/sat',
     );
     expect(
+      src.contains('_kParaphrase') ||
+          src.contains('_kInteriorVerb') ||
+          src.contains('_kSameBeatVerb') ||
+          src.contains('_kRestateVerb') ||
+          src.contains('_kCoverVerb'),
+      isFalse,
+      reason:
+          'a source-scan that finds a new closed paraphrase/verb list '
+          '(besides the existing function-word set) MUST FAIL',
+    );
+    for (final w in ['tucked', 'buried', 'stays', 'rests']) {
+      expect(
+        src.contains("'$w'") || src.contains('"$w"'),
+        isFalse,
+        reason:
+            'no verb list — "$w" must not appear as a product string. '
+            'Interior leftover DROPS without naming tucked/buried/stays/rests',
+      );
+    }
+    final normAt = src.indexOf('String _normalizeCoverLine(');
+    expect(
+      normAt,
+      greaterThanOrEqualTo(0),
+      reason:
+          'cover normalize must still exist so place-compound fold has a home',
+    );
+    final normSlice = src.substring(
+      normAt,
+      (normAt + 400).clamp(0, src.length),
+    );
+    expect(
+      normSlice.contains('_foldPlaceCompounds'),
+      isTrue,
+      reason:
+          'place-compound fold belongs in cover normalize — frontporch '
+          'must not sit as interior leftover between shared tokens',
+    );
+    expect(
       src.contains('leftover.length == 1'),
       isFalse,
       reason:
@@ -2002,6 +2050,9 @@ void main() {
           'window': 'Nia: the spare key tucked under the third flowerpot',
           'absent': 'tucked',
         },
+        {'tag': 'buried under', 'window': kBuriedUnder, 'absent': 'buried'},
+        {'tag': 'stays under', 'window': kStaysUnder, 'absent': 'stays'},
+        {'tag': 'rests under', 'window': kRestsUnder, 'absent': 'rests'},
       ];
       for (var i = 0; i < cases.length; i++) {
         final c = cases[i];
@@ -2450,6 +2501,34 @@ void main() {
           'kept': 'hidden',
           'drop': true,
         },
+        {
+          'tag': 'that creaked',
+          'card': kGist,
+          'window': kGistThatCreaked,
+          'kept': 'creaked',
+          'drop': false,
+        },
+        {
+          'tag': 'pot creaked',
+          'card': kGist,
+          'window': kPotCreaked,
+          'kept': 'creaked',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+died',
+          'card': kGist,
+          'window': kGistDied,
+          'kept': 'died',
+          'drop': false,
+        },
+        {
+          'tag': 'gist+sat',
+          'card': kGist,
+          'window': kGistSat,
+          'kept': 'sat',
+          'drop': false,
+        },
       ];
       for (var i = 0; i < cases.length; i++) {
         final c = cases[i];
@@ -2509,10 +2588,10 @@ void main() {
             prompt,
             isNot(contains(kRagRememberedHeader.trim())),
             reason:
-                'same-beat leftover is a closed paraphrase set '
-                '(lives / hidden / creaked), not leftover==1 and not '
-                'leftover==2. "$tag" must DROP. Flipping ==1 to ==2 is '
-                'fake-green — DROP is kind, not count',
+                'same-beat is INTERIOR leftover (tokens between first and '
+                'last shared token) — no closed paraphrase/verb list. '
+                '"$tag" must DROP. A verb list of lives/hidden/creaked '
+                'or leftover==1/==2 is fake-green',
           );
           expect(
             prompt,
@@ -2526,9 +2605,9 @@ void main() {
             prompt,
             contains(kept),
             reason:
-                'distinctive leftover is an extra fact — "$tag" must KEEP '
-                '"$kept". leftover==1 on a 3-distinctive gist treats '
-                'burned / lighthouse as paraphrase and goes red here',
+                'suffix leftover is an extra fact — "$tag" must KEEP '
+                '"$kept". that-creaked / pot-creaked / burned / died / sat '
+                'KEEP; leftover==1 or a creaked verb list goes red here',
           );
         }
       }
@@ -2772,4 +2851,72 @@ void main() {
     expect(widePreview, contains('swing'));
     expect(widePreview, isNot(contains('flowerpot')));
   });
+
+  test(
+    'LOCK: place-compound fold — frontporch is not interior leftover',
+    () async {
+      expect(
+        coverContentTokens(kSatFrontPorchSwing),
+        contains('frontporch'),
+        reason:
+            'cover normalize must fold front+porch so "front" is not an '
+            'interior leftover token between sat and swing',
+      );
+      expect(
+        coverContentTokens(kSatFrontPorchSwing),
+        isNot(contains('front')),
+        reason: 'frontporch is one token — "front" must not remain leftover',
+      );
+      final card = await seedOverflowSession(
+        sessionId: 'sess-gistlock-frontporch-fold',
+        charDbId: 'char-gistlock-frontporch-fold',
+        emotion: kEmotion,
+        fixation: kFixation,
+      );
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value('sess-gistlock-frontporch-fold'),
+          characterId: Value(card.stableGroupId),
+          content: const Value(kHerPorchSwing),
+          category: const Value('about_us'),
+          heat: const Value(0.9),
+        ),
+      );
+      memory.canned = [
+        RetrievedMemory(
+          content: kSatFrontPorchSwing,
+          characterId: 'Nia',
+          sessionId: 'sess-gistlock-frontporch-fold',
+          positionStart: 0,
+          positionEnd: 0,
+          score: 0.9,
+        ),
+      ];
+
+      await chat.sendMessage(kSit);
+
+      expect(
+        memory.retrieveCalls,
+        greaterThan(0),
+        reason: 'cues are present — retrieve must run so the fold is real',
+      );
+      expect(llm.chatPrompts, isNotEmpty);
+      final prompt = llm.chatPrompts.last;
+      expect(
+        prompt,
+        contains(kHerPorchSwing),
+        reason:
+            'the porch-swing card must inject or fold KEEP was never tested',
+      );
+      expect(prompt, contains(kRagRememberedHeader.trim()));
+      expect(
+        prompt,
+        contains('front'),
+        reason:
+            'place-compound fold in cover normalize — "I sat on her porch '
+            'swing" must NOT drop "I sat on the front porch swing". Without '
+            'the fold, "front" is interior leftover and the window DROPS',
+      );
+    },
+  );
 }

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -157,6 +157,10 @@ const kWraparoundPorchFeeling = 'I felt safe on the wraparound porch tonight';
 const kWraparoundPorchSwing = 'Nia: the wraparound porch swing creaked tonight';
 const kThePorchFeeling = 'I felt safe on the porch tonight';
 const kThePorchSwing = 'Nia: the porch swing creaked tonight';
+const kFrontStepsFeeling = 'I felt safe on the front steps tonight';
+const kFrontStepsSwing = 'Nia: the front steps swing creaked tonight';
+const kBackPatioFeeling = 'I felt safe on the back patio tonight';
+const kBackPatioSwing = 'Nia: the back patio swing creaked tonight';
 const kSwingTight = 'Nia:the swing';
 const kSwingSpaced = 'Nia: the swing';
 const kSwingBare = 'the swing';
@@ -738,10 +742,22 @@ void main() {
           'set MUST FAIL — the product must not be that restricted list',
     );
     expect(
-      src.contains("{'the', 'a', 'an'}"),
+      src.contains("'this'") && src.contains("'on'"),
       isTrue,
       reason:
-          'the / a / an stay filler — do not fold "the porch" into theporch',
+          'this/my/our/your/on stay particles — do not fold thisporch/onporch',
+    );
+    expect(
+      src.contains("'steps'") &&
+          src.contains("'patio'") &&
+          src.contains("'walk'"),
+      isTrue,
+      reason: 'setting nouns are cover filler — not a longer fold-noun list',
+    );
+    expect(
+      src.contains(r'(porch|yard|lawn|deck|stoop|steps'),
+      isFalse,
+      reason: 'do not grow the fold noun list with steps/patio and stop',
     );
   });
 
@@ -763,6 +779,16 @@ void main() {
           'tag': 'screened porch',
           'feeling': kScreenedPorchFeeling,
           'swing': kScreenedPorchSwing,
+        },
+        {
+          'tag': 'front steps',
+          'feeling': kFrontStepsFeeling,
+          'swing': kFrontStepsSwing,
+        },
+        {
+          'tag': 'back patio',
+          'feeling': kBackPatioFeeling,
+          'swing': kBackPatioSwing,
         },
       ];
       for (var i = 0; i < cases.length; i++) {

--- a/test/services/chat/gist_first_recall_locks_test.dart
+++ b/test/services/chat/gist_first_recall_locks_test.dart
@@ -39,8 +39,10 @@
 // Short leftover is ANY extra content token on the longer side —
 // died/gone/fell/hid/ran count even when length < 5. Leftover kind,
 // not position: short leftover and long distinctive leftover are extra
-// facts. Length 5-6 distinctive leftover is restatement. Covered lines
-// strip into contiguous runs; each run remaps its span.
+// facts (any slot). Length 5-6 distinctive leftover is restatement
+// (any slot). leftover-empty is same-beat DROP. endsWith ned so burned
+// stays extra fact vs tucked/buried. Covered lines strip into
+// contiguous runs; each run remaps its span.
 
 import 'dart:io';
 
@@ -246,6 +248,28 @@ const kThreeLineGap =
     'Nia: the porch swing creaked tonight\n'
     'Nia: I still think about the spare key under the third flowerpot\n'
     'Nia: I sat on the front garden';
+const kSuffixHidden = 'Nia: the spare key under the third flowerpot hidden';
+const kSuffixTucked = 'Nia: the spare key under the third flowerpot tucked';
+const kSuffixBuried = 'Nia: the spare key under the third flowerpot buried';
+const kSuffixStays = 'Nia: the spare key under the third flowerpot stays';
+const kSuffixRests = 'Nia: the spare key under the third flowerpot rests';
+const kSuffixLives = 'Nia: the spare key under the third flowerpot lives';
+const kSuffixLivesHidden =
+    'Nia: the spare key under the third flowerpot lives hidden';
+const kInteriorBurned = 'Nia: the spare key burned under the third flowerpot';
+const kInteriorLighthouse =
+    'Nia: the spare key lighthouse under the third flowerpot';
+const kInteriorCreaked = 'Nia: the spare key creaked under the third flowerpot';
+const kInteriorDied = 'Nia: the spare key died under the third flowerpot';
+const kInteriorSat = 'Nia: the spare key sat under the third flowerpot';
+const kInteriorFell = 'Nia: the spare key fell under the third flowerpot';
+const kInteriorHid = 'Nia: the spare key hid under the third flowerpot';
+const kPrefixHid = 'Nia: hid the spare key under the third flowerpot';
+const kPrefixSat = 'Nia: sat the spare key under the third flowerpot';
+const kPrefixDied = 'Nia: died the spare key under the third flowerpot';
+const kPrefixHidden = 'Nia: hidden the spare key under the third flowerpot';
+const kPrefixTucked = 'Nia: tucked the spare key under the third flowerpot';
+const kSatOnPorch = 'I sat on porch; the swing creaked tonight';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -1294,21 +1318,82 @@ void main() {
           src.contains('_kInteriorVerb') ||
           src.contains('_kSameBeatVerb') ||
           src.contains('_kRestateVerb') ||
-          src.contains('_kCoverVerb'),
+          src.contains('_kCoverVerb') ||
+          src.contains('_kExtraFact') ||
+          src.contains('_kLeftoverKind'),
       isFalse,
       reason:
           'a source-scan that finds a new closed paraphrase/verb list '
           '(besides the existing function-word set) MUST FAIL',
     );
-    for (final w in ['tucked', 'buried', 'stays', 'rests']) {
+    for (final w in [
+      'hidden',
+      'tucked',
+      'buried',
+      'stays',
+      'rests',
+      'lives',
+      'creaked',
+      'burned',
+      'lighthouse',
+    ]) {
       expect(
         src.contains("'$w'") || src.contains('"$w"'),
         isFalse,
         reason:
             'no verb list — "$w" must not appear as a product string. '
-            'Interior leftover DROPS without naming tucked/buried/stays/rests',
+            'Length 5-6 distinctive leftover DROPS and long leftover KEEPS '
+            'without naming hidden/tucked/buried/stays/rests/lives',
       );
     }
+    expect(
+      src.contains("endsWith('ned')"),
+      isTrue,
+      reason:
+          'burned (6) stays extra fact vs tucked/buried — kind uses '
+          "endsWith('ned'), not a burned list",
+    );
+    expect(
+      src.contains('_kTimeFiller') &&
+          src.contains('_kJournalBoilerplate') &&
+          src.contains('_kCoverFiller'),
+      isTrue,
+      reason:
+          '_kTimeFiller, _kJournalBoilerplate, _kCoverFiller stay this '
+          'pass (not deleted, not grown)',
+    );
+    final timeAt = src.indexOf('const _kTimeFiller = {');
+    expect(timeAt, greaterThanOrEqualTo(0));
+    final timeEnd = src.indexOf('};', timeAt);
+    expect(
+      RegExp(r"'[a-z]+'").allMatches(src.substring(timeAt, timeEnd)).length,
+      8,
+      reason: '_kTimeFiller is not grown',
+    );
+    final jbAt = src.indexOf('const _kJournalBoilerplate = {');
+    expect(jbAt, greaterThanOrEqualTo(0));
+    final jbEnd = src.indexOf('};', jbAt);
+    expect(
+      RegExp(r"'[a-z]+'").allMatches(src.substring(jbAt, jbEnd)).length,
+      6,
+      reason: '_kJournalBoilerplate is not grown',
+    );
+    final coverAt = src.indexOf('const _kCoverFiller = {');
+    expect(coverAt, greaterThanOrEqualTo(0));
+    final coverEnd = src.indexOf('};', coverAt);
+    expect(
+      RegExp(r"'[a-z]+'").allMatches(src.substring(coverAt, coverEnd)).length,
+      43,
+      reason: '_kCoverFiller is not grown',
+    );
+    final fnAt = src.indexOf('const _kFunctionWords = {');
+    expect(fnAt, greaterThanOrEqualTo(0));
+    final fnEnd = src.indexOf('};', fnAt);
+    expect(
+      RegExp(r"'[a-z]+'").allMatches(src.substring(fnAt, fnEnd)).length,
+      74,
+      reason: 'function-word set unchanged',
+    );
     final normAt = src.indexOf('String _normalizeCoverLine(');
     expect(
       normAt,
@@ -2593,8 +2678,8 @@ void main() {
             prompt,
             isNot(contains(kRagRememberedHeader.trim())),
             reason:
-                'same-beat is INTERIOR leftover (tokens between first and '
-                'last shared token) — no closed paraphrase/verb list. '
+                'same-beat is leftover-empty or length 5-6 distinctive '
+                'leftover (any slot) — no closed paraphrase/verb list. '
                 '"$tag" must DROP. A verb list of lives/hidden/creaked '
                 'or leftover==1/==2 is fake-green',
           );
@@ -2610,9 +2695,10 @@ void main() {
             prompt,
             contains(kept),
             reason:
-                'suffix leftover is an extra fact — "$tag" must KEEP '
-                '"$kept". that-creaked / pot-creaked / burned / died / sat '
-                'KEEP; leftover==1 or a creaked verb list goes red here',
+                'short leftover and long distinctive leftover are extra '
+                'facts (any slot) — "$tag" must KEEP "$kept". that-creaked / '
+                'pot-creaked / burned / died / sat KEEP; leftover==1 or a '
+                'creaked verb list goes red here',
           );
         }
       }
@@ -2922,6 +3008,266 @@ void main() {
             'swing" must NOT drop "I sat on the front porch swing". Without '
             'the fold, "front" is interior leftover and the window DROPS',
       );
+    },
+  );
+
+  test(
+    'LOCK: leftover kind any slot — suffix hidden DROP; interior burned KEEP; prefix hid KEEP',
+    () async {
+      Set<String> bodyTokens(String s) =>
+          coverContentTokens(s.replaceFirst(RegExp(r'^[^:\n]{1,40}:\s*'), ''));
+      expect(
+        bodyTokens(kSuffixHidden).difference(bodyTokens(kGist)),
+        {'hidden'},
+        reason:
+            'suffix hidden is the 9e61 hole — suffix leftover used to KEEP. '
+            'Length 5-6 distinctive leftover is restatement, any slot',
+      );
+      expect(
+        bodyTokens(kInteriorBurned).difference(bodyTokens(kGist)),
+        {'burned'},
+        reason:
+            'interior burned is the 9e61 hole — interior leftover used to '
+            'DROP. endsWith ned keeps burned as an extra fact, any slot',
+      );
+      expect(
+        bodyTokens(kPrefixHid).difference(bodyTokens(kGist)),
+        {'hid'},
+        reason:
+            'prefix hid is the 9e61 hole — short prefix used to DROP. '
+            'Short leftover is an extra fact, any slot',
+      );
+      expect(
+        bodyTokens(kPrefixHidden).difference(bodyTokens(kGist)),
+        {'hidden'},
+        reason:
+            'prefix hidden is the 9e61 hole — distinctive prefix used to '
+            'KEEP. Length 5-6 distinctive leftover is restatement, any slot',
+      );
+
+      const cases = [
+        {
+          'tag': 'suffix hidden',
+          'card': kGist,
+          'window': kSuffixHidden,
+          'kept': 'hidden',
+          'drop': true,
+        },
+        {
+          'tag': 'suffix tucked',
+          'card': kGist,
+          'window': kSuffixTucked,
+          'kept': 'tucked',
+          'drop': true,
+        },
+        {
+          'tag': 'suffix buried',
+          'card': kGist,
+          'window': kSuffixBuried,
+          'kept': 'buried',
+          'drop': true,
+        },
+        {
+          'tag': 'suffix stays',
+          'card': kGist,
+          'window': kSuffixStays,
+          'kept': 'stays',
+          'drop': true,
+        },
+        {
+          'tag': 'suffix rests',
+          'card': kGist,
+          'window': kSuffixRests,
+          'kept': 'rests',
+          'drop': true,
+        },
+        {
+          'tag': 'suffix lives',
+          'card': kGist,
+          'window': kSuffixLives,
+          'kept': 'lives',
+          'drop': true,
+        },
+        {
+          'tag': 'suffix lives-hidden',
+          'card': kGist,
+          'window': kSuffixLivesHidden,
+          'kept': 'hidden',
+          'drop': true,
+        },
+        {
+          'tag': 'interior burned',
+          'card': kGist,
+          'window': kInteriorBurned,
+          'kept': 'burned',
+          'drop': false,
+        },
+        {
+          'tag': 'interior lighthouse',
+          'card': kGist,
+          'window': kInteriorLighthouse,
+          'kept': 'lighthouse',
+          'drop': false,
+        },
+        {
+          'tag': 'interior creaked',
+          'card': kGist,
+          'window': kInteriorCreaked,
+          'kept': 'creaked',
+          'drop': false,
+        },
+        {
+          'tag': 'interior died',
+          'card': kGist,
+          'window': kInteriorDied,
+          'kept': 'died',
+          'drop': false,
+        },
+        {
+          'tag': 'interior sat',
+          'card': kGist,
+          'window': kInteriorSat,
+          'kept': 'sat',
+          'drop': false,
+        },
+        {
+          'tag': 'interior fell',
+          'card': kGist,
+          'window': kInteriorFell,
+          'kept': 'fell',
+          'drop': false,
+        },
+        {
+          'tag': 'interior hid',
+          'card': kGist,
+          'window': kInteriorHid,
+          'kept': 'hid',
+          'drop': false,
+        },
+        {
+          'tag': 'prefix hid',
+          'card': kGist,
+          'window': kPrefixHid,
+          'kept': 'hid',
+          'drop': false,
+        },
+        {
+          'tag': 'prefix sat',
+          'card': kGist,
+          'window': kPrefixSat,
+          'kept': 'sat',
+          'drop': false,
+        },
+        {
+          'tag': 'prefix died',
+          'card': kGist,
+          'window': kPrefixDied,
+          'kept': 'died',
+          'drop': false,
+        },
+        {
+          'tag': 'prefix hidden',
+          'card': kGist,
+          'window': kPrefixHidden,
+          'kept': 'hidden',
+          'drop': true,
+        },
+        {
+          'tag': 'prefix tucked',
+          'card': kGist,
+          'window': kPrefixTucked,
+          'kept': 'tucked',
+          'drop': true,
+        },
+        {
+          'tag': 'sat-on-porch',
+          'card': kThePorchSwing,
+          'window': kSatOnPorch,
+          'kept': 'sat',
+          'drop': false,
+        },
+      ];
+      for (var i = 0; i < cases.length; i++) {
+        final c = cases[i];
+        final tag = c['tag']! as String;
+        final cardText = c['card']! as String;
+        final window = c['window']! as String;
+        final kept = c['kept']! as String;
+        final drop = c['drop']! as bool;
+        final sessionId = 'sess-gistlock-anyslot-$i';
+        final card = await seedOverflowSession(
+          sessionId: sessionId,
+          charDbId: 'char-gistlock-anyslot-$i',
+          emotion: kEmotion,
+          fixation: kFixation,
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: Value(sessionId),
+            characterId: Value(card.stableGroupId),
+            content: Value(cardText),
+            category: const Value('about_us'),
+            heat: const Value(0.9),
+          ),
+        );
+        memory.retrieveCalls = 0;
+        memory.canned = [
+          RetrievedMemory(
+            content: window,
+            characterId: 'Nia',
+            sessionId: sessionId,
+            positionStart: 0,
+            positionEnd: 0,
+            score: 0.9,
+          ),
+        ];
+        llm.chatPrompts.clear();
+
+        await chat.sendMessage(kSit);
+
+        expect(
+          memory.retrieveCalls,
+          greaterThan(0),
+          reason:
+              'cues are present — retrieve must run so leftover kind is real',
+        );
+        expect(llm.chatPrompts, isNotEmpty);
+        final prompt = llm.chatPrompts.last;
+        expect(
+          prompt,
+          contains(cardText),
+          reason:
+              'the "$cardText" card must inject or leftover kind was '
+              'never tested',
+        );
+        if (drop) {
+          expect(
+            prompt,
+            isNot(contains(kRagRememberedHeader.trim())),
+            reason:
+                'position is not kind — length 5-6 distinctive leftover '
+                'is restatement in any slot. "$tag" must DROP. A suffix-KEEP '
+                'or prefix-KEEP rule, or a hidden/tucked verb list, is '
+                'fake-green',
+          );
+          expect(
+            prompt,
+            isNot(contains(window)),
+            reason: '"$tag" still DROPS — "$window" must not reach the prompt',
+          );
+        } else {
+          expect(prompt, contains(kRagRememberedHeader.trim()));
+          expect(
+            prompt,
+            contains(kept),
+            reason:
+                'position is not kind — short leftover and long distinctive '
+                'leftover are extra facts in any slot. "$tag" must KEEP '
+                '"$kept". Interior-DROP, short-prefix-DROP, or sat-on-porch '
+                'DROP goes red here',
+          );
+        }
+      }
     },
   );
 }

--- a/test/services/chat/journal_expand_memory_test.dart
+++ b/test/services/chat/journal_expand_memory_test.dart
@@ -102,6 +102,7 @@ void main() {
       characterName: 'Mara',
       userName: 'Sam',
       queryText: 'Sam: you remember when we had our wedding vows here?',
+      lastWords: 'Sam: you remember when we had our wedding vows here?',
       messageCount: messages.length,
     );
     // The feeling (the card) is present…
@@ -115,8 +116,7 @@ void main() {
     expect(result.expandedPositions, {10, 11});
   });
 
-  test('an unrelated query injects the card but never the verbatim',
-      () async {
+  test('an unrelated query injects the card but never the verbatim', () async {
     await plantWeddingCard();
     final result = await injection().buildJournalBlock(
       characterId: cid,
@@ -130,21 +130,20 @@ void main() {
     expect(result.expandedPositions, isEmpty);
   });
 
-  test('age gate: receipts still near the transcript do not expand',
-      () async {
+  test('age gate: receipts still near the transcript do not expand', () async {
     await plantWeddingCard(positions: const [55]);
     final result = await injection().buildJournalBlock(
       characterId: cid,
       characterName: 'Mara',
       userName: 'Sam',
       queryText: 'Sam: remember our wedding vows?',
+      lastWords: 'Sam: remember our wedding vows?',
       messageCount: messages.length,
     );
     expect(result.expandedPositions, isEmpty);
   });
 
-  test('no-embedder floor: block renders, expansion silently absent',
-      () async {
+  test('no-embedder floor: block renders, expansion silently absent', () async {
     store = JournalStore(getDb: () => db); // no embedText
     await db.insertJournalCard(
       JournalMemoriesCompanion(
@@ -160,6 +159,7 @@ void main() {
       characterName: 'Mara',
       userName: 'Sam',
       queryText: 'Sam: remember?',
+      lastWords: 'Sam: remember?',
       messageCount: messages.length,
     );
     expect(result.text, contains('a hot memory'));
@@ -190,11 +190,10 @@ void main() {
         score: 0.7,
       ),
     ];
-    final kept = RetrievedMemory.excludingPositions(
-      mems,
-      {10, 11},
-      currentSessionId: sid,
-    );
+    final kept = RetrievedMemory.excludingPositions(mems, {
+      10,
+      11,
+    }, currentSessionId: sid);
     expect(kept.map((m) => m.content), [
       'an unrelated passage',
       'cross-session source (different position space)',

--- a/test/services/chat/journal_physics_test.dart
+++ b/test/services/chat/journal_physics_test.dart
@@ -21,7 +21,11 @@ import 'package:front_porch_ai/services/chat/journal_physics.dart';
 import 'package:front_porch_ai/services/chat/journal_store.dart';
 import 'package:front_porch_ai/services/chat/prompt_injection/journal_injection.dart';
 
-ChatMessage _msg(String sender, String text, {Map<String, dynamic>? metadata}) =>
+ChatMessage _msg(
+  String sender,
+  String text, {
+  Map<String, dynamic>? metadata,
+}) =>
     ChatMessage(text: text, sender: sender, isUser: false, metadata: metadata);
 
 Uint8List _vecBytes(List<double> v) {
@@ -56,10 +60,29 @@ void main() {
     );
 
     test('flashbulb decay: mild fades normally, strong barely at all', () {
-      expect(JournalPhysics.cooledHeat(card(intensity: 'mild')), closeTo(0.85, 1e-9));
-      expect(JournalPhysics.cooledHeat(card(intensity: null)), closeTo(0.85, 1e-9));
-      expect(JournalPhysics.cooledHeat(card(intensity: 'moderate')), closeTo(0.925, 1e-9));
-      expect(JournalPhysics.cooledHeat(card(intensity: 'strong')), closeTo(0.9775, 1e-9));
+      expect(
+        JournalPhysics.cooledHeat(card(intensity: 'mild')),
+        closeTo(0.85, 1e-9),
+      );
+      expect(
+        JournalPhysics.cooledHeat(card(intensity: null)),
+        closeTo(0.85, 1e-9),
+      );
+      expect(
+        JournalPhysics.cooledHeat(card(intensity: 'moderate')),
+        closeTo(0.925, 1e-9),
+      );
+      expect(
+        JournalPhysics.cooledHeat(card(intensity: 'strong')),
+        closeTo(0.9775, 1e-9),
+      );
+    });
+
+    test('topHotJournalLine picks the hottest card and ignores cold ones', () {
+      final cold = card(heat: 0.1);
+      final hot = card(heat: 0.9);
+      expect(JournalPhysics.topHotJournalLine([cold, hot], 'wistful'), 'c');
+      expect(JournalPhysics.topHotJournalLine([cold], 'wistful'), isNull);
     });
 
     test('pinned never decays and heat floors at zero', () {
@@ -67,13 +90,16 @@ void main() {
       expect(JournalPhysics.cooledHeat(card(heat: 0.05)), 0.0);
     });
 
-    test('milestone cards never cool but are not always-injected (Living Time v1.5)', () {
-      final m = card(kind: 'milestone', heat: 1.0, intensity: 'mild');
-      expect(JournalPhysics.isMilestone(m), isTrue);
-      expect(JournalPhysics.cooledHeat(m), 1.0);
-      expect(JournalPhysics.isHot(m), isFalse);
-      expect(JournalPhysics.cardKind(m), 'milestone');
-    });
+    test(
+      'milestone cards never cool but are not always-injected (Living Time v1.5)',
+      () {
+        final m = card(kind: 'milestone', heat: 1.0, intensity: 'mild');
+        expect(JournalPhysics.isMilestone(m), isTrue);
+        expect(JournalPhysics.cooledHeat(m), 1.0);
+        expect(JournalPhysics.isHot(m), isFalse);
+        expect(JournalPhysics.cardKind(m), 'milestone');
+      },
+    );
 
     test('promise cards are ledger-class (Train B)', () {
       final p = card(kind: 'promise', heat: 1.0, intensity: 'mild');
@@ -84,7 +110,10 @@ void main() {
     });
 
     test('hot/cold threshold, pinned always hot', () {
-      expect(JournalPhysics.isHot(card(heat: JournalPhysics.kColdThreshold)), isTrue);
+      expect(
+        JournalPhysics.isHot(card(heat: JournalPhysics.kColdThreshold)),
+        isTrue,
+      );
       expect(JournalPhysics.isHot(card(heat: 0.1)), isFalse);
       expect(JournalPhysics.isHot(card(heat: 0.0, pinned: true)), isTrue);
     });
@@ -93,7 +122,10 @@ void main() {
       expect(JournalPhysics.emotionFamily('wistful'), 'sadness');
       expect(JournalPhysics.emotionFamily('Melancholy '), 'sadness');
       expect(JournalPhysics.emotionFamily('taken aback'), 'surprise');
-      expect(JournalPhysics.emotionFamily('gribble'), 'gribble'); // unknown = own family
+      expect(
+        JournalPhysics.emotionFamily('gribble'),
+        'gribble',
+      ); // unknown = own family
       expect(JournalPhysics.emotionFamily(null), '');
     });
 
@@ -113,13 +145,21 @@ void main() {
     test('salient events: big swings, trust repair, chance time', () {
       expect(
         JournalPhysics.hasSalientEvent([
-          _msg('Mara', 'x', metadata: {'bond_delta': JournalPhysics.kEventBondSwing}),
+          _msg(
+            'Mara',
+            'x',
+            metadata: {'bond_delta': JournalPhysics.kEventBondSwing},
+          ),
         ]),
         isTrue,
       );
       expect(
         JournalPhysics.hasSalientEvent([
-          _msg('Mara', 'x', metadata: {'bond_delta': -JournalPhysics.kEventBondSwing}),
+          _msg(
+            'Mara',
+            'x',
+            metadata: {'bond_delta': -JournalPhysics.kEventBondSwing},
+          ),
         ]),
         isTrue,
       );
@@ -137,7 +177,11 @@ void main() {
       );
       expect(
         JournalPhysics.hasSalientEvent([
-          _msg('Mara', 'x', metadata: {'chance_time_event': 'A stranger arrives'}),
+          _msg(
+            'Mara',
+            'x',
+            metadata: {'chance_time_event': 'A stranger arrives'},
+          ),
         ]),
         isTrue,
       );
@@ -172,8 +216,10 @@ void main() {
         emotionIntensity: intensity,
         maxCards: 200,
       );
-      return (await store.cardsFor('s1', 'mara'))
-          .firstWhere((c) => c.content == content);
+      return (await store.cardsFor(
+        's1',
+        'mara',
+      )).firstWhere((c) => c.content == content);
     }
 
     test('coolCards applies intensity-modified decay, skips pinned', () async {
@@ -275,40 +321,39 @@ void main() {
       expect((await store.cardsFor('s1', 'mara')).single.embedding, isNotNull);
     });
 
-    test('embedMissing vectors only unembedded cards; no embedder = no-op',
-        () async {
-      var calls = 0;
-      final embeddingStore = JournalStore(
-        getDb: () => db,
-        embedText: (text) async {
-          calls++;
-          return [0.5, 0.5, 0.5];
-        },
-      );
-      await embeddingStore.addCard(
-        sessionId: 's1',
-        characterId: 'mara',
-        content: 'needs a vector',
-        category: 'moment',
-        maxCards: 200,
-      );
-      await store.embedMissing('s1', 'mara'); // store has NO embedder
-      expect(calls, 0);
-      expect(
-        (await store.cardsFor('s1', 'mara')).single.embedding,
-        isNull,
-      );
+    test(
+      'embedMissing vectors only unembedded cards; no embedder = no-op',
+      () async {
+        var calls = 0;
+        final embeddingStore = JournalStore(
+          getDb: () => db,
+          embedText: (text) async {
+            calls++;
+            return [0.5, 0.5, 0.5];
+          },
+        );
+        await embeddingStore.addCard(
+          sessionId: 's1',
+          characterId: 'mara',
+          content: 'needs a vector',
+          category: 'moment',
+          maxCards: 200,
+        );
+        await store.embedMissing('s1', 'mara'); // store has NO embedder
+        expect(calls, 0);
+        expect((await store.cardsFor('s1', 'mara')).single.embedding, isNull);
 
-      await embeddingStore.embedMissing('s1', 'mara');
-      expect(calls, 1);
-      final card = (await store.cardsFor('s1', 'mara')).single;
-      expect(card.embedding, isNotNull);
-      expect(card.dimensions, 3);
+        await embeddingStore.embedMissing('s1', 'mara');
+        expect(calls, 1);
+        final card = (await store.cardsFor('s1', 'mara')).single;
+        expect(card.embedding, isNotNull);
+        expect(card.dimensions, 3);
 
-      // Already-embedded cards are skipped on the next sweep.
-      await embeddingStore.embedMissing('s1', 'mara');
-      expect(calls, 1);
-    });
+        // Already-embedded cards are skipped on the next sweep.
+        await embeddingStore.embedMissing('s1', 'mara');
+        expect(calls, 1);
+      },
+    );
   });
 
   group('JournalInjection with physics', () {
@@ -343,62 +388,69 @@ void main() {
         emotionLabel: emotion,
         maxCards: 200,
       );
-      return (await store.cardsFor('s1', 'mara'))
-          .firstWhere((c) => c.content == content);
+      return (await store.cardsFor(
+        's1',
+        'mara',
+      )).firstWhere((c) => c.content == content);
     }
 
-    test('cold cards leave the always-injected set; pinned cold stay', () async {
-      final cold = await addOne('gone cold');
-      await db.updateJournalCard(
-        cold.id,
-        const JournalMemoriesCompanion(heat: Value(0.1)),
-      );
-      final pinnedCold = await addOne('pinned survivor');
-      await db.updateJournalCard(
-        pinnedCold.id,
-        const JournalMemoriesCompanion(heat: Value(0.0), pinned: Value(true)),
-      );
+    test(
+      'cold cards leave the always-injected set; pinned cold stay',
+      () async {
+        final cold = await addOne('gone cold');
+        await db.updateJournalCard(
+          cold.id,
+          const JournalMemoriesCompanion(heat: Value(0.1)),
+        );
+        final pinnedCold = await addOne('pinned survivor');
+        await db.updateJournalCard(
+          pinnedCold.id,
+          const JournalMemoriesCompanion(heat: Value(0.0), pinned: Value(true)),
+        );
 
-      final block = (await buildInjection().buildJournalBlock(
-        characterId: 'mara',
-        characterName: 'Mara',
-        userName: 'Sam',
-      )).text;
-      expect(block, isNot(contains('gone cold')));
-      expect(block, contains('pinned survivor'));
-    });
+        final block = (await buildInjection().buildJournalBlock(
+          characterId: 'mara',
+          characterName: 'Mara',
+          userName: 'Sam',
+        )).text;
+        expect(block, isNot(contains('gone cold')));
+        expect(block, contains('pinned survivor'));
+      },
+    );
 
-    test('mood congruence lifts a cooler matching memory up the order',
-        () async {
-      final sadOlder = await addOne('the sad one', emotion: 'melancholy');
-      await db.updateJournalCard(
-        sadOlder.id,
-        const JournalMemoriesCompanion(heat: Value(0.9)),
-      );
-      await addOne('the joyful one', emotion: 'joyful'); // newer, heat 1.0
+    test(
+      'mood congruence lifts a cooler matching memory up the order',
+      () async {
+        final sadOlder = await addOne('the sad one', emotion: 'melancholy');
+        await db.updateJournalCard(
+          sadOlder.id,
+          const JournalMemoriesCompanion(heat: Value(0.9)),
+        );
+        await addOne('the joyful one', emotion: 'joyful'); // newer, heat 1.0
 
-      currentEmotion = 'wistful'; // sadness family → boost the sad card
-      final block = (await buildInjection().buildJournalBlock(
-        characterId: 'mara',
-        characterName: 'Mara',
-        userName: 'Sam',
-      )).text;
-      expect(
-        block.indexOf('the sad one'),
-        lessThan(block.indexOf('the joyful one')),
-      );
+        currentEmotion = 'wistful'; // sadness family → boost the sad card
+        final block = (await buildInjection().buildJournalBlock(
+          characterId: 'mara',
+          characterName: 'Mara',
+          userName: 'Sam',
+        )).text;
+        expect(
+          block.indexOf('the sad one'),
+          lessThan(block.indexOf('the joyful one')),
+        );
 
-      currentEmotion = 'neutral'; // no boost → plain heat order wins
-      final unboosted = (await buildInjection().buildJournalBlock(
-        characterId: 'mara',
-        characterName: 'Mara',
-        userName: 'Sam',
-      )).text;
-      expect(
-        unboosted.indexOf('the joyful one'),
-        lessThan(unboosted.indexOf('the sad one')),
-      );
-    });
+        currentEmotion = 'neutral'; // no boost → plain heat order wins
+        final unboosted = (await buildInjection().buildJournalBlock(
+          characterId: 'mara',
+          characterName: 'Mara',
+          userName: 'Sam',
+        )).text;
+        expect(
+          unboosted.indexOf('the joyful one'),
+          lessThan(unboosted.indexOf('the sad one')),
+        );
+      },
+    );
 
     test('semantic retrieval resurfaces and re-warms a cold card', () async {
       final cold = await addOne('the lighthouse trip');
@@ -420,8 +472,10 @@ void main() {
       )).text;
       expect(withQuery, contains('the lighthouse trip'));
 
-      final rewarmed = (await store.cardsFor('s1', 'mara'))
-          .firstWhere((c) => c.content == 'the lighthouse trip');
+      final rewarmed = (await store.cardsFor(
+        's1',
+        'mara',
+      )).firstWhere((c) => c.content == 'the lighthouse trip');
       expect(rewarmed.heat, JournalPhysics.kRewarmHeat);
       expect(rewarmed.accessCount, 1);
     });
@@ -453,8 +507,10 @@ void main() {
       )).text;
       expect(dissimilar, isNot(contains('unrelated memory')));
       // And the buried card was never counted as accessed.
-      final untouched = (await store.cardsFor('s1', 'mara'))
-          .firstWhere((c) => c.content == 'unrelated memory');
+      final untouched = (await store.cardsFor(
+        's1',
+        'mara',
+      )).firstWhere((c) => c.content == 'unrelated memory');
       expect(untouched.accessCount, 0);
     });
   });

--- a/test/services/chat/rag_embedding_invalidation_test.dart
+++ b/test/services/chat/rag_embedding_invalidation_test.dart
@@ -28,7 +28,7 @@
 //   * the window's stored `content` is the PRE-rewrite text, and
 //     MemoryService's dedupe is positional only (a range already present is
 //     skipped forever), so the discarded reply was never re-embedded and got
-//     injected 20+ turns later under "Exact earlier lines from this chat …
+//     injected 20+ turns later as a remembered-from-earlier line …
 //     already happened". Delete did not delete.
 //   * after a delete every later window's (start,end) addresses different
 //     messages, mis-stamping story days and mis-aligning the journal de-dupe.

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -408,6 +408,24 @@ void main() {
       },
     );
 
+    test('HOLD lock: front-porch compound is not cover', () {
+      final swing = _mem(
+        'Nia: the front porch swing creaked tonight',
+        sessionId: 's1',
+        pos: 2,
+      );
+      final feeling = 'I felt safe on the front porch tonight';
+      expect(
+        coverContentTokens(
+          feeling,
+        ).intersection(coverContentTokens(swing.content)),
+        {'frontporch'},
+      );
+      expect(dropCoveredRagWindows([swing], [feeling]), [
+        swing,
+      ], reason: 'shared place-compound {front, porch} is not cover');
+    });
+
     test('HOLD r2: porch feeling does not eat a porch-swing fact', () {
       final swing = _mem(
         'Nia: the porch swing creaked',
@@ -533,7 +551,8 @@ void main() {
           reachingForQuote: false,
         );
         expect(block, contains(kRagRememberedHeader.trim()));
-        expect(block, contains('- (Day 1) Nia: the swing creaked'));
+        expect(block, contains('- (Day 1) the swing creaked'));
+        expect(block, isNot(contains('Nia:')));
         expect(block, isNot(contains('Exact earlier lines')));
       },
     );
@@ -593,6 +612,29 @@ void main() {
         expect(line, contains('spare key'));
       },
     );
+
+    test('HOLD lock: single-line window strips the speaker prefix too', () {
+      expect(
+        rememberedLineFromWindow('Nia: the swing creaked'),
+        'the swing creaked',
+      );
+      final m = _mem('Nia: the swing creaked', sessionId: 's1', pos: 2);
+      final block = buildRagMemoriesBlock(
+        memories: [m],
+        currentSessionId: 's1',
+        days: {m: 1},
+        reachingForQuote: false,
+      );
+      expect(block, contains('- (Day 1) the swing creaked'));
+      expect(block, isNot(contains('Nia:')));
+      final quoted = buildRagMemoriesBlock(
+        memories: [m],
+        currentSessionId: 's1',
+        days: {m: 2},
+        reachingForQuote: true,
+      );
+      expect(quoted, contains('Nia: the swing creaked'));
+    });
 
     test('quote-reach uses the quote header; day stamp stays display-only', () {
       final m = _mem(

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -427,7 +427,12 @@ void main() {
     });
 
     test('HOLD hole: setting nouns are filler — not a longer noun list', () {
-      for (final phrase in ['front steps', 'back patio']) {
+      for (final phrase in [
+        'front steps',
+        'back patio',
+        'front walk',
+        'back path',
+      ]) {
         final feeling = 'I felt safe on the $phrase tonight';
         final swing = _mem(
           'Nia: the $phrase swing creaked tonight',
@@ -446,11 +451,36 @@ void main() {
           swing,
         ], reason: 'feeling × $phrase swing must not cover-drop');
       }
+      for (final noun in [
+        'porch',
+        'yard',
+        'lawn',
+        'deck',
+        'stoop',
+        'steps',
+        'patio',
+        'walk',
+        'path',
+      ]) {
+        expect(
+          coverContentTokens('felt safe $noun'),
+          isNot(contains(noun)),
+          reason: '$noun is setting-noun filler — not a longer fold list',
+        );
+      }
       expect(
         coverContentTokens('this porch swing'),
         isNot(contains('thisporch')),
       );
       expect(coverContentTokens('my porch swing'), isNot(contains('myporch')));
+      expect(
+        coverContentTokens('our porch swing'),
+        isNot(contains('ourporch')),
+      );
+      expect(
+        coverContentTokens('your porch swing'),
+        isNot(contains('yourporch')),
+      );
       expect(coverContentTokens('I sat on porch'), isNot(contains('onporch')));
       const gist = 'Nia: the porch swing creaked tonight';
       expect(
@@ -480,6 +510,34 @@ void main() {
         ),
         isEmpty,
         reason: 'same-beat my-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: our porch swing creaked tonight',
+              sessionId: 's1',
+              pos: 5,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'same-beat our-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: your porch swing creaked tonight',
+              sessionId: 's1',
+              pos: 6,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'same-beat your-porch swing still drops',
       );
       expect(
         dropCoveredRagWindows(

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -426,6 +426,44 @@ void main() {
       ], reason: 'shared place-compound {front, porch} is not cover');
     });
 
+    test('HOLD hole: side porch and front lawn fold — not two more pairs', () {
+      for (final phrase in [
+        'side porch',
+        'front lawn',
+        'side deck',
+        'back stoop',
+      ]) {
+        final folded = phrase.replaceAll(' ', '');
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem(
+          'Nia: the $phrase swing creaked tonight',
+          sessionId: 's1',
+          pos: 2,
+        );
+        expect(coverContentTokens(feeling), contains(folded));
+        expect(
+          coverContentTokens(feeling),
+          isNot(contains(phrase.split(' ').first)),
+        );
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      final fact = _mem(
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 1,
+      );
+      expect(
+        dropCoveredRagWindows(
+          [fact],
+          ['I still think about the spare key under the third flowerpot'],
+        ),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD lock: front/back porch and yard fold to one token', () {
       const compounds = {
         'front porch': 'frontporch',
@@ -655,6 +693,11 @@ void main() {
       expect(
         rememberedLineFromWindow('Nia: the swing creaked'),
         'the swing creaked',
+      );
+      expect(
+        rememberedLineFromWindow('Nia:the swing creaked'),
+        'the swing creaked',
+        reason: 'optional space after the colon — Nia:the must strip',
       );
       final m = _mem('Nia: the swing creaked', sessionId: 's1', pos: 2);
       final block = buildRagMemoriesBlock(

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -575,10 +575,12 @@ void main() {
         sessionId: 's1',
         pos: 7,
       );
+      final keptBoth = dropCoveredRagWindows([both], [gist]);
+      expect(keptBoth, hasLength(1));
       expect(
-        dropCoveredRagWindows([both], [gist]),
-        isEmpty,
-        reason: 'same-beat two-line flowerpot window still drops',
+        keptBoth.first.content,
+        contains('lives'),
+        reason: 'lives is leftover — leftover-empty only, so this line KEEPS',
       );
     });
 
@@ -661,8 +663,8 @@ void main() {
       );
       expect(
         dropCoveredRagWindows([hidden], [gist]),
-        isEmpty,
-        reason: 'lives hidden is same-beat paraphrase, not leftover==2',
+        isNot(isEmpty),
+        reason: 'lives hidden has leftover — leftover-empty only, so KEEP',
       );
       final gapped = _mem(
         'Nia: the porch swing creaked tonight\n'
@@ -712,8 +714,8 @@ void main() {
         );
         expect(
           dropCoveredRagWindows([m], [gist]),
-          isEmpty,
-          reason: '"$verb under the third flowerpot" is interior same-beat',
+          isNot(isEmpty),
+          reason: '"$verb under" has leftover — leftover-empty only, so KEEP',
         );
       }
       final potCreaked = _mem(
@@ -756,8 +758,8 @@ void main() {
         );
         expect(
           dropCoveredRagWindows([suffix], [gist]),
-          isEmpty,
-          reason: '$verb as suffix is still same-beat restatement',
+          isNot(isEmpty),
+          reason: '$verb as suffix has leftover — leftover-empty only, so KEEP',
         );
       }
       expect(
@@ -771,8 +773,9 @@ void main() {
           ],
           [gist],
         ),
-        isEmpty,
-        reason: 'lives hidden as suffix is still same-beat',
+        isNot(isEmpty),
+        reason:
+            'lives hidden as suffix has leftover — leftover-empty only, so KEEP',
       );
       for (final extra in [
         'burned',
@@ -810,8 +813,8 @@ void main() {
         );
         expect(
           dropCoveredRagWindows([prefix], [gist]),
-          isEmpty,
-          reason: '$verb as prefix is still same-beat restatement',
+          isNot(isEmpty),
+          reason: '$verb as prefix has leftover — leftover-empty only, so KEEP',
         );
       }
     });

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -908,6 +908,18 @@ void main() {
       expect(dropCoveredRagWindows([tomorrow], [porch]), [
         tomorrow,
       ], reason: 'porch-swing × tomorrow is leftover, not leftover-empty');
+      final withoutWin = _mem(
+        'Nia: I still think about the spare key without the third flowerpot',
+        sessionId: 's1',
+        pos: 25,
+      );
+      expect(
+        dropCoveredRagWindows([withoutWin], [gist]),
+        isEmpty,
+        reason:
+            'without vs under still DROPS — both are function words. '
+            'Do not grow the set to make without KEEP',
+      );
     });
 
     test('HOLD hole: prefix card does not cover a bigger fact', () {

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -296,6 +296,9 @@ void main() {
       );
       expect(isReachingForQuote('You: can you quote that'), isTrue);
       expect(isReachingForQuote('You: remember what you said'), isTrue);
+      expect(isReachingForQuote('You: what did I promise'), isTrue);
+      expect(isReachingForQuote('You: exact words'), isTrue);
+      expect(isReachingForQuote('You: vows?'), isTrue);
     });
 
     test('normal path keeps one uncovered window; quote-reach keeps all', () {
@@ -372,6 +375,38 @@ void main() {
         swing,
       ], reason: 'one shared place/noun (porch) is not cover');
     });
+
+    test('HOLD r2: one shared spare token is not cover', () {
+      final fact = _mem(
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 1,
+      );
+      final kept = dropCoveredRagWindows(
+        [fact],
+        ['I still think about the spare room'],
+      );
+      expect(kept, [fact], reason: 'one shared noun (spare) is not cover');
+    });
+
+    test(
+      'HOLD r2: same-beat flowerpot gist still drops the covered window',
+      () {
+        final fact = _mem(
+          'Nia: I still think about the spare key under the third flowerpot',
+          sessionId: 's1',
+          pos: 1,
+        );
+        expect(
+          dropCoveredRagWindows(
+            [fact],
+            ['I still think about the spare key under the third flowerpot'],
+          ),
+          isEmpty,
+          reason: 'same-beat flowerpot gist must still drop that window',
+        );
+      },
+    );
 
     test(
       'HOLD: empty cover (Journal off / no gist this beat) does not cover-drop',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -514,6 +514,72 @@ void main() {
       },
     );
 
+    test('HOLD hole: short leftover and mixed span', () {
+      final died = _mem('Nia: the spare key died', sessionId: 's1', pos: 2);
+      expect(dropCoveredRagWindows([died], ['the spare key']), [
+        died,
+      ], reason: 'died is leftover even though length < 5');
+      final gone = _mem('Nia: the spare key is gone', sessionId: 's1', pos: 3);
+      expect(dropCoveredRagWindows([gone], ['the spare key']), [
+        gone,
+      ], reason: 'gone is leftover even though length < 5');
+      final fell = _mem(
+        'Nia: the third flowerpot fell',
+        sessionId: 's1',
+        pos: 4,
+      );
+      expect(dropCoveredRagWindows([fell], ['third flowerpot']), [
+        fell,
+      ], reason: 'fell is leftover — third flowerpot does not cover it');
+      for (final verb in ['hid', 'ran']) {
+        final m = _mem('Nia: the spare key $verb', sessionId: 's1', pos: 20);
+        expect(dropCoveredRagWindows([m], ['the spare key']), [
+          m,
+        ], reason: '$verb is leftover even though length < 5');
+      }
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      final creakedSame = _mem(
+        'Nia: I still think about the spare key under the third flowerpot that creaked',
+        sessionId: 's1',
+        pos: 5,
+      );
+      expect(
+        dropCoveredRagWindows([creakedSame], [gist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist + that creaked still drops',
+      );
+      final mixed = _mem(
+        'Nia: I still think about the spare key under the third flowerpot\n'
+        'Nia: the swing creaked',
+        sessionId: 's1',
+        pos: 6,
+      );
+      final kept = dropCoveredRagWindows([mixed], [gist]);
+      expect(kept, hasLength(1));
+      expect(
+        kept.first.content,
+        contains('swing'),
+        reason: 'uncovered swing line must reach the prompt',
+      );
+      expect(
+        kept.first.content,
+        isNot(contains('flowerpot')),
+        reason: 'covered flowerpot line is stripped, not the whole span',
+      );
+      final both = _mem(
+        'You: the spare key lives under the third flowerpot\n'
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 7,
+      );
+      expect(
+        dropCoveredRagWindows([both], [gist]),
+        isEmpty,
+        reason: 'same-beat two-line flowerpot window still drops',
+      );
+    });
+
     test('HOLD hole: prefix card does not cover a bigger fact', () {
       final gardenSwing = _mem(
         'Nia: the front garden swing creaked tonight',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -426,6 +426,44 @@ void main() {
       ], reason: 'shared place-compound {front, porch} is not cover');
     });
 
+    test('HOLD lock: front/back porch and yard fold to one token', () {
+      const compounds = {
+        'front porch': 'frontporch',
+        'back porch': 'backporch',
+        'front yard': 'frontyard',
+        'back yard': 'backyard',
+      };
+      for (final e in compounds.entries) {
+        final phrase = e.key;
+        final folded = e.value;
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem(
+          'Nia: the $phrase swing creaked tonight',
+          sessionId: 's1',
+          pos: 2,
+        );
+        expect(
+          coverContentTokens(feeling),
+          contains(folded),
+          reason: '"$phrase" must fold to one token ($folded)',
+        );
+        expect(
+          coverContentTokens(feeling),
+          isNot(contains(phrase.split(' ').first)),
+          reason: '"$phrase" must not stay two tokens',
+        );
+        expect(
+          coverContentTokens(
+            feeling,
+          ).intersection(coverContentTokens(swing.content)),
+          {folded},
+        );
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing is not cover');
+      }
+    });
+
     test('HOLD r2: porch feeling does not eat a porch-swing fact', () {
       final swing = _mem(
         'Nia: the porch swing creaked',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -32,6 +32,8 @@
 //   * drop the stamp from formatRagLine → the stamp tests go red
 //   * truncate nothing in buildRagReceipt → the preview-cap test goes red
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:front_porch_ai/models/models.dart';
@@ -425,6 +427,84 @@ void main() {
         swing,
       ], reason: 'shared place-compound {front, porch} is not cover');
     });
+
+    test(
+      'HOLD lock: leftover 2-token overlap is not cover — hallway keeps',
+      () {
+        const gist =
+            'I still think about the spare key under the third flowerpot';
+        final hallway = _mem(
+          'Nia: the spare key lives in the hallway drawer',
+          sessionId: 's1',
+          pos: 2,
+        );
+        expect(
+          coverContentTokens(
+            hallway.content,
+          ).intersection(coverContentTokens(gist)).length,
+          greaterThanOrEqualTo(2),
+          reason:
+              'hallway shares leftover tokens ≥ 2 with the flowerpot gist — '
+              'if that were the cover rule this window would drop',
+        );
+        expect(
+          dropCoveredRagWindows([hallway], [gist]),
+          [hallway],
+          reason:
+              'shared leftover tokens ≥ 2 is NOT cover — hallway is not a '
+              'near-substring of the flowerpot card. A source-scan for '
+              '2-token intersection as the cover rule MUST FAIL.',
+        );
+        final flower = _mem(
+          'Nia: I still think about the spare key under the third flowerpot',
+          sessionId: 's1',
+          pos: 1,
+        );
+        expect(
+          dropCoveredRagWindows([flower], [gist]),
+          isEmpty,
+          reason:
+              'same-beat flowerpot gist DROPS because the card names the '
+              'flowerpot in the window (near-substring), not 2-token overlap',
+        );
+      },
+    );
+
+    test(
+      'HOLD lock: cover-drop source is near-substring, not leftover tokens',
+      () {
+        final src = File(
+          'lib/services/chat/rag_injection.dart',
+        ).readAsStringSync();
+        final coveredAt = src.indexOf('bool _ragCoveredByJournal(');
+        expect(coveredAt, greaterThanOrEqualTo(0));
+        final coveredSlice = src.substring(
+          coveredAt,
+          (coveredAt + 280).clamp(0, src.length),
+        );
+        expect(src.contains('bool _nearCover('), isTrue);
+        expect(
+          coveredSlice.contains('.intersection('),
+          isFalse,
+          reason:
+              'a source-scan for 2-token intersection as the cover rule '
+              'MUST FAIL — product must not use shared-content-tokens ≥ 2',
+        );
+        expect(coveredSlice.contains('_nearCover('), isTrue);
+        final fillerAt = src.indexOf('const _kCoverFiller = {');
+        expect(fillerAt, greaterThanOrEqualTo(0));
+        final filler = src.substring(fillerAt, src.indexOf('};', fillerAt));
+        for (final w in ['garden', 'balcony', 'driveway']) {
+          expect(
+            filler.contains("'$w'"),
+            isFalse,
+            reason:
+                "'$w' must not appear on the setting-noun / cover-filler "
+                'place list',
+          );
+        }
+      },
+    );
 
     test('HOLD hole: garden/balcony/driveway + his/her are not a new list', () {
       for (final phrase in ['front garden', 'back balcony', 'side driveway']) {

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -483,6 +483,13 @@ void main() {
           (coveredAt + 280).clamp(0, src.length),
         );
         expect(src.contains('bool _nearCover('), isTrue);
+        expect(src.contains('_kJournalBoilerplate'), isTrue);
+        expect(src.contains('containsAll'), isTrue);
+        expect(
+          src.contains('longer.contains(shorter)'),
+          isFalse,
+          reason: 'unanchored contains() is the key-inside-keyboard hole',
+        );
         expect(
           coveredSlice.contains('.intersection('),
           isFalse,
@@ -505,6 +512,46 @@ void main() {
         }
       },
     );
+
+    test('HOLD hole: whole tokens + distinctive — key is not keyboard', () {
+      final keyboard = _mem(
+        'Nia: I still think about the spare keyboard in the attic',
+        sessionId: 's1',
+        pos: 2,
+      );
+      expect(
+        dropCoveredRagWindows(
+          [keyboard],
+          ['I still think about the spare key'],
+        ),
+        [keyboard],
+        reason: 'key is not inside keyboard — whole tokens only',
+      );
+      final gardenKey = _mem(
+        'Nia: I felt safe on the front garden until the spare key went missing',
+        sessionId: 's1',
+        pos: 3,
+      );
+      expect(dropCoveredRagWindows([gardenKey], ['I felt safe tonight']), [
+        gardenKey,
+      ], reason: 'mood-only felt/safe must not cover a longer beat');
+      final flower = _mem(
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 1,
+      );
+      expect(dropCoveredRagWindows([flower], ['I still think about it']), [
+        flower,
+      ], reason: 'still/think boilerplate must not eat the flowerpot window');
+      expect(
+        dropCoveredRagWindows(
+          [flower],
+          ['I still think about the spare key under the third flowerpot'],
+        ),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
 
     test('HOLD hole: garden/balcony/driveway + his/her are not a new list', () {
       for (final phrase in ['front garden', 'back balcony', 'side driveway']) {

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -739,7 +739,81 @@ void main() {
       );
       expect(dropCoveredRagWindows([sat], [gist]), [
         sat,
-      ], reason: 'sat on the complete gist is a suffix extra fact');
+      ], reason: 'sat on the complete gist is an extra fact');
+
+      for (final verb in [
+        'hidden',
+        'tucked',
+        'buried',
+        'stays',
+        'rests',
+        'lives',
+      ]) {
+        final suffix = _mem(
+          'Nia: the spare key under the third flowerpot $verb',
+          sessionId: 's1',
+          pos: 13,
+        );
+        expect(
+          dropCoveredRagWindows([suffix], [gist]),
+          isEmpty,
+          reason: '$verb as suffix is still same-beat restatement',
+        );
+      }
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: the spare key under the third flowerpot lives hidden',
+              sessionId: 's1',
+              pos: 14,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'lives hidden as suffix is still same-beat',
+      );
+      for (final extra in [
+        'burned',
+        'lighthouse',
+        'creaked',
+        'died',
+        'sat',
+        'fell',
+        'hid',
+      ]) {
+        final interior = _mem(
+          'Nia: the spare key $extra under the third flowerpot',
+          sessionId: 's1',
+          pos: 15,
+        );
+        expect(dropCoveredRagWindows([interior], [gist]), [
+          interior,
+        ], reason: '$extra as interior is still an extra fact');
+      }
+      for (final extra in ['hid', 'sat', 'died']) {
+        final prefix = _mem(
+          'Nia: $extra the spare key under the third flowerpot',
+          sessionId: 's1',
+          pos: 16,
+        );
+        expect(dropCoveredRagWindows([prefix], [gist]), [
+          prefix,
+        ], reason: 'short prefix leftover $extra is an extra fact');
+      }
+      for (final verb in ['hidden', 'tucked']) {
+        final prefix = _mem(
+          'Nia: $verb the spare key under the third flowerpot',
+          sessionId: 's1',
+          pos: 17,
+        );
+        expect(
+          dropCoveredRagWindows([prefix], [gist]),
+          isEmpty,
+          reason: '$verb as prefix is still same-beat restatement',
+        );
+      }
     });
 
     test('HOLD hole: prefix card does not cover a bigger fact', () {
@@ -1012,8 +1086,8 @@ void main() {
           ],
           [gist],
         ),
-        isEmpty,
-        reason: 'same-beat I-sat-on-porch still drops',
+        isNot(isEmpty),
+        reason: 'short leftover sat is an extra fact, not same-beat',
       );
       final fact = _mem(
         'Nia: I still think about the spare key under the third flowerpot',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -247,6 +247,28 @@ void main() {
     test('omits empty cues so a cue-less beat is just last words', () {
       expect(composeRagQuery(lastWords: 'You: evening'), 'You: evening');
     });
+
+    test('HOLD leftover: cue-less beat must not retrieve like last-1', () {
+      expect(ragHasCues(), isFalse);
+      expect(
+        ragHasCues(emotion: '', fixation: '', hotJournalLine: ''),
+        isFalse,
+      );
+      expect(ragHasCues(emotion: 'wistful'), isTrue);
+      expect(ragHasCues(fixation: 'the spare key'), isTrue);
+      expect(ragHasCues(hotJournalLine: 'I still think about the key'), isTrue);
+      expect(
+        shouldRetrieveRag(hasCues: false, reachingForQuote: false),
+        isFalse,
+        reason: 'cue-less sit-down skips last-1 search',
+      );
+      expect(
+        shouldRetrieveRag(hasCues: false, reachingForQuote: true),
+        isTrue,
+        reason: 'quote-reach still retrieves',
+      );
+      expect(shouldRetrieveRag(hasCues: true, reachingForQuote: false), isTrue);
+    });
   });
 
   group('lastWordsFromMessages', () {
@@ -276,6 +298,31 @@ void main() {
         expect(words, contains('[shared a photo: a red kite over the bay]'));
         expect(words, isNot(contains('old one')));
         expect(words, isNot(contains('You: look\nnice')));
+      },
+    );
+
+    test(
+      'HOLD leftover: quote-ask reads last spoken line, not photo captions',
+      () {
+        final msgs = [
+          ChatMessage(
+            text: 'look',
+            sender: 'You',
+            isUser: true,
+            metadata: {
+              'is_user_image': true,
+              'image_caption': 'remember our beach day',
+            },
+          ),
+          ChatMessage(text: 'Mind if I sit?', sender: 'You', isUser: true),
+        ];
+        final words = lastWordsFromMessages(msgs);
+        expect(words, contains('remember our beach day'));
+        expect(isReachingForQuote(words), isTrue);
+        final spoken = lastSpokenLineFromMessages(msgs);
+        expect(spoken, contains('Mind if I sit?'));
+        expect(spoken, isNot(contains('remember our beach day')));
+        expect(isReachingForQuote(spoken), isFalse);
       },
     );
   });
@@ -376,6 +423,29 @@ void main() {
       ], reason: 'one shared place/noun (porch) is not cover');
     });
 
+    test('HOLD leftover: porch+tonight is setting+time, not cover', () {
+      final swing = _mem(
+        'Nia: the porch swing creaked tonight',
+        sessionId: 's1',
+        pos: 2,
+      );
+      expect(
+        coverContentTokens('I felt safe on the porch tonight'),
+        isNot(contains('tonight')),
+      );
+      expect(
+        coverContentTokens('Nia: the porch swing creaked tonight'),
+        isNot(contains('tonight')),
+      );
+      final kept = dropCoveredRagWindows(
+        [swing],
+        ['I felt safe on the porch tonight'],
+      );
+      expect(kept, [
+        swing,
+      ], reason: 'tonight/today/night are filler — porch+tonight is not cover');
+    });
+
     test('HOLD r2: one shared spare token is not cover', () {
       final fact = _mem(
         'Nia: I still think about the spare key under the third flowerpot',
@@ -435,6 +505,40 @@ void main() {
         expect(block, contains(kRagRememberedHeader.trim()));
         expect(block, contains('- (Day 1) Nia: the swing creaked'));
         expect(block, isNot(contains('Exact earlier lines')));
+      },
+    );
+
+    test(
+      'HOLD leftover: plain turn is one remembered line, not the transcript',
+      () {
+        final m = _mem(
+          'You: the spare key lives under the third flowerpot\n'
+          'Nia: I still think about the spare key under the third flowerpot',
+          sessionId: 's1',
+          pos: 1,
+        );
+        final plain = buildRagMemoriesBlock(
+          memories: [m],
+          currentSessionId: 's1',
+          days: {m: 1},
+          reachingForQuote: false,
+        );
+        expect(plain, contains(kRagRememberedHeader.trim()));
+        expect(plain, contains('spare key'));
+        expect(plain, contains('flowerpot'));
+        expect(plain, isNot(contains('You: the spare key')));
+        expect(plain.split('\n').where((l) => l.startsWith('- ')).length, 1);
+        final quoted = buildRagMemoriesBlock(
+          memories: [m],
+          currentSessionId: 's1',
+          days: {m: 1},
+          reachingForQuote: true,
+        );
+        expect(quoted, contains(kRagQuoteHeader.trim()));
+        expect(
+          quoted,
+          contains('You: the spare key lives under the third flowerpot'),
+        );
       },
     );
 

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -485,6 +485,7 @@ void main() {
         expect(src.contains('bool _nearCover('), isTrue);
         expect(src.contains('_kJournalBoilerplate'), isTrue);
         expect(src.contains('containsAll'), isTrue);
+        expect(src.contains('longD.difference(shortD)'), isTrue);
         expect(
           src.contains('longer.contains(shorter)'),
           isFalse,
@@ -512,6 +513,66 @@ void main() {
         }
       },
     );
+
+    test('HOLD hole: prefix card does not cover a bigger fact', () {
+      final gardenSwing = _mem(
+        'Nia: the front garden swing creaked tonight',
+        sessionId: 's1',
+        pos: 2,
+      );
+      expect(dropCoveredRagWindows([gardenSwing], ['the front garden']), [
+        gardenSwing,
+      ], reason: 'front garden must not drop front-garden-swing');
+      final swingAndPot = _mem(
+        'Nia: the porch swing creaked by the flowerpot',
+        sessionId: 's1',
+        pos: 3,
+      );
+      expect(
+        dropCoveredRagWindows([swingAndPot], ['The porch swing.']),
+        [swingAndPot],
+        reason: 'porch swing must not drop a window that also names flowerpot',
+      );
+      final frontPorchSwing = _mem(
+        'Nia: I sat on the front porch swing',
+        sessionId: 's1',
+        pos: 4,
+      );
+      expect(
+        dropCoveredRagWindows([frontPorchSwing], ['I sat on her porch swing']),
+        [frontPorchSwing],
+        reason: '{porch, swing} must not drop front porch swing',
+      );
+      final lovedPot = _mem(
+        'Nia: I loved the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 1,
+      );
+      expect(dropCoveredRagWindows([lovedPot], ['I loved it']), [
+        lovedPot,
+      ], reason: 'mood-only loved must not cover a flowerpot fact');
+      final worryPot = _mem(
+        'Nia: I worry about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 5,
+      );
+      expect(dropCoveredRagWindows([worryPot], ['I worry']), [
+        worryPot,
+      ], reason: 'mood-only worry must not cover a flowerpot fact');
+      final flower = _mem(
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 6,
+      );
+      expect(
+        dropCoveredRagWindows(
+          [flower],
+          ['I still think about the spare key under the third flowerpot'],
+        ),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
 
     test('HOLD hole: whole tokens + distinctive — key is not keyboard', () {
       final keyboard = _mem(

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -426,6 +426,52 @@ void main() {
       ], reason: 'shared place-compound {front, porch} is not cover');
     });
 
+    test('HOLD hole: garden/balcony/driveway + his/her are not a new list', () {
+      for (final phrase in ['front garden', 'back balcony', 'side driveway']) {
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem(
+          'Nia: the $phrase swing creaked tonight',
+          sessionId: 's1',
+          pos: 2,
+        );
+        expect(
+          coverContentTokens(feeling),
+          isNot(contains(phrase.replaceAll(' ', ''))),
+        );
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      expect(
+        coverContentTokens('his porch swing'),
+        isNot(contains('hisporch')),
+      );
+      expect(
+        coverContentTokens('her porch swing'),
+        isNot(contains('herporch')),
+      );
+      expect(
+        coverContentTokens('that porch swing'),
+        isNot(contains('thatporch')),
+      );
+      expect(coverContentTokens('off the porch'), isNot(contains('offporch')));
+      expect(coverContentTokens('in the porch'), isNot(contains('inporch')));
+      expect(coverContentTokens('at the porch'), isNot(contains('atporch')));
+      final fact = _mem(
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 1,
+      );
+      expect(
+        dropCoveredRagWindows(
+          [fact],
+          ['I still think about the spare key under the third flowerpot'],
+        ),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: setting nouns are filler — not a longer noun list', () {
       for (final phrase in [
         'front steps',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -426,6 +426,45 @@ void main() {
       ], reason: 'shared place-compound {front, porch} is not cover');
     });
 
+    test('HOLD hole: any token before a place noun folds — screened porch', () {
+      for (final phrase in [
+        'screened porch',
+        'covered porch',
+        'wraparound porch',
+      ]) {
+        final folded = phrase.replaceAll(' ', '');
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem(
+          'Nia: the $phrase swing creaked tonight',
+          sessionId: 's1',
+          pos: 2,
+        );
+        expect(coverContentTokens(feeling), contains(folded));
+        expect(
+          coverContentTokens(feeling),
+          isNot(contains(phrase.split(' ').first)),
+        );
+        expect(coverContentTokens('the porch'), contains('porch'));
+        expect(coverContentTokens('the porch'), isNot(contains('theporch')));
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      final fact = _mem(
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 1,
+      );
+      expect(
+        dropCoveredRagWindows(
+          [fact],
+          ['I still think about the spare key under the third flowerpot'],
+        ),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: side porch and front lawn fold — not two more pairs', () {
       for (final phrase in [
         'side porch',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -284,6 +284,11 @@ void main() {
     test('remember/said/vows count as quote-reach; a plain beat does not', () {
       expect(isReachingForQuote('You: remember our wedding vows?'), isTrue);
       expect(isReachingForQuote('You: evening. mind if I sit?'), isFalse);
+      expect(
+        isReachingForQuote('You: I told you the tomatoes came in'),
+        isFalse,
+      );
+      expect(isReachingForQuote('Nia: she said the cicadas started'), isFalse);
     });
 
     test('normal path keeps one uncovered window; quote-reach keeps all', () {
@@ -323,6 +328,40 @@ void main() {
       );
       expect(kept, [leftHistory]);
     });
+
+    test(
+      'HOLD: filler still/think/about with a lighthouse card does not eat the flowerpot fact',
+      () {
+        final fact = _mem(
+          'Nia: I still think about the spare key under the third flowerpot',
+          sessionId: 's1',
+          pos: 1,
+        );
+        final kept = dropCoveredRagWindows(
+          [fact],
+          ['I still think about the lighthouse'],
+        );
+        expect(
+          kept,
+          [fact],
+          reason:
+              'cover overlap must be content (flowerpot / lighthouse), not '
+              'filler — this is the cabinet-card false drop',
+        );
+      },
+    );
+
+    test(
+      'HOLD: empty cover (Journal off / no gist this beat) does not cover-drop',
+      () {
+        final fact = _mem(
+          'Nia: the spare key lives under the third flowerpot',
+          sessionId: 's1',
+          pos: 1,
+        );
+        expect(dropCoveredRagWindows([fact], const []), [fact]);
+      },
+    );
   });
 
   group('buildRagMemoriesBlock', () {

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -426,6 +426,90 @@ void main() {
       ], reason: 'shared place-compound {front, porch} is not cover');
     });
 
+    test('HOLD hole: setting nouns are filler — not a longer noun list', () {
+      for (final phrase in ['front steps', 'back patio']) {
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem(
+          'Nia: the $phrase swing creaked tonight',
+          sessionId: 's1',
+          pos: 2,
+        );
+        expect(
+          coverContentTokens(feeling),
+          isNot(contains(phrase.split(' ').last)),
+        );
+        expect(
+          coverContentTokens(feeling),
+          isNot(contains(phrase.replaceAll(' ', ''))),
+        );
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      expect(
+        coverContentTokens('this porch swing'),
+        isNot(contains('thisporch')),
+      );
+      expect(coverContentTokens('my porch swing'), isNot(contains('myporch')));
+      expect(coverContentTokens('I sat on porch'), isNot(contains('onporch')));
+      const gist = 'Nia: the porch swing creaked tonight';
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: this porch swing creaked tonight',
+              sessionId: 's1',
+              pos: 2,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'same-beat this-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: my porch swing creaked tonight',
+              sessionId: 's1',
+              pos: 3,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'same-beat my-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'I sat on porch; the swing creaked tonight',
+              sessionId: 's1',
+              pos: 4,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'same-beat I-sat-on-porch still drops',
+      );
+      final fact = _mem(
+        'Nia: I still think about the spare key under the third flowerpot',
+        sessionId: 's1',
+        pos: 1,
+      );
+      expect(
+        dropCoveredRagWindows(
+          [fact],
+          ['I still think about the spare key under the third flowerpot'],
+        ),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: any token before a place noun folds — screened porch', () {
       for (final phrase in [
         'screened porch',
@@ -445,7 +529,7 @@ void main() {
           coverContentTokens(feeling),
           isNot(contains(phrase.split(' ').first)),
         );
-        expect(coverContentTokens('the porch'), contains('porch'));
+        expect(coverContentTokens('the porch'), isNot(contains('porch')));
         expect(coverContentTokens('the porch'), isNot(contains('theporch')));
         expect(dropCoveredRagWindows([swing], [feeling]), [
           swing,
@@ -454,8 +538,8 @@ void main() {
       for (final article in ['the', 'a', 'an']) {
         expect(
           coverContentTokens('$article porch'),
-          contains('porch'),
-          reason: '$article stays filler — porch must remain a token',
+          isNot(contains('porch')),
+          reason: '$article stays filler and porch is setting-noun filler',
         );
         expect(
           coverContentTokens('$article porch'),

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -224,4 +224,139 @@ void main() {
       expect(err['status'], isNot(dead['status']));
     });
   });
+
+  group('composeRagQuery', () {
+    test('is not the last-3 live lines alone', () {
+      final q = composeRagQuery(
+        emotion: 'wistful',
+        fixation: 'the broken promise',
+        hotJournalLine: 'I still think about the lighthouse',
+        lastWords: 'You: that photo was from our last trip',
+      );
+      expect(q, contains('feeling wistful'));
+      expect(q, contains('on the mind: the broken promise'));
+      expect(q, contains('remembered: I still think about the lighthouse'));
+      expect(q, contains('You: that photo was from our last trip'));
+      expect(
+        q,
+        isNot(equals('You: that photo was from our last trip')),
+        reason: 'cues must ride WITH last words, not be replaced by them',
+      );
+    });
+
+    test('omits empty cues so a cue-less beat is just last words', () {
+      expect(composeRagQuery(lastWords: 'You: evening'), 'You: evening');
+    });
+  });
+
+  group('lastWordsFromMessages', () {
+    test(
+      'keeps the latest line and nearby photo markers, not a last-3 dump',
+      () {
+        final msgs = [
+          ChatMessage(text: 'old one', sender: 'Nia', isUser: false),
+          ChatMessage(
+            text: 'look',
+            sender: 'You',
+            isUser: true,
+            metadata: {
+              'is_user_image': true,
+              'image_caption': 'a red kite over the bay',
+            },
+          ),
+          ChatMessage(text: 'nice', sender: 'Nia', isUser: false),
+          ChatMessage(
+            text: 'That photo was from our last trip',
+            sender: 'You',
+            isUser: true,
+          ),
+        ];
+        final words = lastWordsFromMessages(msgs);
+        expect(words, contains('That photo was from our last trip'));
+        expect(words, contains('[shared a photo: a red kite over the bay]'));
+        expect(words, isNot(contains('old one')));
+        expect(words, isNot(contains('You: look\nnice')));
+      },
+    );
+  });
+
+  group('isReachingForQuote / capRagWindows / dropCoveredRagWindows', () {
+    test('remember/said/vows count as quote-reach; a plain beat does not', () {
+      expect(isReachingForQuote('You: remember our wedding vows?'), isTrue);
+      expect(isReachingForQuote('You: evening. mind if I sit?'), isFalse);
+    });
+
+    test('normal path keeps one uncovered window; quote-reach keeps all', () {
+      final a = _mem('Nia: the porch swing creaked', sessionId: 's1', pos: 2);
+      final b = _mem('You: the red kite', sessionId: 's2', pos: 7);
+      expect(capRagWindows([a, b], reachingForQuote: false), [a]);
+      expect(capRagWindows([a, b], reachingForQuote: true), [a, b]);
+    });
+
+    test('a journal card that covers the beat drops that RAG window', () {
+      final covered = _mem(
+        'Nia: I still think about the lighthouse on the cliff',
+        sessionId: 's1',
+        pos: 4,
+      );
+      final leftover = _mem(
+        'You: remember the red kite on the pier',
+        sessionId: 's1',
+        pos: 9,
+      );
+      final kept = dropCoveredRagWindows(
+        [covered, leftover],
+        ['I still think about the lighthouse'],
+      );
+      expect(kept.map((m) => m.content).toList(), [leftover.content]);
+    });
+
+    test('an uncovered fact that left history still retrieves', () {
+      final leftHistory = _mem(
+        'Nia: the spare key lives under the third flowerpot',
+        sessionId: 's1',
+        pos: 3,
+      );
+      final kept = dropCoveredRagWindows(
+        [leftHistory],
+        ['I felt safe on the porch tonight'],
+      );
+      expect(kept, [leftHistory]);
+    });
+  });
+
+  group('buildRagMemoriesBlock', () {
+    test(
+      'default frame is remembered-from-earlier, not Exact earlier lines',
+      () {
+        final m = _mem('Nia: the swing creaked', sessionId: 's1', pos: 2);
+        final block = buildRagMemoriesBlock(
+          memories: [m],
+          currentSessionId: 's1',
+          days: {m: 1},
+          reachingForQuote: false,
+        );
+        expect(block, contains(kRagRememberedHeader.trim()));
+        expect(block, contains('- (Day 1) Nia: the swing creaked'));
+        expect(block, isNot(contains('Exact earlier lines')));
+      },
+    );
+
+    test('quote-reach uses the quote header; day stamp stays display-only', () {
+      final m = _mem(
+        'Nia: I never want to see you again',
+        sessionId: 's1',
+        pos: 2,
+      );
+      final block = buildRagMemoriesBlock(
+        memories: [m],
+        currentSessionId: 's1',
+        days: {m: 2},
+        reachingForQuote: true,
+      );
+      expect(block, contains(kRagQuoteHeader.trim()));
+      expect(block, contains('(Day 2)'));
+      expect(block, isNot(contains('Exact earlier lines')));
+    });
+  });
 }

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -580,6 +580,59 @@ void main() {
       );
     });
 
+    test('HOLD hole: extra fact on the line and stripped span', () {
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      final andSwing = _mem(
+        'Nia: the spare key under the third flowerpot and the swing creaked',
+        sessionId: 's1',
+        pos: 2,
+      );
+      expect(
+        dropCoveredRagWindows([andSwing], [gist]),
+        [andSwing],
+        reason:
+            'swing creaked is a second fact — 3 shared distinctive tokens '
+            'must not drop it',
+      );
+      final keyboard = _mem(
+        'Nia: the spare keyboard sits on the third flowerpot',
+        sessionId: 's1',
+        pos: 3,
+      );
+      expect(dropCoveredRagWindows([keyboard], [gist]), [
+        keyboard,
+      ], reason: 'key is not keyboard — 3 shared tokens must not skip that');
+      final mixed = _mem(
+        'Nia: I still think about the spare key under the third flowerpot\n'
+        'Nia: the swing creaked',
+        sessionId: 's1',
+        pos: 2,
+        end: 3,
+      );
+      final kept = dropCoveredRagWindows([mixed], [gist]);
+      expect(kept, hasLength(1));
+      expect(kept.first.content, contains('swing'));
+      expect(kept.first.positionStart, 3);
+      expect(kept.first.positionEnd, 3);
+      expect(
+        RetrievedMemory.excludingPositions(kept, {2}, currentSessionId: 's1'),
+        hasLength(1),
+        reason:
+            'stripped flowerpot line must not keep pos 2 — receipt / '
+            'excludingPositions treat the swing as this retrieval',
+      );
+      expect(
+        RetrievedMemory.excludingPositions(
+          [mixed],
+          {2},
+          currentSessionId: 's1',
+        ),
+        isEmpty,
+        reason: 'the unstripped 2–3 span still overlaps the flowerpot line',
+      );
+    });
+
     test('HOLD hole: prefix card does not cover a bigger fact', () {
       final gardenSwing = _mem(
         'Nia: the front garden swing creaked tonight',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -446,6 +446,36 @@ void main() {
       ], reason: 'tonight/today/night are filler — porch+tonight is not cover');
     });
 
+    test(
+      'HOLD leftover: tonight/today/night/morning/evening are cover filler',
+      () {
+        const words = ['tonight', 'today', 'night', 'morning', 'evening'];
+        for (final w in words) {
+          expect(
+            coverContentTokens('porch $w'),
+            isNot(contains(w)),
+            reason: '$w is time filler — must not count as cover',
+          );
+          final swing = _mem(
+            'Nia: the porch swing creaked $w',
+            sessionId: 's1',
+            pos: 2,
+          );
+          final kept = dropCoveredRagWindows(
+            [swing],
+            ['I felt safe on the porch $w'],
+          );
+          expect(
+            kept,
+            [swing],
+            reason:
+                'Porch feeling × porch swing creaked $w must not drop the '
+                'window — $w is filler, one shared noun (porch) is not cover',
+          );
+        }
+      },
+    );
+
     test('HOLD r2: one shared spare token is not cover', () {
       final fact = _mem(
         'Nia: I still think about the spare key under the third flowerpot',
@@ -539,6 +569,28 @@ void main() {
           quoted,
           contains('You: the spare key lives under the third flowerpot'),
         );
+        expect(
+          quoted,
+          contains(
+            'Nia: I still think about the spare key under the third flowerpot',
+          ),
+          reason: 'quote-reach still gets the raw You:/Nia: window',
+        );
+      },
+    );
+
+    test(
+      'HOLD leftover: rememberedLineFromWindow is one body, not the tape',
+      () {
+        const window =
+            'You: the spare key lives under the third flowerpot\n'
+            'Nia: I still think about the spare key under the third flowerpot';
+        final line = rememberedLineFromWindow(window);
+        expect(line.contains('\n'), isFalse);
+        expect(line, isNot(contains('You:')));
+        expect(line, isNot(contains('Nia:')));
+        expect(line, contains('flowerpot'));
+        expect(line, contains('spare key'));
       },
     );
 

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -582,6 +582,16 @@ void main() {
         contains('lives'),
         reason: 'lives is leftover — leftover-empty only, so this line KEEPS',
       );
+      expect(
+        keptBoth.first.content,
+        contains('You: the spare key lives under the third flowerpot'),
+        reason: 'two-line lives-under: the lives line KEEPS',
+      );
+      expect(
+        keptBoth.first.content,
+        isNot(contains('I still think about')),
+        reason: 'exact gist line still strips from the two-line window',
+      );
     });
 
     test('HOLD hole: extra fact on the line and stripped span', () {
@@ -785,6 +795,13 @@ void main() {
         'sat',
         'fell',
         'hid',
+        'stolen',
+        'broken',
+        'locked',
+        'rusty',
+        'moved',
+        'taken',
+        'yellow',
       ]) {
         final interior = _mem(
           'Nia: the spare key $extra under the third flowerpot',
@@ -805,7 +822,7 @@ void main() {
           prefix,
         ], reason: 'short prefix leftover $extra is an extra fact');
       }
-      for (final verb in ['hidden', 'tucked']) {
+      for (final verb in ['hidden', 'tucked', 'buried', 'stays', 'rests', 'lives']) {
         final prefix = _mem(
           'Nia: $verb the spare key under the third flowerpot',
           sessionId: 's1',
@@ -817,6 +834,41 @@ void main() {
           reason: '$verb as prefix has leftover — leftover-empty only, so KEEP',
         );
       }
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: lives hidden the spare key under the third flowerpot',
+              sessionId: 's1',
+              pos: 18,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason:
+            'lives hidden as prefix has leftover — leftover-empty only, so KEEP',
+      );
+      final interiorHidden = _mem(
+        'Nia: the spare key hidden under the third flowerpot',
+        sessionId: 's1',
+        pos: 19,
+      );
+      expect(
+        dropCoveredRagWindows([interiorHidden], [gist]),
+        [interiorHidden],
+        reason: 'interior hidden has leftover — leftover-empty only, so KEEP',
+      );
+      final interiorLives = _mem(
+        'Nia: the spare key lives under the third flowerpot',
+        sessionId: 's1',
+        pos: 21,
+      );
+      expect(
+        dropCoveredRagWindows([interiorLives], [gist]),
+        [interiorLives],
+        reason: 'interior lives has leftover — leftover-empty only, so KEEP',
+      );
     });
 
     test('HOLD hole: prefix card does not cover a bigger fact', () {

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -546,8 +546,10 @@ void main() {
       );
       expect(
         dropCoveredRagWindows([creakedSame], [gist]),
-        isEmpty,
-        reason: 'same-beat flowerpot gist + that creaked still drops',
+        [creakedSame],
+        reason:
+            'suffix leftover is an extra fact — that creaked is not '
+            'same-beat just because creaked used to be on a list',
       );
       final mixed = _mem(
         'Nia: I still think about the spare key under the third flowerpot\n'
@@ -697,6 +699,47 @@ void main() {
         hasLength(1),
         reason: 'span ≠ line count must not keep the flowerpot pos',
       );
+    });
+
+    test('HOLD hole: interior restatement, suffix extra fact, no verb list', () {
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      for (final verb in ['tucked', 'buried', 'stays', 'rests']) {
+        final m = _mem(
+          'Nia: the spare key $verb under the third flowerpot',
+          sessionId: 's1',
+          pos: 8,
+        );
+        expect(
+          dropCoveredRagWindows([m], [gist]),
+          isEmpty,
+          reason: '"$verb under the third flowerpot" is interior same-beat',
+        );
+      }
+      final potCreaked = _mem(
+        'Nia: the spare key under the third flowerpot creaked',
+        sessionId: 's1',
+        pos: 9,
+      );
+      expect(dropCoveredRagWindows([potCreaked], [gist]), [
+        potCreaked,
+      ], reason: 'the pot creaked is a suffix extra fact');
+      final died = _mem(
+        'Nia: I still think about the spare key under the third flowerpot died',
+        sessionId: 's1',
+        pos: 11,
+      );
+      expect(dropCoveredRagWindows([died], [gist]), [
+        died,
+      ], reason: 'short suffix leftover on a 3-D gist is an extra fact');
+      final sat = _mem(
+        'Nia: I still think about the spare key under the third flowerpot sat',
+        sessionId: 's1',
+        pos: 12,
+      );
+      expect(dropCoveredRagWindows([sat], [gist]), [
+        sat,
+      ], reason: 'sat on the complete gist is a suffix extra fact');
     });
 
     test('HOLD hole: prefix card does not cover a bigger fact', () {

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -289,6 +289,13 @@ void main() {
         isFalse,
       );
       expect(isReachingForQuote('Nia: she said the cicadas started'), isFalse);
+      expect(isReachingForQuote('You: Remember to lock the door?'), isFalse);
+      expect(
+        isReachingForQuote('You: Remember the tomatoes came in early?'),
+        isFalse,
+      );
+      expect(isReachingForQuote('You: can you quote that'), isTrue);
+      expect(isReachingForQuote('You: remember what you said'), isTrue);
     });
 
     test('normal path keeps one uncovered window; quote-reach keeps all', () {
@@ -311,7 +318,7 @@ void main() {
       );
       final kept = dropCoveredRagWindows(
         [covered, leftover],
-        ['I still think about the lighthouse'],
+        ['I still think about the lighthouse on the cliff'],
       );
       expect(kept.map((m) => m.content).toList(), [leftover.content]);
     });
@@ -350,6 +357,21 @@ void main() {
         );
       },
     );
+
+    test('HOLD r2: porch feeling does not eat a porch-swing fact', () {
+      final swing = _mem(
+        'Nia: the porch swing creaked',
+        sessionId: 's1',
+        pos: 2,
+      );
+      final kept = dropCoveredRagWindows(
+        [swing],
+        ['I felt safe on the porch tonight'],
+      );
+      expect(kept, [
+        swing,
+      ], reason: 'one shared place/noun (porch) is not cover');
+    });
 
     test(
       'HOLD: empty cover (Journal off / no gist this beat) does not cover-drop',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -822,7 +822,14 @@ void main() {
           prefix,
         ], reason: 'short prefix leftover $extra is an extra fact');
       }
-      for (final verb in ['hidden', 'tucked', 'buried', 'stays', 'rests', 'lives']) {
+      for (final verb in [
+        'hidden',
+        'tucked',
+        'buried',
+        'stays',
+        'rests',
+        'lives',
+      ]) {
         final prefix = _mem(
           'Nia: $verb the spare key under the third flowerpot',
           sessionId: 's1',
@@ -854,21 +861,53 @@ void main() {
         sessionId: 's1',
         pos: 19,
       );
-      expect(
-        dropCoveredRagWindows([interiorHidden], [gist]),
-        [interiorHidden],
-        reason: 'interior hidden has leftover — leftover-empty only, so KEEP',
-      );
+      expect(dropCoveredRagWindows([interiorHidden], [gist]), [
+        interiorHidden,
+      ], reason: 'interior hidden has leftover — leftover-empty only, so KEEP');
       final interiorLives = _mem(
         'Nia: the spare key lives under the third flowerpot',
         sessionId: 's1',
         pos: 21,
       );
-      expect(
-        dropCoveredRagWindows([interiorLives], [gist]),
-        [interiorLives],
-        reason: 'interior lives has leftover — leftover-empty only, so KEEP',
+      expect(dropCoveredRagWindows([interiorLives], [gist]), [
+        interiorLives,
+      ], reason: 'interior lives has leftover — leftover-empty only, so KEEP');
+    });
+
+    test('HOLD hole: filler lists do not erase cover leftover', () {
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      for (final extra in ['safe', 'felt', 'remember']) {
+        final win = _mem(
+          'Nia: I still think about the spare key under the third flowerpot $extra',
+          sessionId: 's1',
+          pos: 22,
+        );
+        expect(
+          dropCoveredRagWindows([win], [gist]),
+          [win],
+          reason: 'boilerplate leftover $extra must KEEP — not leftover-empty',
+        );
+      }
+      for (final extra in ['yesterday', 'tomorrow', 'morning', 'evening']) {
+        final win = _mem(
+          'Nia: I still think about the spare key under the third flowerpot $extra',
+          sessionId: 's1',
+          pos: 23,
+        );
+        expect(dropCoveredRagWindows([win], [gist]), [
+          win,
+        ], reason: 'time leftover $extra must KEEP — not leftover-empty');
+      }
+      const porch = 'Nia: the porch swing creaked tonight';
+      final tomorrow = _mem(
+        'Nia: the porch swing creaked tomorrow',
+        sessionId: 's1',
+        pos: 24,
       );
+      expect(dropCoveredRagWindows([tomorrow], [porch]), [
+        tomorrow,
+      ], reason: 'porch-swing × tomorrow is leftover, not leftover-empty');
     });
 
     test('HOLD hole: prefix card does not cover a bigger fact', () {

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -633,6 +633,72 @@ void main() {
       );
     });
 
+    test('HOLD hole: leftover kind, remap gap, two-word paraphrase', () {
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      final burned = _mem(
+        'Nia: I still think about the spare key under the third flowerpot burned',
+        sessionId: 's1',
+        pos: 2,
+      );
+      expect(dropCoveredRagWindows([burned], [gist]), [
+        burned,
+      ], reason: 'burned is a one-word second fact, not paraphrase');
+      final lighthouse = _mem(
+        'Nia: I still think about the spare key under the third flowerpot lighthouse',
+        sessionId: 's1',
+        pos: 3,
+      );
+      expect(dropCoveredRagWindows([lighthouse], [gist]), [
+        lighthouse,
+      ], reason: 'lighthouse is a one-word second fact, not paraphrase');
+      final hidden = _mem(
+        'Nia: the spare key lives hidden under the third flowerpot',
+        sessionId: 's1',
+        pos: 4,
+      );
+      expect(
+        dropCoveredRagWindows([hidden], [gist]),
+        isEmpty,
+        reason: 'lives hidden is same-beat paraphrase, not leftover==2',
+      );
+      final gapped = _mem(
+        'Nia: the porch swing creaked tonight\n'
+        'Nia: I still think about the spare key under the third flowerpot\n'
+        'Nia: I sat on the front garden',
+        sessionId: 's1',
+        pos: 10,
+        end: 12,
+      );
+      final gapKept = dropCoveredRagWindows([gapped], [gist]);
+      expect(gapKept, hasLength(2));
+      expect(gapKept.map((m) => m.positionStart).toList(), [10, 12]);
+      expect(
+        gapKept.any((m) => m.positionStart <= 11 && m.positionEnd >= 11),
+        isFalse,
+        reason: 'middle covered pos must not stay inside a first-to-last span',
+      );
+      final wide = _mem(
+        'Nia: I still think about the spare key under the third flowerpot\n'
+        'Nia: the swing creaked',
+        sessionId: 's1',
+        pos: 10,
+        end: 13,
+      );
+      final wideKept = dropCoveredRagWindows([wide], [gist]);
+      expect(wideKept, hasLength(1));
+      expect(wideKept.first.positionStart, 12);
+      expect(wideKept.first.positionEnd, 13);
+      expect(
+        RetrievedMemory.excludingPositions(wideKept, {
+          10,
+          11,
+        }, currentSessionId: 's1'),
+        hasLength(1),
+        reason: 'span ≠ line count must not keep the flowerpot pos',
+      );
+    });
+
     test('HOLD hole: prefix card does not cover a bigger fact', () {
       final gardenSwing = _mem(
         'Nia: the front garden swing creaked tonight',

--- a/test/services/chat/rag_injection_test.dart
+++ b/test/services/chat/rag_injection_test.dart
@@ -431,6 +431,7 @@ void main() {
         'screened porch',
         'covered porch',
         'wraparound porch',
+        'wraparound deck',
       ]) {
         final folded = phrase.replaceAll(' ', '');
         final feeling = 'I felt safe on the $phrase tonight';
@@ -449,6 +450,18 @@ void main() {
         expect(dropCoveredRagWindows([swing], [feeling]), [
           swing,
         ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      for (final article in ['the', 'a', 'an']) {
+        expect(
+          coverContentTokens('$article porch'),
+          contains('porch'),
+          reason: '$article stays filler — porch must remain a token',
+        );
+        expect(
+          coverContentTokens('$article porch'),
+          isNot(contains('${article}porch')),
+          reason: 'do not fold "$article porch" into ${article}porch',
+        );
       }
       final fact = _mem(
         'Nia: I still think about the spare key under the third flowerpot',

--- a/test/services/chat/rag_receipt_wiring_test.dart
+++ b/test/services/chat/rag_receipt_wiring_test.dart
@@ -272,7 +272,7 @@ void main() {
       photoMsg.activeMetadata!['is_user_image'] = true;
       photoMsg.activeMetadata!['image_caption'] = 'a red kite over the bay';
 
-      await chat.sendMessage('That photo was from our last trip, remember?');
+      await chat.sendMessage('That photo was from our last trip, remember what you said?');
 
       expect(
         memory.lastQuery,

--- a/test/services/chat/rag_receipt_wiring_test.dart
+++ b/test/services/chat/rag_receipt_wiring_test.dart
@@ -291,7 +291,14 @@ void main() {
       );
 
       final prompt = llm.chatPrompts.last;
-      expect(prompt, contains('in story order'));
+      expect(
+        prompt,
+        contains('from earlier'),
+        reason:
+            'gist-first frame — the old "Exact earlier lines … in story '
+            'order" dump is no longer the normal (or quote-reach) header',
+      );
+      expect(prompt, isNot(contains('Exact earlier lines')));
       const otherLine = '- (another chat) You: remember the red kite';
       const ownLine = '- (Day 1) Nia: the porch swing creaked all night';
       expect(prompt, contains(otherLine));

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -51,8 +51,7 @@ const kLastUser = 'Evening. Mind if I sit?';
 
 const kLiveNia = 'The cicadas started all at once tonight';
 const kLiveYou = 'The tomatoes came in early this year';
-const kRegurgWindow =
-    'Nia: $kLiveNia\nYou: $kLiveYou\nYou: $kLastUser';
+const kRegurgWindow = 'Nia: $kLiveNia\nYou: $kLiveYou\nYou: $kLastUser';
 
 const kKite = 'the red kite on the pier';
 const kKiteWindow = 'You: remember $kKite';
@@ -254,62 +253,68 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   _setupPathProviderMock();
 
-  group('history construction (fact off-screen, next line does not restate)', () {
-    final history = plantedHistory();
+  group(
+    'history construction (fact off-screen, next line does not restate)',
+    () {
+      final history = plantedHistory();
 
-    test('fact has left the visible budget AND the age gate', () {
-      const factEnd = 1;
-      expect(
-        factEnd < kInContextStart,
-        isTrue,
-        reason: 'fact window must sit before the visible-context boundary',
-      );
-      expect(
-        MemoryService.isWindowEligible(
-          candidateSessionId: kSession,
-          currentSessionId: kSession,
-          positionEnd: factEnd,
-          inContextStart: kInContextStart,
-        ),
-        isTrue,
-        reason:
-            'fact must also clear kRagMinAgeMessages '
-            '(${MemoryService.kRagMinAgeMessages}) — just-trimmed near-dups '
-            'are regurgitate, not memory',
-      );
-      expect(
-        MemoryService.kRagMinAgeMessages,
-        20,
-        reason: 'lock names the age floor; do not silently retune it here',
-      );
-    });
+      test('fact has left the visible budget AND the age gate', () {
+        const factEnd = 1;
+        expect(
+          factEnd < kInContextStart,
+          isTrue,
+          reason: 'fact window must sit before the visible-context boundary',
+        );
+        expect(
+          MemoryService.isWindowEligible(
+            candidateSessionId: kSession,
+            currentSessionId: kSession,
+            positionEnd: factEnd,
+            inContextStart: kInContextStart,
+          ),
+          isTrue,
+          reason:
+              'fact must also clear kRagMinAgeMessages '
+              '(${MemoryService.kRagMinAgeMessages}) — just-trimmed near-dups '
+              'are regurgitate, not memory',
+        );
+        expect(
+          MemoryService.kRagMinAgeMessages,
+          20,
+          reason: 'lock names the age floor; do not silently retune it here',
+        );
+      });
 
-    test('next user turn never restates the fact', () {
-      expect(history.last.text, kLastUser);
-      expect(history.last.isUser, isTrue);
-      expect(history.last.text.toLowerCase(), isNot(contains('flowerpot')));
-      expect(history.last.text.toLowerCase(), isNot(contains('spare key')));
-      expect(lastWordsFromMessages(history), isNot(contains('flowerpot')));
-      expect(lastWordsFromMessages(history), isNot(contains('spare key')));
-    });
-  });
+      test('next user turn never restates the fact', () {
+        expect(history.last.text, kLastUser);
+        expect(history.last.isUser, isTrue);
+        expect(history.last.text.toLowerCase(), isNot(contains('flowerpot')));
+        expect(history.last.text.toLowerCase(), isNot(contains('spare key')));
+        expect(lastWordsFromMessages(history), isNot(contains('flowerpot')));
+        expect(lastWordsFromMessages(history), isNot(contains('spare key')));
+      });
+    },
+  );
 
   group('cued query is not last-3 live lines', () {
     final history = plantedHistory();
 
-    test('composeRagQuery is emotion + fixation + hot journal + last words', () {
-      final q = cuedQuery();
-      expect(q, contains('feeling $kEmotion'));
-      expect(q, contains('on the mind: $kFixation'));
-      expect(q, contains('remembered: $kJournalGist'));
-      expect(q, contains(kLastUser));
-      expect(
-        q,
-        isNot(equals(lastThreeDump(history))),
-        reason: 'last-3 transcript dump is the regurgitate query',
-      );
-      expect(q, isNot(equals('You: $kLastUser')));
-    });
+    test(
+      'composeRagQuery is emotion + fixation + hot journal + last words',
+      () {
+        final q = cuedQuery();
+        expect(q, contains('feeling $kEmotion'));
+        expect(q, contains('on the mind: $kFixation'));
+        expect(q, contains('remembered: $kJournalGist'));
+        expect(q, contains(kLastUser));
+        expect(
+          q,
+          isNot(equals(lastThreeDump(history))),
+          reason: 'last-3 transcript dump is the regurgitate query',
+        );
+        expect(q, isNot(equals('You: $kLastUser')));
+      },
+    );
 
     test('lastWordsFromMessages is the latest line, not a last-3 dump', () {
       final words = lastWordsFromMessages(history);
@@ -320,23 +325,21 @@ void main() {
     });
 
     test('topHotJournalLine supplies the hot journal cue, ignores cold', () {
-      JournalMemoryData card({
-        required String content,
-        required double heat,
-      }) => JournalMemoryData(
-        id: content,
-        sessionId: kSession,
-        characterId: kChar,
-        content: content,
-        category: 'moment',
-        heat: heat,
-        accessCount: 0,
-        pinned: false,
-        dimensions: 0,
-        createdAt: DateTime(2026),
-        lastAccessedAt: DateTime(2026),
-        updatedAt: DateTime(2026),
-      );
+      JournalMemoryData card({required String content, required double heat}) =>
+          JournalMemoryData(
+            id: content,
+            sessionId: kSession,
+            characterId: kChar,
+            content: content,
+            category: 'moment',
+            heat: heat,
+            accessCount: 0,
+            pinned: false,
+            dimensions: 0,
+            createdAt: DateTime(2026),
+            lastAccessedAt: DateTime(2026),
+            updatedAt: DateTime(2026),
+          );
       expect(
         JournalPhysics.topHotJournalLine([
           card(content: kPorchFeeling, heat: 0.1),
@@ -519,7 +522,10 @@ void main() {
       final hits = await search(lastThreeDump(plantedHistory()));
       final dups = hits.where(namesLastThree).toList();
       if (dups.isEmpty) return; // last-3 retrieved nothing — also not remember
-      expect(dups.first.score, greaterThanOrEqualTo(MemoryService.kRagMinScore));
+      expect(
+        dups.first.score,
+        greaterThanOrEqualTo(MemoryService.kRagMinScore),
+      );
       expect(
         dups.first.content,
         isNot(contains('flowerpot')),
@@ -544,37 +550,75 @@ void main() {
       expect(block, isNot(contains('Exact earlier lines')));
     });
 
-    test('quote-reach still uses the quote header (verbatim expand allowed)', () {
-      expect(isReachingForQuote('You: remember where the spare key lives?'), isTrue);
-      expect(isReachingForQuote('You: $kLastUser'), isFalse);
-      final m = _mem(kFactWindow, pos: 1);
-      final block = buildRagMemoriesBlock(
-        memories: [m],
-        currentSessionId: kSession,
-        days: {m: 1},
-        reachingForQuote: true,
-      );
-      expect(block, contains(kRagQuoteHeader.trim()));
-      expect(block, contains(kFact));
-      expect(block, isNot(contains('Exact earlier lines')));
-    });
+    test(
+      'quote-reach still uses the quote header (verbatim expand allowed)',
+      () {
+        expect(
+          isReachingForQuote('You: remember where the spare key lives?'),
+          isTrue,
+        );
+        expect(isReachingForQuote('You: $kLastUser'), isFalse);
+        final m = _mem(kFactWindow, pos: 1);
+        final block = buildRagMemoriesBlock(
+          memories: [m],
+          currentSessionId: kSession,
+          days: {m: 1},
+          reachingForQuote: true,
+        );
+        expect(block, contains(kRagQuoteHeader.trim()));
+        expect(block, contains(kFact));
+        expect(block, isNot(contains('Exact earlier lines')));
+      },
+    );
 
-    test('cover-drop: journal card covering the beat drops that RAG window', () {
-      final covered = _mem(kFactLine, pos: 1);
-      final leftover = _mem(kKiteWindow, pos: 9);
-      final kept = dropCoveredRagWindows([covered, leftover], [kJournalGist]);
-      expect(kept.map((m) => m.content).toList(), [kKiteWindow]);
-    });
+    test(
+      'cover-drop: journal card covering the beat drops that RAG window',
+      () {
+        final covered = _mem(kFactLine, pos: 1);
+        final leftover = _mem(kKiteWindow, pos: 9);
+        final kept = dropCoveredRagWindows([covered, leftover], [kJournalGist]);
+        expect(kept.map((m) => m.content).toList(), [kKiteWindow]);
+      },
+    );
 
     test('one uncovered window still retrieves a fallen-off fact', () {
       final leftHistory = _mem(kFactLine, pos: 1);
       final kept = dropCoveredRagWindows([leftHistory], [kPorchFeeling]);
       expect(kept, [leftHistory]);
-      expect(
-        capRagWindows(kept, reachingForQuote: false),
-        [leftHistory],
-      );
+      expect(capRagWindows(kept, reachingForQuote: false), [leftHistory]);
     });
+
+    test('HOLD: lighthouse filler card does not eat the flowerpot fact', () {
+      final fact = _mem(kFactLine, pos: 1);
+      final kept = dropCoveredRagWindows(
+        [fact],
+        ['I still think about the lighthouse'],
+      );
+      expect(kept, [fact]);
+    });
+
+    test('HOLD: no injected gist does not cover-drop', () {
+      final fact = _mem(kFactLine, pos: 1);
+      expect(dropCoveredRagWindows([fact], const []), [fact]);
+    });
+
+    test(
+      'HOLD: spoken I-told-you is not quote-reach and does not dump tape',
+      () {
+        const spoken = 'You: I told you the tomatoes came in';
+        expect(isReachingForQuote(spoken), isFalse);
+        expect(
+          isReachingForQuote('You: she said the cicadas started'),
+          isFalse,
+        );
+        final a = _mem(kFactLine, pos: 1);
+        final b = _mem(kKiteWindow, pos: 9);
+        expect(
+          capRagWindows([a, b], reachingForQuote: isReachingForQuote(spoken)),
+          [a],
+        );
+      },
+    );
 
     test('normal path keeps one uncovered window; quote-reach keeps all', () {
       final a = _mem(kFactLine, pos: 1);
@@ -645,6 +689,14 @@ void main() {
         // The live query's last words never restated the fact.
         expect(cuedQuery(), contains(kLastUser));
         expect(kLastUser.toLowerCase(), isNot(contains('flowerpot')));
+        expect(
+          result.expandedPositions,
+          isEmpty,
+          reason:
+              'HOLD 3: a plain sit-down must stay gist — the cued query '
+              'contains the hot line so cosine alone would always expand',
+        );
+        expect(result.text, isNot(contains('exact words')));
       },
     );
 
@@ -673,17 +725,20 @@ void main() {
       },
     );
 
-    test('receipts still near the transcript do not expand (age gate)', () async {
-      await plantGistCard(positions: const [55]);
-      final result = await injection().buildJournalBlock(
-        characterId: kChar,
-        characterName: 'Nia',
-        userName: 'You',
-        queryText: 'You: remember where the spare key lives?',
-        messageCount: messages.length,
-      );
-      expect(result.expandedPositions, isEmpty);
-      expect(result.text, isNot(contains('exact words')));
-    });
+    test(
+      'receipts still near the transcript do not expand (age gate)',
+      () async {
+        await plantGistCard(positions: const [55]);
+        final result = await injection().buildJournalBlock(
+          characterId: kChar,
+          characterName: 'Nia',
+          userName: 'You',
+          queryText: 'You: remember where the spare key lives?',
+          messageCount: messages.length,
+        );
+        expect(result.expandedPositions, isEmpty);
+        expect(result.text, isNot(contains('exact words')));
+      },
+    );
   });
 }

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -736,6 +736,53 @@ void main() {
       },
     );
 
+    test('HOLD hole: short leftover and mixed span', () {
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: the spare key died', pos: 2)],
+          ['the spare key'],
+        ),
+        isNot(isEmpty),
+        reason: 'died is leftover even though length < 5',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: the third flowerpot fell', pos: 3)],
+          ['third flowerpot'],
+        ),
+        isNot(isEmpty),
+        reason: 'fell is leftover',
+      );
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I still think about the spare key under the third flowerpot that creaked',
+              pos: 4,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'same-beat gist + that creaked still drops',
+      );
+      final kept = dropCoveredRagWindows(
+        [
+          _mem(
+            'Nia: I still think about the spare key under the third flowerpot\n'
+            'Nia: the swing creaked',
+            pos: 5,
+          ),
+        ],
+        [gist],
+      );
+      expect(kept, hasLength(1));
+      expect(kept.first.content, contains('swing'));
+      expect(kept.first.content, isNot(contains('flowerpot')));
+    });
+
     test('HOLD hole: prefix card does not cover a bigger fact', () {
       expect(
         dropCoveredRagWindows(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -921,6 +921,19 @@ void main() {
         isNot(isEmpty),
         reason: 'short suffix leftover on a 3-D gist is an extra fact',
       );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I still think about the spare key under the third flowerpot sat',
+              pos: 12,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'sat on the complete gist is a suffix extra fact',
+      );
     });
 
     test('HOLD hole: prefix card does not cover a bigger fact', () {

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -702,6 +702,51 @@ void main() {
       );
     });
 
+    test('HOLD hole: setting nouns are filler — front steps / this-porch', () {
+      for (final phrase in ['front steps', 'back patio', 'screened porch']) {
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem('Nia: the $phrase swing creaked tonight', pos: 2);
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      expect(
+        coverContentTokens('this porch swing'),
+        isNot(contains('thisporch')),
+      );
+      expect(coverContentTokens('I sat on porch'), isNot(contains('onporch')));
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: this porch swing creaked tonight', pos: 2)],
+          ['Nia: the porch swing creaked tonight'],
+        ),
+        isEmpty,
+        reason: 'same-beat this-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: my porch swing creaked tonight', pos: 3)],
+          ['Nia: the porch swing creaked tonight'],
+        ),
+        isEmpty,
+        reason: 'same-beat my-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem('I sat on porch; the swing creaked tonight', pos: 4)],
+          ['Nia: the porch swing creaked tonight'],
+        ),
+        isEmpty,
+        reason: 'same-beat I-sat-on-porch still drops',
+      );
+      final fact = _mem(kFactLine, pos: 1);
+      expect(
+        dropCoveredRagWindows([fact], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: covered/wraparound fold; the/a/an stay filler', () {
       for (final phrase in [
         'covered porch',
@@ -725,8 +770,8 @@ void main() {
       for (final article in ['the', 'a', 'an']) {
         expect(
           coverContentTokens('$article porch'),
-          contains('porch'),
-          reason: '$article stays filler — porch must remain a token',
+          isNot(contains('porch')),
+          reason: '$article stays filler and porch is setting-noun filler',
         );
         expect(
           coverContentTokens('$article porch'),

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -703,16 +703,48 @@ void main() {
     });
 
     test('HOLD hole: setting nouns are filler — front steps / this-porch', () {
-      for (final phrase in ['front steps', 'back patio', 'screened porch']) {
+      for (final phrase in [
+        'front steps',
+        'back patio',
+        'screened porch',
+        'front walk',
+        'back path',
+      ]) {
         final feeling = 'I felt safe on the $phrase tonight';
         final swing = _mem('Nia: the $phrase swing creaked tonight', pos: 2);
         expect(dropCoveredRagWindows([swing], [feeling]), [
           swing,
         ], reason: 'feeling × $phrase swing must not cover-drop');
       }
+      for (final noun in [
+        'porch',
+        'yard',
+        'lawn',
+        'deck',
+        'stoop',
+        'steps',
+        'patio',
+        'walk',
+        'path',
+      ]) {
+        expect(
+          coverContentTokens('felt safe $noun'),
+          isNot(contains(noun)),
+          reason: '$noun is setting-noun filler',
+        );
+      }
       expect(
         coverContentTokens('this porch swing'),
         isNot(contains('thisporch')),
+      );
+      expect(coverContentTokens('my porch swing'), isNot(contains('myporch')));
+      expect(
+        coverContentTokens('our porch swing'),
+        isNot(contains('ourporch')),
+      );
+      expect(
+        coverContentTokens('your porch swing'),
+        isNot(contains('yourporch')),
       );
       expect(coverContentTokens('I sat on porch'), isNot(contains('onporch')));
       expect(
@@ -730,6 +762,22 @@ void main() {
         ),
         isEmpty,
         reason: 'same-beat my-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: our porch swing creaked tonight', pos: 5)],
+          ['Nia: the porch swing creaked tonight'],
+        ),
+        isEmpty,
+        reason: 'same-beat our-porch swing still drops',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: your porch swing creaked tonight', pos: 6)],
+          ['Nia: the porch swing creaked tonight'],
+        ),
+        isEmpty,
+        reason: 'same-beat your-porch swing still drops',
       );
       expect(
         dropCoveredRagWindows(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -855,8 +855,8 @@ void main() {
           ],
           [gist],
         ),
-        isEmpty,
-        reason: 'lives hidden is same-beat paraphrase',
+        isNot(isEmpty),
+        reason: 'lives hidden has leftover — leftover-empty only, so KEEP',
       );
       final gapKept = dropCoveredRagWindows(
         [
@@ -891,8 +891,8 @@ void main() {
             ],
             [gist],
           ),
-          isEmpty,
-          reason: '"$verb under" is interior same-beat',
+          isNot(isEmpty),
+          reason: '"$verb under" has leftover — leftover-empty only, so KEEP',
         );
       }
       expect(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -682,6 +682,26 @@ void main() {
       );
     });
 
+    test('HOLD hole: screened porch folds without a new adj list', () {
+      final feeling = 'I felt safe on the screened porch tonight';
+      final swing = _mem(
+        'Nia: the screened porch swing creaked tonight',
+        pos: 2,
+      );
+      expect(coverContentTokens(feeling), contains('screenedporch'));
+      expect(coverContentTokens(feeling), isNot(contains('screened')));
+      expect(coverContentTokens('the porch'), isNot(contains('theporch')));
+      expect(dropCoveredRagWindows([swing], [feeling]), [
+        swing,
+      ], reason: 'feeling × screened-porch swing must not cover-drop');
+      final fact = _mem(kFactLine, pos: 1);
+      expect(
+        dropCoveredRagWindows([fact], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: side porch and front lawn fold — not two more pairs', () {
       for (final phrase in ['side porch', 'front lawn']) {
         final feeling = 'I felt safe on the $phrase tonight';

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -736,6 +736,48 @@ void main() {
       },
     );
 
+    test('HOLD hole: whole tokens + distinctive — key is not keyboard', () {
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I still think about the spare keyboard in the attic',
+              pos: 2,
+            ),
+          ],
+          ['I still think about the spare key'],
+        ),
+        isNot(isEmpty),
+        reason: 'key is not inside keyboard',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I felt safe on the front garden until the spare key went missing',
+              pos: 3,
+            ),
+          ],
+          ['I felt safe tonight'],
+        ),
+        isNot(isEmpty),
+        reason: 'mood-only felt/safe must not cover',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem(kFactLine, pos: 1)],
+          ['I still think about it'],
+        ),
+        isNot(isEmpty),
+        reason: 'still/think must not eat the flowerpot window',
+      );
+      expect(
+        dropCoveredRagWindows([_mem(kFactLine, pos: 1)], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: garden/balcony/driveway + his/her are not a new list', () {
       for (final phrase in ['front garden', 'back balcony', 'side driveway']) {
         final feeling = 'I felt safe on the $phrase tonight';

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -561,6 +561,29 @@ void main() {
       );
     });
 
+    test('HOLD lock: single-line window strips the speaker prefix too', () {
+      expect(
+        rememberedLineFromWindow('Nia: the swing creaked'),
+        'the swing creaked',
+      );
+      final m = _mem('Nia: the swing creaked', pos: 2);
+      final plain = buildRagMemoriesBlock(
+        memories: [m],
+        currentSessionId: kSession,
+        days: {m: 1},
+        reachingForQuote: false,
+      );
+      expect(plain, contains('- (Day 1) the swing creaked'));
+      expect(plain, isNot(contains('Nia:')));
+      final quoted = buildRagMemoriesBlock(
+        memories: [m],
+        currentSessionId: kSession,
+        days: {m: 2},
+        reachingForQuote: true,
+      );
+      expect(quoted, contains('Nia: the swing creaked'));
+    });
+
     test(
       'quote-reach still uses the quote header (verbatim expand allowed)',
       () {
@@ -647,6 +670,31 @@ void main() {
         [swing],
         reason: 'shared place-compound is not cover',
       );
+      final fact = _mem(kFactLine, pos: 1);
+      expect(
+        dropCoveredRagWindows([fact], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
+    test('HOLD lock: front/back porch and yard fold to one token', () {
+      const compounds = {
+        'front porch': 'frontporch',
+        'back porch': 'backporch',
+        'front yard': 'frontyard',
+        'back yard': 'backyard',
+      };
+      for (final e in compounds.entries) {
+        final phrase = e.key;
+        final folded = e.value;
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem('Nia: the $phrase swing creaked tonight', pos: 2);
+        expect(coverContentTokens(feeling), contains(folded));
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing is not cover');
+      }
       final fact = _mem(kFactLine, pos: 1);
       expect(
         dropCoveredRagWindows([fact], [kJournalGist]),

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -602,6 +602,35 @@ void main() {
       expect(dropCoveredRagWindows([fact], const []), [fact]);
     });
 
+    test('HOLD: cover tokens are content, not still/think/about', () {
+      final fact = coverContentTokens(kFactLine);
+      final lighthouse = coverContentTokens(
+        'I still think about the lighthouse',
+      );
+      expect(fact.contains('still'), isFalse);
+      expect(fact.contains('think'), isFalse);
+      expect(fact.contains('about'), isFalse);
+      expect(lighthouse.contains('still'), isFalse);
+      expect(lighthouse.contains('think'), isFalse);
+      expect(lighthouse.contains('about'), isFalse);
+      expect(
+        lighthouse.intersection(fact),
+        isEmpty,
+        reason:
+            'unrelated lighthouse gist must not share a content token '
+            'with the flowerpot window',
+      );
+      expect(fact, contains('flowerpot'));
+      expect(lighthouse, contains('lighthouse'));
+      expect(
+        coverContentTokens(
+          'Nia: I still think about the lighthouse on the cliff',
+        ).intersection(lighthouse),
+        isNot(isEmpty),
+        reason: 'a matching lighthouse beat still covers on the content token',
+      );
+    });
+
     test(
       'HOLD: spoken I-told-you is not quote-reach and does not dump tape',
       () {
@@ -611,11 +640,41 @@ void main() {
           isReachingForQuote('You: she said the cicadas started'),
           isFalse,
         );
+        expect(
+          isReachingForQuote('You: I promised I would bring the tomatoes'),
+          isFalse,
+          reason: 'spoken promised is not an ask for the words',
+        );
+        expect(
+          isReachingForQuote('You: she promised the cicadas would start'),
+          isFalse,
+        );
+        expect(isReachingForQuote('You: what did you promise?'), isTrue);
+        expect(isReachingForQuote('You: what you promised'), isTrue);
+        expect(isReachingForQuote('You: exact words'), isTrue);
         final a = _mem(kFactLine, pos: 1);
         final b = _mem(kKiteWindow, pos: 9);
         expect(
           capRagWindows([a, b], reachingForQuote: isReachingForQuote(spoken)),
           [a],
+        );
+        expect(
+          capRagWindows(
+            [a, b],
+            reachingForQuote: isReachingForQuote(
+              'You: I promised I would bring the tomatoes',
+            ),
+          ),
+          [a],
+          reason: 'spoken promised keeps the one-window cap',
+        );
+        expect(
+          capRagWindows(
+            [a, b],
+            reachingForQuote: isReachingForQuote('You: $kLastUser'),
+          ),
+          [a],
+          reason: 'plain sit-down is not quote-reach — cap stays one window',
         );
       },
     );
@@ -690,6 +749,11 @@ void main() {
         expect(cuedQuery(), contains(kLastUser));
         expect(kLastUser.toLowerCase(), isNot(contains('flowerpot')));
         expect(
+          isReachingForQuote(cuedQuery()),
+          isFalse,
+          reason: 'HOLD 3: gist GREEN path is not a verbatim ask',
+        );
+        expect(
           result.expandedPositions,
           isEmpty,
           reason:
@@ -724,6 +788,115 @@ void main() {
         expect(result.expandedPositions, {0, 1});
       },
     );
+
+    test(
+      'HOLD: this-beat injected gist only — cold cabinet flowerpot does not cover-drop',
+      () async {
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: const Value(kSession),
+            characterId: const Value(kChar),
+            content: const Value(kPorchFeeling),
+            category: const Value('moment'),
+            emotionLabel: const Value('wistful'),
+            heat: const Value(0.9),
+          ),
+        );
+        await db.insertJournalCard(
+          JournalMemoriesCompanion(
+            sessionId: const Value(kSession),
+            characterId: const Value(kChar),
+            content: const Value(kJournalGist),
+            category: const Value('about_us'),
+            emotionLabel: const Value('wistful'),
+            heat: const Value(0.1),
+          ),
+        );
+        await store.embedMissing(kSession, kChar);
+
+        final sitDown = composeRagQuery(
+          emotion: kEmotion,
+          fixation: 'the porch',
+          hotJournalLine: kPorchFeeling,
+          lastWords: 'You: $kLastUser',
+        );
+        expect(isReachingForQuote(sitDown), isFalse);
+        expect(sitDown.toLowerCase(), isNot(contains('flowerpot')));
+        expect(sitDown.toLowerCase(), isNot(contains('spare key')));
+
+        final result = await injection().buildJournalBlock(
+          characterId: kChar,
+          characterName: 'Nia',
+          userName: 'You',
+          queryText: sitDown,
+          messageCount: messages.length,
+        );
+        expect(result.injectedContents, contains(kPorchFeeling));
+        expect(
+          result.injectedContents,
+          isNot(contains(kJournalGist)),
+          reason:
+              'cold cabinet flowerpot must not ride this-beat cover — '
+              'that is the whole-cabinet false drop',
+        );
+        expect(result.expandedPositions, isEmpty);
+
+        final fact = _mem(kFactLine, pos: 1);
+        expect(
+          dropCoveredRagWindows([fact], result.injectedContents),
+          [fact],
+          reason:
+              'this-beat porch gist must not cover-drop the uncovered '
+              'flowerpot window',
+        );
+        expect(
+          dropCoveredRagWindows([fact], [kPorchFeeling, kJournalGist]),
+          isEmpty,
+          reason:
+              'whole cabinet WOULD drop the window — that is why cover '
+              'must be this-beat injected gist only',
+        );
+      },
+    );
+
+    test('HOLD: journal-off and this-beat cover wiring', () {
+      final blocks = File(
+        'lib/services/chat/chat_service_generation_blocks.dart',
+      ).readAsStringSync();
+      expect(
+        blocks.contains('t.journalCoverLines = const [];'),
+        isTrue,
+        reason: 'cover starts empty so Journal-off cannot cover-drop',
+      );
+      expect(
+        blocks.contains(
+          't.journalCoverLines = [for (final c in cards) c.content]',
+        ),
+        isFalse,
+        reason: 'whole cabinet must not become cover',
+      );
+      expect(
+        blocks.contains('t.journalCoverLines = journal.injectedContents;'),
+        isTrue,
+      );
+      final gate = blocks.indexOf(
+        'if (_storageService.memorySettings.journalEnabled',
+      );
+      final assign = blocks.indexOf(
+        't.journalCoverLines = journal.injectedContents;',
+      );
+      expect(gate, greaterThanOrEqualTo(0));
+      expect(
+        assign,
+        greaterThan(gate),
+        reason: 'injectedContents assignment is inside the journalEnabled gate',
+      );
+      final rag = File(
+        'lib/services/chat/chat_service_generation_rag.dart',
+      ).readAsStringSync();
+      expect(rag.contains('dropCoveredRagWindows('), isTrue);
+      expect(rag.contains('t.journalCoverLines'), isTrue);
+    });
 
     test(
       'receipts still near the transcript do not expand (age gate)',

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -597,6 +597,23 @@ void main() {
       expect(kept, [fact]);
     });
 
+    test('HOLD r2: porch feeling does not eat a porch-swing fact', () {
+      final swing = _mem('Nia: the porch swing creaked', pos: 2);
+      final kept = dropCoveredRagWindows([swing], [kPorchFeeling]);
+      expect(kept, [
+        swing,
+      ], reason: 'one shared place/noun (porch) is not cover');
+    });
+
+    test('HOLD r2: one shared spare token is not cover', () {
+      final fact = _mem(kFactLine, pos: 1);
+      final kept = dropCoveredRagWindows(
+        [fact],
+        ['I still think about the spare room'],
+      );
+      expect(kept, [fact], reason: 'one shared noun (spare) is not cover');
+    });
+
     test('HOLD: no injected gist does not cover-drop', () {
       final fact = _mem(kFactLine, pos: 1);
       expect(dropCoveredRagWindows([fact], const []), [fact]);
@@ -652,6 +669,13 @@ void main() {
         expect(isReachingForQuote('You: what did you promise?'), isTrue);
         expect(isReachingForQuote('You: what you promised'), isTrue);
         expect(isReachingForQuote('You: exact words'), isTrue);
+        expect(isReachingForQuote('You: Remember to lock the door?'), isFalse);
+        expect(
+          isReachingForQuote('You: Remember the tomatoes came in early?'),
+          isFalse,
+        );
+        expect(isReachingForQuote('You: can you quote that'), isTrue);
+        expect(isReachingForQuote('You: remember what you said'), isTrue);
         final a = _mem(kFactLine, pos: 1);
         final b = _mem(kKiteWindow, pos: 9);
         expect(
@@ -669,10 +693,10 @@ void main() {
           reason: 'spoken promised keeps the one-window cap',
         );
         expect(
-          capRagWindows(
-            [a, b],
-            reachingForQuote: isReachingForQuote('You: $kLastUser'),
-          ),
+          capRagWindows([
+            a,
+            b,
+          ], reachingForQuote: isReachingForQuote('You: $kLastUser')),
           [a],
           reason: 'plain sit-down is not quote-reach — cap stays one window',
         );
@@ -741,6 +765,7 @@ void main() {
           characterName: 'Nia',
           userName: 'You',
           queryText: cuedQuery(),
+          lastWords: 'You: $kLastUser',
           messageCount: messages.length,
         );
         expect(result.text, contains('spare key'));
@@ -780,6 +805,7 @@ void main() {
           characterName: 'Nia',
           userName: 'You',
           queryText: reaching,
+          lastWords: 'You: remember where the spare key lives?',
           messageCount: messages.length,
         );
         expect(result.text, contains(kJournalGist));
@@ -829,6 +855,7 @@ void main() {
           characterName: 'Nia',
           userName: 'You',
           queryText: sitDown,
+          lastWords: 'You: $kLastUser',
           messageCount: messages.length,
         );
         expect(result.injectedContents, contains(kPorchFeeling));
@@ -879,6 +906,11 @@ void main() {
         blocks.contains('t.journalCoverLines = journal.injectedContents;'),
         isTrue,
       );
+      expect(
+        blocks.contains('lastWords: lastWordsFromMessages(_messages)'),
+        isTrue,
+        reason: 'HOLD r2: expand gates on lastWords, same as RAG',
+      );
       final gate = blocks.indexOf(
         'if (_storageService.memorySettings.journalEnabled',
       );
@@ -899,6 +931,39 @@ void main() {
     });
 
     test(
+      'HOLD r2: diary I-remember-where in the cued query does not expand',
+      () async {
+        await plantGistCard();
+        final diaryCue = composeRagQuery(
+          emotion: kEmotion,
+          fixation: kFixation,
+          hotJournalLine: 'I remember where we sat on the porch',
+          lastWords: 'You: $kLastUser',
+        );
+        expect(
+          isReachingForQuote(diaryCue),
+          isTrue,
+          reason: 'composed query contains remember where — that is the trap',
+        );
+        expect(isReachingForQuote('You: $kLastUser'), isFalse);
+        final result = await injection().buildJournalBlock(
+          characterId: kChar,
+          characterName: 'Nia',
+          userName: 'You',
+          queryText: diaryCue,
+          lastWords: 'You: $kLastUser',
+          messageCount: messages.length,
+        );
+        expect(
+          result.expandedPositions,
+          isEmpty,
+          reason: 'expand must use lastWords, never the composed query',
+        );
+        expect(result.text, isNot(contains('exact words')));
+      },
+    );
+
+    test(
       'receipts still near the transcript do not expand (age gate)',
       () async {
         await plantGistCard(positions: const [55]);
@@ -907,6 +972,7 @@ void main() {
           characterName: 'Nia',
           userName: 'You',
           queryText: 'You: remember where the spare key lives?',
+          lastWords: 'You: remember where the spare key lives?',
           messageCount: messages.length,
         );
         expect(result.expandedPositions, isEmpty);

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -637,6 +637,24 @@ void main() {
       ], reason: 'one shared place/noun (porch) is not cover');
     });
 
+    test('HOLD lock: front-porch compound is not cover', () {
+      final swing = _mem('Nia: the front porch swing creaked tonight', pos: 2);
+      expect(
+        dropCoveredRagWindows(
+          [swing],
+          ['I felt safe on the front porch tonight'],
+        ),
+        [swing],
+        reason: 'shared place-compound is not cover',
+      );
+      final fact = _mem(kFactLine, pos: 1);
+      expect(
+        dropCoveredRagWindows([fact], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD leftover: porch+tonight is setting+time, not cover', () {
       final swing = _mem('Nia: the porch swing creaked tonight', pos: 2);
       expect(coverContentTokens(kPorchFeeling).contains('tonight'), isFalse);
@@ -982,6 +1000,26 @@ void main() {
         reason:
             'HOLD leftover: expand/quote-ask use last spoken line, not captions',
       );
+      final journalCall = blocks.indexOf(
+        '_journalInjection.buildJournalBlock(',
+      );
+      expect(journalCall, greaterThanOrEqualTo(0));
+      final journalSlice = blocks.substring(
+        journalCall,
+        (journalCall + 900).clamp(0, blocks.length),
+      );
+      expect(
+        journalSlice.contains(
+          'lastWords: lastSpokenLineFromMessages(_messages)',
+        ),
+        isTrue,
+        reason: 'HOLD lock 3: journal expand uses lastSpoken, never lastWords',
+      );
+      expect(
+        journalSlice.contains('lastWordsFromMessages'),
+        isFalse,
+        reason: 'HOLD lock 3: captions must not ride journal lastWords',
+      );
       final gate = blocks.indexOf(
         'if (_storageService.memorySettings.journalEnabled',
       );
@@ -1003,6 +1041,37 @@ void main() {
       expect(rag.contains('shouldRetrieveRag('), isTrue);
       expect(rag.contains('Skipping memory retrieval — cue-less beat'), isTrue);
     });
+
+    test(
+      'HOLD lock 3: caption lastWords would expand; lastSpoken sit does not',
+      () async {
+        await plantGistCard();
+        final msgs = [
+          ChatMessage(
+            text: 'look',
+            sender: 'You',
+            isUser: true,
+            metadata: {
+              'is_user_image': true,
+              'image_caption': 'remember our beach day',
+            },
+          ),
+          ChatMessage(text: kLastUser, sender: 'You', isUser: true),
+        ];
+        expect(isReachingForQuote(lastWordsFromMessages(msgs)), isTrue);
+        expect(isReachingForQuote(lastSpokenLineFromMessages(msgs)), isFalse);
+        final result = await injection().buildJournalBlock(
+          characterId: kChar,
+          characterName: 'Nia',
+          userName: 'You',
+          queryText: cuedQuery(),
+          lastWords: lastSpokenLineFromMessages(msgs),
+          messageCount: messages.length,
+        );
+        expect(result.expandedPositions, isEmpty);
+        expect(result.text, isNot(contains('exact words')));
+      },
+    );
 
     test(
       'HOLD r2: diary remember-when in remembered: does not expand sit-down',

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -702,6 +702,40 @@ void main() {
       );
     });
 
+    test(
+      'HOLD lock: leftover 2-token overlap is not cover — hallway keeps',
+      () {
+        final hallway = _mem(
+          'Nia: the spare key lives in the hallway drawer',
+          pos: 2,
+        );
+        expect(
+          coverContentTokens(
+            hallway.content,
+          ).intersection(coverContentTokens(kJournalGist)).length,
+          greaterThanOrEqualTo(2),
+          reason:
+              'hallway shares leftover tokens ≥ 2 with the flowerpot gist — '
+              'if that were the cover rule this window would drop',
+        );
+        expect(
+          dropCoveredRagWindows([hallway], [kJournalGist]),
+          [hallway],
+          reason:
+              'shared leftover tokens ≥ 2 is NOT cover. A source-scan for '
+              '2-token intersection as the cover rule MUST FAIL.',
+        );
+        final flower = _mem(kFactLine, pos: 1);
+        expect(
+          dropCoveredRagWindows([flower], [kJournalGist]),
+          isEmpty,
+          reason:
+              'same-beat flowerpot gist DROPS because the card names the '
+              'flowerpot in the window (near-substring), not 2-token overlap',
+        );
+      },
+    );
+
     test('HOLD hole: garden/balcony/driveway + his/her are not a new list', () {
       for (final phrase in ['front garden', 'back balcony', 'side driveway']) {
         final feeling = 'I felt safe on the $phrase tonight';
@@ -718,6 +752,13 @@ void main() {
         coverContentTokens('her porch swing'),
         isNot(contains('herporch')),
       );
+      expect(
+        coverContentTokens('that porch swing'),
+        isNot(contains('thatporch')),
+      );
+      expect(coverContentTokens('off the porch'), isNot(contains('offporch')));
+      expect(coverContentTokens('in the porch'), isNot(contains('inporch')));
+      expect(coverContentTokens('at the porch'), isNot(contains('atporch')));
       final fact = _mem(kFactLine, pos: 1);
       expect(
         dropCoveredRagWindows([fact], [kJournalGist]),

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -614,6 +614,33 @@ void main() {
       expect(kept, [fact], reason: 'one shared noun (spare) is not cover');
     });
 
+    test(
+      'HOLD r2: same-beat flowerpot gist still drops the covered window',
+      () {
+        final fact = _mem(kFactLine, pos: 1);
+        expect(
+          coverContentTokens(kFactLine)
+              .intersection(
+                coverContentTokens('I still think about the spare room'),
+              )
+              .length,
+          1,
+          reason: 'cover needs ≥2 content tokens — spare alone is not cover',
+        );
+        expect(
+          coverContentTokens(
+            kFactLine,
+          ).intersection(coverContentTokens(kJournalGist)).length,
+          greaterThanOrEqualTo(2),
+        );
+        expect(
+          dropCoveredRagWindows([fact], [kJournalGist]),
+          isEmpty,
+          reason: 'same-beat flowerpot gist must still drop that window',
+        );
+      },
+    );
+
     test('HOLD: no injected gist does not cover-drop', () {
       final fact = _mem(kFactLine, pos: 1);
       expect(dropCoveredRagWindows([fact], const []), [fact]);
@@ -676,6 +703,9 @@ void main() {
         );
         expect(isReachingForQuote('You: can you quote that'), isTrue);
         expect(isReachingForQuote('You: remember what you said'), isTrue);
+        expect(isReachingForQuote('You: what did I promise'), isTrue);
+        expect(isReachingForQuote('You: remember our wedding vows?'), isTrue);
+        expect(isReachingForQuote('You: vows?'), isTrue);
         final a = _mem(kFactLine, pos: 1);
         final b = _mem(kKiteWindow, pos: 9);
         expect(
@@ -929,6 +959,45 @@ void main() {
       expect(rag.contains('dropCoveredRagWindows('), isTrue);
       expect(rag.contains('t.journalCoverLines'), isTrue);
     });
+
+    test(
+      'HOLD r2: diary remember-when in remembered: does not expand sit-down',
+      () async {
+        await plantGistCard();
+        final diaryCue = composeRagQuery(
+          emotion: kEmotion,
+          fixation: kFixation,
+          hotJournalLine: 'I remember when we sat on the porch',
+          lastWords: 'You: $kLastUser',
+        );
+        expect(
+          diaryCue,
+          contains('remembered: I remember when we sat on the porch'),
+        );
+        expect(
+          isReachingForQuote('I remember when we sat on the porch'),
+          isFalse,
+          reason: 'diary remember-when is not quote-ask',
+        );
+        expect(isReachingForQuote('You: $kLastUser'), isFalse);
+        final result = await injection().buildJournalBlock(
+          characterId: kChar,
+          characterName: 'Nia',
+          userName: 'You',
+          queryText: diaryCue,
+          lastWords: 'You: $kLastUser',
+          messageCount: messages.length,
+        );
+        expect(
+          result.expandedPositions,
+          isEmpty,
+          reason:
+              'a diary remember-when sitting in remembered: must not '
+              'expand a sit-down turn',
+        );
+        expect(result.text, isNot(contains('exact words')));
+      },
+    );
 
     test(
       'HOLD r2: diary I-remember-where in the cued query does not expand',

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -702,6 +702,30 @@ void main() {
       );
     });
 
+    test('HOLD hole: garden/balcony/driveway + his/her are not a new list', () {
+      for (final phrase in ['front garden', 'back balcony', 'side driveway']) {
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem('Nia: the $phrase swing creaked tonight', pos: 2);
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      expect(
+        coverContentTokens('his porch swing'),
+        isNot(contains('hisporch')),
+      );
+      expect(
+        coverContentTokens('her porch swing'),
+        isNot(contains('herporch')),
+      );
+      final fact = _mem(kFactLine, pos: 1);
+      expect(
+        dropCoveredRagWindows([fact], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: setting nouns are filler — front steps / this-porch', () {
       for (final phrase in [
         'front steps',

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -1,0 +1,689 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// REMEMBER vs REGURGITATE (gist-first + cued RAG).
+//
+// The fact must leave the visible history budget AND sit past
+// MemoryService.kRagMinAgeMessages (20). The next user turn never restates
+// it. Green is: retrieval includes that fallen-off window and/or the gist
+// journal card, and the injection payload can use the fact. Red is: the hit
+// list is only near-duplicates of the last 3 live lines, or the fact only
+// injects while it is still on screen.
+//
+// Embeddings are a deterministic bag-of-words over *content*. Cosine then
+// tracks lexical overlap, so a last-3-only query of the live lines cannot
+// reach an aged fact those lines never name — and a cued query
+// (emotion + fixation + hot journal line + last words) can. A fixture
+// MemoryService that always returns the plant is refused here (that is
+// fake-green). So are "rag_receipt exists", "score ≥ 0.45", and "contains
+// the last user line" as stand-alone greens.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:front_porch_ai/database/database.dart';
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/chat/chat.dart';
+import 'package:front_porch_ai/services/chat/prompt_injection/journal_injection.dart';
+import 'package:front_porch_ai/services/embedding_service.dart';
+import 'package:front_porch_ai/services/memory_service.dart';
+import 'package:front_porch_ai/services/storage_service.dart';
+
+// ── Planted fact + live beat (deliberately disjoint vocab) ──────────────
+
+const kFact = 'the spare key lives under the third flowerpot';
+const kFactUser = 'You: $kFact';
+const kFactLine =
+    'Nia: I still think about the spare key under the third flowerpot';
+const kFactWindow = '$kFactUser\n$kFactLine';
+
+const kJournalGist =
+    'I still think about the spare key under the third flowerpot';
+const kEmotion = 'wistful';
+const kFixation = 'the spare key';
+const kLastUser = 'Evening. Mind if I sit?';
+
+const kLiveNia = 'The cicadas started all at once tonight';
+const kLiveYou = 'The tomatoes came in early this year';
+const kRegurgWindow =
+    'Nia: $kLiveNia\nYou: $kLiveYou\nYou: $kLastUser';
+
+const kKite = 'the red kite on the pier';
+const kKiteWindow = 'You: remember $kKite';
+const kPorchFeeling = 'I felt safe on the porch tonight';
+
+const kSession = 'sess-remember';
+const kChar = 'nia-remember';
+
+/// Visible-context boundary. Fact window ends at 1; regurgitate-of-last-3
+/// window ends at 8; a too-young last-3 near-dup ends at 28.
+const kInContextStart = 30;
+
+const kTranscriptLen = 50;
+
+void _setupPathProviderMock() {
+  const channel = MethodChannel('plugins.flutter.io/path_provider');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') {
+          return Directory.systemTemp.createTempSync('fpai_remember_').path;
+        }
+        return null;
+      });
+}
+
+/// Tokens that actually carry meaning for this suite. Short words and
+/// speaker labels are dropped so "You:" / "Nia:" / "the" cannot glue an
+/// unrelated last-3 query onto the aged fact.
+const _stop = {
+  'the',
+  'and',
+  'for',
+  'you',
+  'nia',
+  'she',
+  'they',
+  'that',
+  'this',
+  'with',
+  'from',
+  'was',
+  'are',
+  'not',
+  'but',
+  'her',
+  'his',
+  'our',
+  'all',
+  'once',
+  'a',
+  'an',
+  'of',
+  'my',
+  'your',
+  'their',
+  'if',
+};
+
+List<String> _tokens(String text) => text
+    .toLowerCase()
+    .replaceAll(RegExp(r'[^a-z0-9\s]'), ' ')
+    .split(RegExp(r'\s+'))
+    .where((t) => t.length >= 3 && !_stop.contains(t))
+    .toList();
+
+/// Closed-vocab bag-of-words. Each token in [corpus] is its own axis, so
+/// cosine similarity is lexical overlap — not a keyword switch, not a
+/// constant hit.
+class _ContentSpace {
+  final List<String> vocab;
+
+  factory _ContentSpace(Iterable<String> corpus) {
+    final set = <String>{};
+    for (final t in corpus) {
+      set.addAll(_tokens(t));
+    }
+    return _ContentSpace._(set.toList()..sort());
+  }
+
+  _ContentSpace._(this.vocab);
+
+  List<double> embed(String text) {
+    final v = List<double>.filled(vocab.length, 0);
+    for (final t in _tokens(text)) {
+      final i = vocab.indexOf(t);
+      if (i >= 0) v[i] += 1;
+    }
+    return v;
+  }
+}
+
+final _space = _ContentSpace([
+  kFactWindow,
+  kJournalGist,
+  kEmotion,
+  kFixation,
+  kLastUser,
+  kLiveNia,
+  kLiveYou,
+  kRegurgWindow,
+  kKiteWindow,
+  kPorchFeeling,
+  'feeling $kEmotion',
+  'on the mind: $kFixation',
+  'remembered: $kJournalGist',
+  'You: $kLastUser',
+  'You: remember where the spare key lives?',
+  'You: what should we cook tonight?',
+  kFactUser,
+  kFactLine,
+]);
+
+class _ContentEmbedder extends EmbeddingService {
+  _ContentEmbedder(super.storage);
+
+  @override
+  bool get isAvailable => true;
+
+  @override
+  Future<void> checkAvailability() async {}
+
+  @override
+  Future<List<double>?> embed(String text) async {
+    if (text.trim().isEmpty) return null;
+    return _space.embed(text);
+  }
+}
+
+/// Real retrieve() path. isOperational is forced so the suite is not
+/// coupled to prefs-key prefixing / sidecar setup. retrieve itself is
+/// NOT stubbed — a stub that always returns the plant is fake-green.
+class _LiveMemory extends MemoryService {
+  _LiveMemory(super.embedding, super.storage, super.db);
+
+  @override
+  bool get isOperational => true;
+}
+
+ChatMessage _msg(String sender, String text, {bool isUser = false}) =>
+    ChatMessage(text: text, sender: sender, isUser: isUser);
+
+RetrievedMemory _mem(
+  String content, {
+  required int pos,
+  int? end,
+  String sessionId = kSession,
+  double score = 0.9,
+}) => RetrievedMemory(
+  content: content,
+  characterId: kChar,
+  sessionId: sessionId,
+  positionStart: pos,
+  positionEnd: end ?? pos,
+  score: score,
+);
+
+Uint8List _vecBytes(List<double> v) {
+  final floats = Float32List.fromList(v);
+  return Uint8List.view(floats.buffer);
+}
+
+/// 50-message transcript: fact at 0–1, filler, last-3 live lines that
+/// never name the fact. Visible budget starts at [kInContextStart].
+List<ChatMessage> plantedHistory() {
+  final msgs = <ChatMessage>[
+    _msg('You', kFact, isUser: true),
+    _msg('Nia', kJournalGist),
+  ];
+  for (var i = 2; i < kTranscriptLen - 3; i++) {
+    final user = i.isOdd;
+    msgs.add(
+      _msg(
+        user ? 'You' : 'Nia',
+        user ? 'Porch boards creak on beat $i' : 'Tea steeps on beat $i',
+        isUser: user,
+      ),
+    );
+  }
+  msgs.add(_msg('Nia', kLiveNia));
+  msgs.add(_msg('You', kLiveYou, isUser: true));
+  msgs.add(_msg('You', kLastUser, isUser: true));
+  assert(msgs.length == kTranscriptLen);
+  return msgs;
+}
+
+String lastThreeDump(List<ChatMessage> msgs) => msgs
+    .sublist(msgs.length - 3)
+    .map((m) => '${m.sender}: ${m.promptText}')
+    .join('\n');
+
+String cuedQuery() => composeRagQuery(
+  emotion: kEmotion,
+  fixation: kFixation,
+  hotJournalLine: kJournalGist,
+  lastWords: 'You: $kLastUser',
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  _setupPathProviderMock();
+
+  group('history construction (fact off-screen, next line does not restate)', () {
+    final history = plantedHistory();
+
+    test('fact has left the visible budget AND the age gate', () {
+      const factEnd = 1;
+      expect(
+        factEnd < kInContextStart,
+        isTrue,
+        reason: 'fact window must sit before the visible-context boundary',
+      );
+      expect(
+        MemoryService.isWindowEligible(
+          candidateSessionId: kSession,
+          currentSessionId: kSession,
+          positionEnd: factEnd,
+          inContextStart: kInContextStart,
+        ),
+        isTrue,
+        reason:
+            'fact must also clear kRagMinAgeMessages '
+            '(${MemoryService.kRagMinAgeMessages}) — just-trimmed near-dups '
+            'are regurgitate, not memory',
+      );
+      expect(
+        MemoryService.kRagMinAgeMessages,
+        20,
+        reason: 'lock names the age floor; do not silently retune it here',
+      );
+    });
+
+    test('next user turn never restates the fact', () {
+      expect(history.last.text, kLastUser);
+      expect(history.last.isUser, isTrue);
+      expect(history.last.text.toLowerCase(), isNot(contains('flowerpot')));
+      expect(history.last.text.toLowerCase(), isNot(contains('spare key')));
+      expect(lastWordsFromMessages(history), isNot(contains('flowerpot')));
+      expect(lastWordsFromMessages(history), isNot(contains('spare key')));
+    });
+  });
+
+  group('cued query is not last-3 live lines', () {
+    final history = plantedHistory();
+
+    test('composeRagQuery is emotion + fixation + hot journal + last words', () {
+      final q = cuedQuery();
+      expect(q, contains('feeling $kEmotion'));
+      expect(q, contains('on the mind: $kFixation'));
+      expect(q, contains('remembered: $kJournalGist'));
+      expect(q, contains(kLastUser));
+      expect(
+        q,
+        isNot(equals(lastThreeDump(history))),
+        reason: 'last-3 transcript dump is the regurgitate query',
+      );
+      expect(q, isNot(equals('You: $kLastUser')));
+    });
+
+    test('lastWordsFromMessages is the latest line, not a last-3 dump', () {
+      final words = lastWordsFromMessages(history);
+      expect(words, contains(kLastUser));
+      expect(words, isNot(contains(kLiveNia)));
+      expect(words, isNot(contains(kLiveYou)));
+      expect(words, isNot(contains(kFact)));
+    });
+
+    test('topHotJournalLine supplies the hot journal cue, ignores cold', () {
+      JournalMemoryData card({
+        required String content,
+        required double heat,
+      }) => JournalMemoryData(
+        id: content,
+        sessionId: kSession,
+        characterId: kChar,
+        content: content,
+        category: 'moment',
+        heat: heat,
+        accessCount: 0,
+        pinned: false,
+        dimensions: 0,
+        createdAt: DateTime(2026),
+        lastAccessedAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      );
+      expect(
+        JournalPhysics.topHotJournalLine([
+          card(content: kPorchFeeling, heat: 0.1),
+          card(content: kJournalGist, heat: 0.9),
+        ], kEmotion),
+        kJournalGist,
+      );
+      expect(
+        JournalPhysics.topHotJournalLine([
+          card(content: kJournalGist, heat: 0.1),
+        ], kEmotion),
+        isNull,
+      );
+    });
+  });
+
+  group('real MemoryService: cued retrieve vs last-3 regurgitate', () {
+    late AppDatabase db;
+    late StorageService storage;
+    late _LiveMemory memory;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({
+        'update_auto_check': false,
+        'rag_enabled': true,
+      });
+      db = AppDatabase.forTesting();
+      storage = StorageService();
+      await storage.initialized;
+      memory = _LiveMemory(_ContentEmbedder(storage), storage, db);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    Future<void> plantWindow({
+      required int start,
+      required int end,
+      required String content,
+    }) {
+      final vec = _space.embed(content);
+      return db.insertEmbedding(
+        MessageEmbeddingsCompanion(
+          sessionId: const Value(kSession),
+          characterId: const Value(kChar),
+          positionStart: Value(start),
+          positionEnd: Value(end),
+          content: Value(content),
+          embedding: Value(_vecBytes(vec)),
+          dimensions: Value(vec.length),
+        ),
+      );
+    }
+
+    Future<void> plantCorpus() async {
+      // Aged fact — the remember target.
+      await plantWindow(start: 0, end: 1, content: kFactWindow);
+      // Aged near-duplicate of the last 3 live lines — the regurgitate trap.
+      await plantWindow(start: 6, end: 8, content: kRegurgWindow);
+      // Too-young last-3 near-dup (still next to the visible boundary).
+      await plantWindow(start: 24, end: 28, content: kRegurgWindow);
+    }
+
+    Future<List<RetrievedMemory>> search(
+      String query, {
+      int inContextStart = kInContextStart,
+    }) => memory.retrieve(
+      queryText: query,
+      sourceCharacterIds: const [kChar],
+      currentSessionId: kSession,
+      inContextStart: inContextStart,
+      limit: 8,
+      sessionScopedCharacterIds: const {kChar},
+    );
+
+    bool namesFact(RetrievedMemory m) =>
+        m.content.contains('flowerpot') && m.content.contains('spare key');
+
+    bool namesLastThree(RetrievedMemory m) =>
+        m.content.contains('cicadas') && m.content.contains('tomatoes');
+
+    test('bag-of-words cosine is honest: last-3 misses, cued reaches', () {
+      final fact = _space.embed(kFactWindow);
+      final last3 = _space.embed(lastThreeDump(plantedHistory()));
+      final cued = _space.embed(cuedQuery());
+      expect(
+        MemoryService.cosineSimilarity(last3, fact),
+        lessThan(MemoryService.kRagMinScore),
+        reason:
+            'if last-3 already clears 0.45 against the aged fact, the '
+            'embedder is not content-cosine (fake-green)',
+      );
+      expect(
+        MemoryService.cosineSimilarity(cued, fact),
+        greaterThanOrEqualTo(MemoryService.kRagMinScore),
+        reason:
+            'cued query (emotion+fixation+hot journal+last words) must '
+            'be able to reach the aged fact',
+      );
+    });
+
+    test(
+      'RED: last-3-only query does not retrieve the fallen-off fact',
+      () async {
+        await plantCorpus();
+        final hits = await search(lastThreeDump(plantedHistory()));
+        expect(
+          hits.where(namesFact),
+          isEmpty,
+          reason:
+              'last-3 live lines never named the flowerpot — retrieving '
+              'it from that query would be a fixture, not memory',
+        );
+        // A last-3 hit that scores well is regurgitate, not remember.
+        for (final h in hits) {
+          expect(namesFact(h), isFalse);
+          expect(
+            namesLastThree(h) || h.score >= MemoryService.kRagMinScore,
+            isTrue,
+          );
+        }
+        expect(
+          hits.any((h) => h.positionEnd >= 24),
+          isFalse,
+          reason: 'the too-young last-3 near-dup must stay behind the age gate',
+        );
+      },
+    );
+
+    test(
+      'GREEN: cued query retrieves the fallen-off fact; injection can use it',
+      () async {
+        await plantCorpus();
+        final hits = await search(cuedQuery());
+        expect(
+          hits.any(namesFact),
+          isTrue,
+          reason:
+              'emotion + fixation + hot journal + last words must reach '
+              'the window that left history',
+        );
+        final factHit = hits.firstWhere(namesFact);
+        expect(factHit.positionStart, 0);
+        expect(factHit.positionEnd, 1);
+        expect(factHit.score, greaterThanOrEqualTo(MemoryService.kRagMinScore));
+
+        // Scripted reply path: the injection payload (no live LLM).
+        final block = buildRagMemoriesBlock(
+          memories: [factHit],
+          currentSessionId: kSession,
+          days: {factHit: 2},
+          reachingForQuote: false,
+        );
+        expect(block, contains(kFact));
+        expect(block, contains(kRagRememberedHeader.trim()));
+        expect(block, isNot(contains('Exact earlier lines')));
+      },
+    );
+
+    test(
+      'RED: the fact does not retrieve while it is still on screen',
+      () async {
+        await plantCorpus();
+        // inContextStart=8: fact window (end=1) is inside the 20-message
+        // age gate. retrieve() runs (start>=3) but must refuse the plant.
+        final hits = await search(cuedQuery(), inContextStart: 8);
+        expect(
+          hits.where(namesFact),
+          isEmpty,
+          reason:
+              'if injection only works while the fact is still in (or '
+              'next to) the visible transcript, that is regurgitate',
+        );
+      },
+    );
+
+    test('score ≥ 0.45 on a last-3 near-dup is not remember', () async {
+      await plantCorpus();
+      final hits = await search(lastThreeDump(plantedHistory()));
+      final dups = hits.where(namesLastThree).toList();
+      if (dups.isEmpty) return; // last-3 retrieved nothing — also not remember
+      expect(dups.first.score, greaterThanOrEqualTo(MemoryService.kRagMinScore));
+      expect(
+        dups.first.content,
+        isNot(contains('flowerpot')),
+        reason:
+            'a high-scoring last-3 near-dup is the regurgitate failure '
+            'mode — it is not a green for the fallen-off fact',
+      );
+    });
+  });
+
+  group('gist frame, cover-drop, one uncovered window, quote-reach', () {
+    test('default RAG frame is gist, not Exact earlier lines', () {
+      final m = _mem(kFactWindow, pos: 1);
+      final block = buildRagMemoriesBlock(
+        memories: [m],
+        currentSessionId: kSession,
+        days: {m: 1},
+        reachingForQuote: false,
+      );
+      expect(block, contains(kRagRememberedHeader.trim()));
+      expect(block, contains(kFact));
+      expect(block, isNot(contains('Exact earlier lines')));
+    });
+
+    test('quote-reach still uses the quote header (verbatim expand allowed)', () {
+      expect(isReachingForQuote('You: remember where the spare key lives?'), isTrue);
+      expect(isReachingForQuote('You: $kLastUser'), isFalse);
+      final m = _mem(kFactWindow, pos: 1);
+      final block = buildRagMemoriesBlock(
+        memories: [m],
+        currentSessionId: kSession,
+        days: {m: 1},
+        reachingForQuote: true,
+      );
+      expect(block, contains(kRagQuoteHeader.trim()));
+      expect(block, contains(kFact));
+      expect(block, isNot(contains('Exact earlier lines')));
+    });
+
+    test('cover-drop: journal card covering the beat drops that RAG window', () {
+      final covered = _mem(kFactLine, pos: 1);
+      final leftover = _mem(kKiteWindow, pos: 9);
+      final kept = dropCoveredRagWindows([covered, leftover], [kJournalGist]);
+      expect(kept.map((m) => m.content).toList(), [kKiteWindow]);
+    });
+
+    test('one uncovered window still retrieves a fallen-off fact', () {
+      final leftHistory = _mem(kFactLine, pos: 1);
+      final kept = dropCoveredRagWindows([leftHistory], [kPorchFeeling]);
+      expect(kept, [leftHistory]);
+      expect(
+        capRagWindows(kept, reachingForQuote: false),
+        [leftHistory],
+      );
+    });
+
+    test('normal path keeps one uncovered window; quote-reach keeps all', () {
+      final a = _mem(kFactLine, pos: 1);
+      final b = _mem(kKiteWindow, pos: 9);
+      expect(capRagWindows([a, b], reachingForQuote: false), [a]);
+      expect(capRagWindows([a, b], reachingForQuote: true), [a, b]);
+    });
+  });
+
+  group('journal gist card + quote-reach expand (real JournalInjection)', () {
+    late AppDatabase db;
+    late JournalStore store;
+
+    // Long enough that receipts at 0–1 clear kExpandMinAgeMessages (30).
+    final messages = [
+      _msg('You', kFact, isUser: true),
+      _msg('Nia', kJournalGist),
+      for (var i = 2; i < 60; i++)
+        _msg(i.isOdd ? 'You' : 'Nia', 'filler line $i', isUser: i.isOdd),
+    ];
+
+    setUp(() {
+      db = AppDatabase.forTesting();
+      store = JournalStore(
+        getDb: () => db,
+        embedText: (text) async => _space.embed(text),
+      );
+    });
+    tearDown(() async => db.close());
+
+    JournalInjection injection() => JournalInjection(
+      store: store,
+      getSessionId: () => kSession,
+      getCurrentEmotion: () => kEmotion,
+      getCurrentStoryDay: () => 12,
+      getStoryStartDate: () => DateTime(2026, 1, 1),
+      getMessageAt: (p) => p >= 0 && p < messages.length ? messages[p] : null,
+    );
+
+    Future<void> plantGistCard({List<int> positions = const [0, 1]}) async {
+      await db.insertJournalCard(
+        JournalMemoriesCompanion(
+          sessionId: const Value(kSession),
+          characterId: const Value(kChar),
+          content: const Value(kJournalGist),
+          category: const Value('about_us'),
+          emotionLabel: const Value('wistful'),
+          emotionIntensity: const Value('strong'),
+          sourceMessageIds: Value(jsonEncode(positions)),
+        ),
+      );
+      await store.embedMissing(kSession, kChar);
+    }
+
+    test(
+      'GREEN: gist journal card carries the fallen-off fact (no restatement)',
+      () async {
+        await plantGistCard();
+        final result = await injection().buildJournalBlock(
+          characterId: kChar,
+          characterName: 'Nia',
+          userName: 'You',
+          queryText: cuedQuery(),
+          messageCount: messages.length,
+        );
+        expect(result.text, contains('spare key'));
+        expect(result.text, contains('flowerpot'));
+        // The live query's last words never restated the fact.
+        expect(cuedQuery(), contains(kLastUser));
+        expect(kLastUser.toLowerCase(), isNot(contains('flowerpot')));
+      },
+    );
+
+    test(
+      'quote-reach expands verbatim when the card is reached and old enough',
+      () async {
+        await plantGistCard();
+        final reaching = composeRagQuery(
+          emotion: kEmotion,
+          fixation: kFixation,
+          hotJournalLine: kJournalGist,
+          lastWords: 'You: remember where the spare key lives?',
+        );
+        expect(isReachingForQuote(reaching), isTrue);
+        final result = await injection().buildJournalBlock(
+          characterId: kChar,
+          characterName: 'Nia',
+          userName: 'You',
+          queryText: reaching,
+          messageCount: messages.length,
+        );
+        expect(result.text, contains(kJournalGist));
+        expect(result.text, contains('exact words'));
+        expect(result.text, contains(kFact));
+        expect(result.expandedPositions, {0, 1});
+      },
+    );
+
+    test('receipts still near the transcript do not expand (age gate)', () async {
+      await plantGistCard(positions: const [55]);
+      final result = await injection().buildJournalBlock(
+        characterId: kChar,
+        characterName: 'Nia',
+        userName: 'You',
+        queryText: 'You: remember where the spare key lives?',
+        messageCount: messages.length,
+      );
+      expect(result.expandedPositions, isEmpty);
+      expect(result.text, isNot(contains('exact words')));
+    });
+  });
+}

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -829,6 +829,54 @@ void main() {
       );
     });
 
+    test('HOLD hole: leftover kind, remap gap, two-word paraphrase', () {
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I still think about the spare key under the third flowerpot burned',
+              pos: 2,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'burned is a one-word second fact',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: the spare key lives hidden under the third flowerpot',
+              pos: 3,
+            ),
+          ],
+          [gist],
+        ),
+        isEmpty,
+        reason: 'lives hidden is same-beat paraphrase',
+      );
+      final gapKept = dropCoveredRagWindows(
+        [
+          _mem(
+            'Nia: the porch swing creaked tonight\n'
+            'Nia: I still think about the spare key under the third flowerpot\n'
+            'Nia: I sat on the front garden',
+            pos: 10,
+            end: 12,
+          ),
+        ],
+        [gist],
+      );
+      expect(gapKept, hasLength(2));
+      expect(
+        gapKept.any((m) => m.positionStart <= 11 && m.positionEnd >= 11),
+        isFalse,
+      );
+    });
+
     test('HOLD hole: prefix card does not cover a bigger fact', () {
       expect(
         dropCoveredRagWindows(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -736,6 +736,56 @@ void main() {
       },
     );
 
+    test('HOLD hole: prefix card does not cover a bigger fact', () {
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: the front garden swing creaked tonight', pos: 2)],
+          ['the front garden'],
+        ),
+        isNot(isEmpty),
+        reason: 'front garden must not drop front-garden-swing',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: the porch swing creaked by the flowerpot', pos: 3)],
+          ['The porch swing.'],
+        ),
+        isNot(isEmpty),
+        reason: 'porch swing must not eat a flowerpot window',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I loved the spare key under the third flowerpot',
+              pos: 1,
+            ),
+          ],
+          ['I loved it'],
+        ),
+        isNot(isEmpty),
+        reason: 'mood-only loved must not cover the flowerpot fact',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I worry about the spare key under the third flowerpot',
+              pos: 4,
+            ),
+          ],
+          ['I worry'],
+        ),
+        isNot(isEmpty),
+        reason: 'mood-only worry must not cover the flowerpot fact',
+      );
+      expect(
+        dropCoveredRagWindows([_mem(kFactLine, pos: 1)], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: whole tokens + distinctive — key is not keyboard', () {
       expect(
         dropCoveredRagWindows(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -497,6 +497,11 @@ void main() {
         expect(block, contains(kFact));
         expect(block, contains(kRagRememberedHeader.trim()));
         expect(block, isNot(contains('Exact earlier lines')));
+        expect(
+          block,
+          isNot(contains(kFactUser)),
+          reason: 'HOLD leftover: remembered line, not the You:/Nia: window',
+        );
       },
     );
 
@@ -548,6 +553,12 @@ void main() {
       expect(block, contains(kRagRememberedHeader.trim()));
       expect(block, contains(kFact));
       expect(block, isNot(contains('Exact earlier lines')));
+      expect(
+        block,
+        isNot(contains(kFactUser)),
+        reason:
+            'HOLD leftover: plain turn must not inject the transcript window',
+      );
     });
 
     test(
@@ -603,6 +614,14 @@ void main() {
       expect(kept, [
         swing,
       ], reason: 'one shared place/noun (porch) is not cover');
+    });
+
+    test('HOLD leftover: porch+tonight is setting+time, not cover', () {
+      final swing = _mem('Nia: the porch swing creaked tonight', pos: 2);
+      expect(coverContentTokens(kPorchFeeling).contains('tonight'), isFalse);
+      expect(dropCoveredRagWindows([swing], [kPorchFeeling]), [
+        swing,
+      ], reason: 'tonight is filler — porch+tonight must not eat the window');
     });
 
     test('HOLD r2: one shared spare token is not cover', () {
@@ -937,9 +956,10 @@ void main() {
         isTrue,
       );
       expect(
-        blocks.contains('lastWords: lastWordsFromMessages(_messages)'),
+        blocks.contains('lastWords: lastSpokenLineFromMessages(_messages)'),
         isTrue,
-        reason: 'HOLD r2: expand gates on lastWords, same as RAG',
+        reason:
+            'HOLD leftover: expand/quote-ask use last spoken line, not captions',
       );
       final gate = blocks.indexOf(
         'if (_storageService.memorySettings.journalEnabled',
@@ -958,6 +978,9 @@ void main() {
       ).readAsStringSync();
       expect(rag.contains('dropCoveredRagWindows('), isTrue);
       expect(rag.contains('t.journalCoverLines'), isTrue);
+      expect(rag.contains('lastSpokenLineFromMessages(_messages)'), isTrue);
+      expect(rag.contains('shouldRetrieveRag('), isTrue);
+      expect(rag.contains('Skipping memory retrieval — cue-less beat'), isTrue);
     });
 
     test(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -566,6 +566,10 @@ void main() {
         rememberedLineFromWindow('Nia: the swing creaked'),
         'the swing creaked',
       );
+      expect(
+        rememberedLineFromWindow('Nia:the swing creaked'),
+        'the swing creaked',
+      );
       final m = _mem('Nia: the swing creaked', pos: 2);
       final plain = buildRagMemoriesBlock(
         memories: [m],
@@ -670,6 +674,26 @@ void main() {
         [swing],
         reason: 'shared place-compound is not cover',
       );
+      final fact = _mem(kFactLine, pos: 1);
+      expect(
+        dropCoveredRagWindows([fact], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
+    test('HOLD hole: side porch and front lawn fold — not two more pairs', () {
+      for (final phrase in ['side porch', 'front lawn']) {
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem('Nia: the $phrase swing creaked tonight', pos: 2);
+        expect(
+          coverContentTokens(feeling),
+          contains(phrase.replaceAll(' ', '')),
+        );
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
       final fact = _mem(kFactLine, pos: 1);
       expect(
         dropCoveredRagWindows([fact], [kJournalGist]),

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -783,6 +783,52 @@ void main() {
       expect(kept.first.content, isNot(contains('flowerpot')));
     });
 
+    test('HOLD hole: extra fact on the line and stripped span', () {
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: the spare key under the third flowerpot and the swing creaked',
+              pos: 2,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'swing creaked is a second fact',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [_mem('Nia: the spare keyboard sits on the third flowerpot', pos: 3)],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'key is not keyboard',
+      );
+      final kept = dropCoveredRagWindows(
+        [
+          _mem(
+            'Nia: I still think about the spare key under the third flowerpot\n'
+            'Nia: the swing creaked',
+            pos: 2,
+            end: 3,
+          ),
+        ],
+        [gist],
+      );
+      expect(kept, hasLength(1));
+      expect(kept.first.positionStart, 3);
+      expect(kept.first.positionEnd, 3);
+      expect(
+        RetrievedMemory.excludingPositions(kept, {
+          2,
+        }, currentSessionId: kSession),
+        hasLength(1),
+      );
+    });
+
     test('HOLD hole: prefix card does not cover a bigger fact', () {
       expect(
         dropCoveredRagWindows(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -765,8 +765,8 @@ void main() {
           ],
           [gist],
         ),
-        isEmpty,
-        reason: 'same-beat gist + that creaked still drops',
+        isNot(isEmpty),
+        reason: 'suffix leftover is an extra fact — that creaked keeps',
       );
       final kept = dropCoveredRagWindows(
         [
@@ -874,6 +874,52 @@ void main() {
       expect(
         gapKept.any((m) => m.positionStart <= 11 && m.positionEnd >= 11),
         isFalse,
+      );
+    });
+
+    test('HOLD hole: interior restatement, suffix extra fact, no verb list', () {
+      const gist =
+          'I still think about the spare key under the third flowerpot';
+      for (final verb in ['tucked', 'buried', 'stays', 'rests']) {
+        expect(
+          dropCoveredRagWindows(
+            [
+              _mem(
+                'Nia: the spare key $verb under the third flowerpot',
+                pos: 8,
+              ),
+            ],
+            [gist],
+          ),
+          isEmpty,
+          reason: '"$verb under" is interior same-beat',
+        );
+      }
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: the spare key under the third flowerpot creaked',
+              pos: 9,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'the pot creaked is a suffix extra fact',
+      );
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: I still think about the spare key under the third flowerpot died',
+              pos: 11,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'short suffix leftover on a 3-D gist is an extra fact',
       );
     });
 

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -880,7 +880,7 @@ void main() {
     test('HOLD hole: interior restatement, suffix extra fact, no verb list', () {
       const gist =
           'I still think about the spare key under the third flowerpot';
-      for (final verb in ['tucked', 'buried', 'stays', 'rests']) {
+      for (final verb in ['hidden', 'tucked', 'buried', 'stays', 'rests', 'lives']) {
         expect(
           dropCoveredRagWindows(
             [
@@ -895,6 +895,84 @@ void main() {
           reason: '"$verb under" has leftover — leftover-empty only, so KEEP',
         );
       }
+      for (final verb in ['hidden', 'tucked', 'buried', 'stays', 'rests', 'lives']) {
+        expect(
+          dropCoveredRagWindows(
+            [
+              _mem(
+                'Nia: the spare key under the third flowerpot $verb',
+                pos: 13,
+              ),
+            ],
+            [gist],
+          ),
+          isNot(isEmpty),
+          reason: '$verb as suffix has leftover — leftover-empty only, so KEEP',
+        );
+      }
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: the spare key under the third flowerpot lives hidden',
+              pos: 14,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'suffix lives-hidden has leftover — leftover-empty only, so KEEP',
+      );
+      for (final verb in ['hidden', 'tucked', 'buried', 'stays', 'rests', 'lives']) {
+        expect(
+          dropCoveredRagWindows(
+            [
+              _mem(
+                'Nia: $verb the spare key under the third flowerpot',
+                pos: 16,
+              ),
+            ],
+            [gist],
+          ),
+          isNot(isEmpty),
+          reason: '$verb as prefix has leftover — leftover-empty only, so KEEP',
+        );
+      }
+      expect(
+        dropCoveredRagWindows(
+          [
+            _mem(
+              'Nia: lives hidden the spare key under the third flowerpot',
+              pos: 17,
+            ),
+          ],
+          [gist],
+        ),
+        isNot(isEmpty),
+        reason: 'prefix lives-hidden has leftover — leftover-empty only, so KEEP',
+      );
+      final twoLine = dropCoveredRagWindows(
+        [
+          _mem(
+            'You: the spare key lives under the third flowerpot\n'
+            'Nia: I still think about the spare key under the third flowerpot',
+            pos: 18,
+            end: 19,
+          ),
+        ],
+        [gist],
+      );
+      expect(twoLine, hasLength(1));
+      expect(
+        twoLine.first.content,
+        contains('lives'),
+        reason: 'two-line lives-under: the lives line KEEPS',
+      );
+      expect(
+        twoLine.first.content,
+        isNot(contains('I still think about')),
+        reason: 'two-line lives-under: the exact gist line still strips',
+      );
       expect(
         dropCoveredRagWindows(
           [

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -1141,8 +1141,8 @@ void main() {
           [_mem('I sat on porch; the swing creaked tonight', pos: 4)],
           ['Nia: the porch swing creaked tonight'],
         ),
-        isEmpty,
-        reason: 'same-beat I-sat-on-porch still drops',
+        isNot(isEmpty),
+        reason: 'short leftover sat is an extra fact, not same-beat',
       );
       final fact = _mem(kFactLine, pos: 1);
       expect(

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -578,7 +578,28 @@ void main() {
         );
         expect(block, contains(kRagQuoteHeader.trim()));
         expect(block, contains(kFact));
+        expect(block, contains(kFactUser));
+        expect(block, contains(kFactLine));
         expect(block, isNot(contains('Exact earlier lines')));
+      },
+    );
+
+    test(
+      'HOLD leftover: today/night/morning/evening are filler like tonight',
+      () {
+        for (final w in ['today', 'night', 'morning', 'evening']) {
+          expect(
+            coverContentTokens('I felt safe on the porch $w').contains(w),
+            isFalse,
+            reason: '$w must be cover filler',
+          );
+          final swing = _mem('Nia: the porch swing creaked $w', pos: 2);
+          expect(
+            dropCoveredRagWindows([swing], ['I felt safe on the porch $w']),
+            [swing],
+            reason: 'porch+$w is setting+time, not cover',
+          );
+        }
       },
     );
 

--- a/test/services/chat/remember_vs_regurgitate_test.dart
+++ b/test/services/chat/remember_vs_regurgitate_test.dart
@@ -702,6 +702,46 @@ void main() {
       );
     });
 
+    test('HOLD hole: covered/wraparound fold; the/a/an stay filler', () {
+      for (final phrase in [
+        'covered porch',
+        'wraparound porch',
+        'wraparound deck',
+      ]) {
+        final feeling = 'I felt safe on the $phrase tonight';
+        final swing = _mem('Nia: the $phrase swing creaked tonight', pos: 2);
+        expect(
+          coverContentTokens(feeling),
+          contains(phrase.replaceAll(' ', '')),
+        );
+        expect(
+          coverContentTokens(feeling),
+          isNot(contains(phrase.split(' ').first)),
+        );
+        expect(dropCoveredRagWindows([swing], [feeling]), [
+          swing,
+        ], reason: 'feeling × $phrase swing must not cover-drop');
+      }
+      for (final article in ['the', 'a', 'an']) {
+        expect(
+          coverContentTokens('$article porch'),
+          contains('porch'),
+          reason: '$article stays filler — porch must remain a token',
+        );
+        expect(
+          coverContentTokens('$article porch'),
+          isNot(contains('${article}porch')),
+          reason: 'do not fold "$article porch" into ${article}porch',
+        );
+      }
+      final fact = _mem(kFactLine, pos: 1);
+      expect(
+        dropCoveredRagWindows([fact], [kJournalGist]),
+        isEmpty,
+        reason: 'same-beat flowerpot gist still drops',
+      );
+    });
+
     test('HOLD hole: side porch and front lawn fold — not two more pairs', () {
       for (final phrase in ['side porch', 'front lawn']) {
         final feeling = 'I felt safe on the $phrase tonight';


### PR DESCRIPTION
## Summary
- Gist-first recall: journal gist injects first. RAG is one remembered line unless the user is reaching for a quote.
- Cued RAG query: current emotion + active fixation + top hot journal line + last words. Cue-less beats skip retrieve. Quote-reach still searches.
- Cover-drop is leftover-empty only (Joe lock 2026-08-22). Extra facts keep. Exact restatement drops. Paraphrases may come back twice.
- lastSpoken drives quote-ask and journal expand (captions do not). Function-word set stays 74. without-vs-under is a known lock collision.
- God file `chat_service.dart` stays 994.
- Untouched: rings, fixation-TTL, fifth engine, identity/hoursMatch/derivePresence/TimeStrip.

## Test plan
- [x] Local TestChampion + Bug Hunter PASS at `84f229d8` (product `4a72e63a`)
- [x] Leftover-empty pins (130 tests)
- [ ] CI green on this PR

Merge on green. Squash.