### PR TITLE
fix(realism): pair greeting alts and seeds, groups Read the Room

### DIFF
--- a/docs/characters.md
+++ b/docs/characters.md
@@ -118,13 +118,22 @@ A quick tour of the fields, whether you're writing your own or editing an import
 | **Scenario** | The situation your story starts in | Where are you two, and why? |
 | **First Message** | The character's opening line | Long and atmospheric is fine |
 | **Example Dialogue** | Sample exchanges showing how they talk | **The single biggest lever** for a consistent voice — a handful of good exchanges works wonders |
-| **Alternate Greetings** | Extra possible openings | Flip between them when starting a chat |
+| **Alternate Greetings** | Extra possible openings | Flip between them when starting a chat. Each alt can carry a Realism/Needs overlay (see below) |
 | **System Prompt** | Hidden instructions for the AI, specific to this character | Optional; overrides the global one |
 | **Post-History Instructions** | A reminder slipped in after the recent chat history | Good for "always stay in character" style nudges |
 | **Tags** | Labels for search and filtering | |
 | **Lorebook** | World-knowledge notes that activate when their keywords come up in chat | Great for places, factions, and backstory the character should "know" |
 | **Worlds** | Shared settings attached to this character | See [Lorebooks & Worlds](user-guide.md#lorebooks--worlds) |
 | **TTS Voice** | A voice just for this character | Assigned per member in the group chat creator; it travels with the card and overrides your default voice wherever that character speaks |
+
+### Greeting seeds (per-alt opening state)
+
+The first message (`first_mes`) always uses the card-level Realism/Needs seed. Alternate greetings may each carry a sparse overlay:
+
+- **Null / missing slot** — unauthored. The engine **Reads the Room** from that greeting's text.
+- **Non-null overlay, including empty `{}`** — authored. Skips Read the Room. `{}` means inherit the card (or group) defaults; present keys override them.
+- **Swipe 0** restores that member/group baseline (the card seed on 1:1, the group blob baseline on a custom group opener).
+- **Groups match 1:1.** Unauthored group/member alts Read the Room the same way; authored overlays (including `{}`) still skip. The editor must not write `{}` just because the seed toggle is on with no fields set — that stays null until a field is authored.
 
 ### Macros
 

--- a/docs/realism-engine.md
+++ b/docs/realism-engine.md
@@ -57,7 +57,7 @@ You can control the Realism Engine at three levels:
 
 ![The settings page, where the Realism Engine defaults live](screenshots/new_settings.png)
 
-> **Tip:** The engine even runs once on the character's greeting — before you've typed anything — so the opening mood matches the opening message. You'll see a brief *"Reading the room..."* overlay when that happens. Alternate greetings can skip that and use an authored seed instead (Dialogue tab, under each alt): mood, bond, trust, clock, needs, and starting wardrobe for *that* opening. Swiping back to the first message restores the card defaults.
+> **Tip:** Front Porch cards keep the card's authored opening seed on the first message (`first_mes`) — that greeting does **not** Read the Room. Unauthored alternate greetings (a missing / null overlay slot) still do, so the opening mood matches *that* greeting. An authored seed on an alt — including an empty `{}` inherit — skips Read the Room and uses the seed (mood, bond, trust, clock, needs, wardrobe). Swiping back to the first message restores the card defaults. Groups match 1:1.
 
 ---
 

--- a/lib/models/character_card.dart
+++ b/lib/models/character_card.dart
@@ -748,6 +748,27 @@ class CharacterCard {
     return greetings.where((g) => g.isNotEmpty).toList();
   }
 
+  /// Replace [alternateGreetings] with rewritten [alts].
+  ///
+  /// Seeds not authored with the rewrite compact against empty so leftover
+  /// source seeds cannot land on the new alts. A `copyWith` that only
+  /// replaces alts must pass the compacted seeds (or `[]`) — never silently
+  /// keep source [greetingSeeds]. Pass [authoredSeeds] when the rewrite
+  /// wrote seeds alongside the new alts.
+  void assignRewrittenAlternateGreetings(
+    List<String> alts, {
+    List<GreetingRealismSeed?>? authoredSeeds,
+  }) {
+    final paired = compactRewrittenGreetingAlts(alts, authoredSeeds);
+    alternateGreetings = paired.greetings;
+    final ext = frontPorchExtensions;
+    if (ext != null) {
+      ext.greetingSeeds = paired.seeds;
+    } else if (paired.seeds.isNotEmpty) {
+      frontPorchExtensions = FrontPorchExtensions(greetingSeeds: paired.seeds);
+    }
+  }
+
   Map<String, dynamic> toJson() {
     // Build extensions map: merge raw (third-party) keys with our namespace
     Map<String, dynamic>? extensions;

--- a/lib/models/character_card.dart
+++ b/lib/models/character_card.dart
@@ -745,7 +745,7 @@ class CharacterCard {
   List<String> get allGreetings {
     final greetings = <String>[firstMessage];
     greetings.addAll(alternateGreetings);
-    return greetings.where((g) => g.isNotEmpty).toList();
+    return greetings.where((g) => g.trim().isNotEmpty).toList();
   }
 
   /// Replace [alternateGreetings] with rewritten [alts].

--- a/lib/models/character_card.dart
+++ b/lib/models/character_card.dart
@@ -404,7 +404,10 @@ class FrontPorchExtensions {
     };
   }
 
-  factory FrontPorchExtensions.fromJson(Map<String, dynamic> json) {
+  factory FrontPorchExtensions.fromJson(
+    Map<String, dynamic> json, {
+    List<String> alternateGreetings = const [],
+  }) {
     // `is Map` + copy rather than `as Map<String, dynamic>?`: jsonDecode always
     // hands back Map<String, dynamic>, but a card map BUILT IN DART (a group
     // member seed, a test fixture, anything assembled from literals) can be
@@ -493,7 +496,11 @@ class FrontPorchExtensions {
       chatFontFamily: realism['chat_font_family'] as String?,
 
       currentTask: realism['current_task'] as String? ?? '',
-      greetingSeeds: parseGreetingSeeds(realism['greeting_seeds']),
+      greetingSeeds: () {
+        final parsed = parseGreetingSeeds(realism['greeting_seeds']);
+        if (alternateGreetings.isEmpty) return parsed;
+        return compactGreetingPairs(alternateGreetings, parsed).seeds;
+      }(),
       tier: realism['tier'] as String?,
       favoriteAvatarId: realism['favorite_avatar_id'] as String?,
     );

--- a/lib/models/greeting_realism_seed.dart
+++ b/lib/models/greeting_realism_seed.dart
@@ -400,10 +400,7 @@ List<GreetingRealismSeed?> compactGreetingSeeds(
 /// Drop empty greet rows *and* the seed slot at the same index so compact
 /// never prefix-aligns a furious seed onto the wrong alt (Add / blank / Add).
 ({List<String> greetings, List<GreetingRealismSeed?> seeds})
-compactGreetingPairs(
-  List<String> greetings,
-  List<GreetingRealismSeed?> seeds,
-) {
+compactGreetingPairs(List<String> greetings, List<GreetingRealismSeed?> seeds) {
   final aligned = alignGreetingSeeds(seeds, greetings.length);
   final outG = <String>[];
   final outS = <GreetingRealismSeed?>[];
@@ -414,6 +411,20 @@ compactGreetingPairs(
   }
   return (greetings: outG, seeds: compactGreetingSeeds(outS));
 }
+
+/// Compact rewritten alternate greetings.
+///
+/// When [authoredSeeds] is omitted/null, pair against empty so leftover
+/// source seeds (enhance `copyWith` of the original, chargen base leftovers)
+/// cannot land furious on Get out. When enhance/chargen actually authored
+/// seeds alongside the new alts (including `[]`), pass those so they are
+/// not wiped.
+({List<String> greetings, List<GreetingRealismSeed?> seeds})
+compactRewrittenGreetingAlts(
+  List<String> alts, [
+  List<GreetingRealismSeed?>? authoredSeeds,
+]) =>
+    compactGreetingPairs(greetingSlotsFromRaw(alts), authoredSeeds ?? const []);
 
 /// Overlay for `allGreetings[index]`. Index 0 (first_mes) is always null —
 /// that opening uses the card-level fields. Alts are `seeds[index - 1]`.
@@ -437,7 +448,6 @@ bool greetingHasAuthoredSeed({
   if (greetingIndex <= 0) return hasCardExtensions;
   return greetingOverlayAt(seeds, greetingIndex) != null;
 }
-
 
 GreetingOpeningSnapshot resolveGreetingOpening(
   GreetingOpeningBase base,

--- a/lib/models/greeting_realism_seed.dart
+++ b/lib/models/greeting_realism_seed.dart
@@ -426,6 +426,9 @@ compactRewrittenGreetingAlts(
 ]) =>
     compactGreetingPairs(greetingSlotsFromRaw(alts), authoredSeeds ?? const []);
 
+/// True when first_mes is missing or whitespace-only. Same pairing as empty.
+bool greetingFirstMesEmpty(String firstMes) => firstMes.trim().isEmpty;
+
 /// Overlay for `allGreetings[index]`.
 ///
 /// When [firstMesEmpty] is false (non-empty first_mes), index 0 is always
@@ -458,12 +461,7 @@ bool greetingHasAuthoredSeed({
   bool firstMesEmpty = false,
 }) {
   if (firstMesEmpty) {
-    return greetingOverlayAt(
-          seeds,
-          greetingIndex,
-          firstMesEmpty: true,
-        ) !=
-        null;
+    return greetingOverlayAt(seeds, greetingIndex, firstMesEmpty: true) != null;
   }
   if (greetingIndex <= 0) return hasCardExtensions;
   return greetingOverlayAt(seeds, greetingIndex) != null;

--- a/lib/models/greeting_realism_seed.dart
+++ b/lib/models/greeting_realism_seed.dart
@@ -426,25 +426,45 @@ compactRewrittenGreetingAlts(
 ]) =>
     compactGreetingPairs(greetingSlotsFromRaw(alts), authoredSeeds ?? const []);
 
-/// Overlay for `allGreetings[index]`. Index 0 (first_mes) is always null —
-/// that opening uses the card-level fields. Alts are `seeds[index - 1]`.
+/// Overlay for `allGreetings[index]`.
+///
+/// When [firstMesEmpty] is false (non-empty first_mes), index 0 is always
+/// null — that opening uses the card-level fields — and alts are
+/// `seeds[index - 1]`. When first_mes is empty, `allGreetings` drops it so
+/// displayed 0 is alt[0] and must read `seeds[0]`.
 GreetingRealismSeed? greetingOverlayAt(
   List<GreetingRealismSeed?> seeds,
-  int greetingIndex,
-) {
+  int greetingIndex, {
+  bool firstMesEmpty = false,
+}) {
+  if (firstMesEmpty) {
+    if (greetingIndex < 0 || greetingIndex >= seeds.length) return null;
+    return seeds[greetingIndex];
+  }
   if (greetingIndex <= 0) return null;
   final i = greetingIndex - 1;
   if (i < 0 || i >= seeds.length) return null;
   return seeds[i];
 }
 
-/// Authored seed? First greet: any Front Porch extensions object counts.
-/// Alts: a non-null slot (including `{}`) counts; missing means read-the-room.
+/// Authored seed? First greet with a present first_mes: any Front Porch
+/// extensions object counts. When first_mes is empty, displayed 0 is an alt
+/// and uses the seed slot. Alts: a non-null slot (including `{}`) counts;
+/// missing means read-the-room.
 bool greetingHasAuthoredSeed({
   required bool hasCardExtensions,
   required List<GreetingRealismSeed?> seeds,
   required int greetingIndex,
+  bool firstMesEmpty = false,
 }) {
+  if (firstMesEmpty) {
+    return greetingOverlayAt(
+          seeds,
+          greetingIndex,
+          firstMesEmpty: true,
+        ) !=
+        null;
+  }
   if (greetingIndex <= 0) return hasCardExtensions;
   return greetingOverlayAt(seeds, greetingIndex) != null;
 }

--- a/lib/models/greeting_realism_seed.dart
+++ b/lib/models/greeting_realism_seed.dart
@@ -354,6 +354,21 @@ List<GreetingRealismSeed?> parseGreetingSeeds(Object? raw) {
   ];
 }
 
+/// Keep JSON-null / non-string greet slots as empty placeholders so zip
+/// stays index-aligned; [compactGreetingPairs] then drops empty+seed together.
+/// Numbers coerce to string (V2 hostile cards); null stays `''`.
+List<String> greetingSlotsFromRaw(Object? raw) {
+  if (raw is! List) return const [];
+  return [
+    for (final e in raw)
+      e == null
+          ? ''
+          : e is String
+          ? e
+          : e.toString(),
+  ];
+}
+
 /// Pad / trim so [seeds] is the same length as the alternate-greetings list.
 List<GreetingRealismSeed?> alignGreetingSeeds(
   List<GreetingRealismSeed?> seeds,

--- a/lib/models/greeting_realism_seed.dart
+++ b/lib/models/greeting_realism_seed.dart
@@ -382,6 +382,24 @@ List<GreetingRealismSeed?> compactGreetingSeeds(
   return seeds.sublist(0, end);
 }
 
+/// Drop empty greet rows *and* the seed slot at the same index so compact
+/// never prefix-aligns a furious seed onto the wrong alt (Add / blank / Add).
+({List<String> greetings, List<GreetingRealismSeed?> seeds})
+compactGreetingPairs(
+  List<String> greetings,
+  List<GreetingRealismSeed?> seeds,
+) {
+  final aligned = alignGreetingSeeds(seeds, greetings.length);
+  final outG = <String>[];
+  final outS = <GreetingRealismSeed?>[];
+  for (var i = 0; i < greetings.length; i++) {
+    if (greetings[i].trim().isEmpty) continue;
+    outG.add(greetings[i]);
+    outS.add(aligned[i]);
+  }
+  return (greetings: outG, seeds: compactGreetingSeeds(outS));
+}
+
 /// Overlay for `allGreetings[index]`. Index 0 (first_mes) is always null —
 /// that opening uses the card-level fields. Alts are `seeds[index - 1]`.
 GreetingRealismSeed? greetingOverlayAt(
@@ -404,6 +422,7 @@ bool greetingHasAuthoredSeed({
   if (greetingIndex <= 0) return hasCardExtensions;
   return greetingOverlayAt(seeds, greetingIndex) != null;
 }
+
 
 GreetingOpeningSnapshot resolveGreetingOpening(
   GreetingOpeningBase base,

--- a/lib/models/group_chat.dart
+++ b/lib/models/group_chat.dart
@@ -137,8 +137,8 @@ class GroupChat {
   /// Custom group opener + alts. Empty when the group uses a member greet.
   List<String> get allGreetings {
     final greetings = <String>[
-      if (firstMessage.isNotEmpty) firstMessage,
-      ...alternateGreetings.where((g) => g.isNotEmpty),
+      if (firstMessage.trim().isNotEmpty) firstMessage,
+      ...alternateGreetings.where((g) => g.trim().isNotEmpty),
     ];
     return greetings;
   }

--- a/lib/models/group_chat.dart
+++ b/lib/models/group_chat.dart
@@ -183,6 +183,17 @@ class GroupChat {
         ? rawWorldIds.map((e) => e.toString()).toList()
         : <String>[];
 
+    final pairedOpening = compactGreetingPairs(
+      [
+        for (final e
+            in (json['alternate_greetings'] is List
+                ? json['alternate_greetings'] as List
+                : const []))
+          if (e is String) e,
+      ],
+      parseGreetingSeeds(json['greeting_seeds']),
+    );
+
     return GroupChat(
       id: json['id'] ?? '',
       stableId:
@@ -200,14 +211,8 @@ class GroupChat {
       autoAdvance: json['auto_advance'] ?? false,
       directorMode: json['director_mode'] ?? false,
       firstMessage: json['first_message'] ?? '',
-      alternateGreetings: [
-        for (final e
-            in (json['alternate_greetings'] is List
-                ? json['alternate_greetings'] as List
-                : const []))
-          if (e is String && e.trim().isNotEmpty) e,
-      ],
-      greetingSeeds: parseGreetingSeeds(json['greeting_seeds']),
+      alternateGreetings: pairedOpening.greetings,
+      greetingSeeds: pairedOpening.seeds,
       scenario: json['scenario'] ?? '',
       systemPrompt: json['system_prompt'] ?? '',
       defaultMemberRealismState: json['default_member_realism_state'] ?? '{}',

--- a/lib/models/group_chat.dart
+++ b/lib/models/group_chat.dart
@@ -157,6 +157,9 @@ class GroupChat {
       'director_mode': directorMode,
       'first_message': firstMessage,
       'alternate_greetings': alternateGreetings,
+      'greeting_seeds': [
+        for (final s in compactGreetingSeeds(greetingSeeds)) s?.toJson(),
+      ],
       'scenario': scenario,
       'system_prompt': systemPrompt,
       'default_member_realism_state': defaultMemberRealismState,
@@ -184,13 +187,7 @@ class GroupChat {
         : <String>[];
 
     final pairedOpening = compactGreetingPairs(
-      [
-        for (final e
-            in (json['alternate_greetings'] is List
-                ? json['alternate_greetings'] as List
-                : const []))
-          if (e is String) e,
-      ],
+      greetingSlotsFromRaw(json['alternate_greetings']),
       parseGreetingSeeds(json['greeting_seeds']),
     );
 

--- a/lib/models/group_member.dart
+++ b/lib/models/group_member.dart
@@ -221,7 +221,10 @@ class GroupMember {
     FrontPorchExtensions? fpExt;
     if (frontPorchExtensions != null) {
       try {
-        fpExt = FrontPorchExtensions.fromJson(frontPorchExtensions!);
+        fpExt = FrontPorchExtensions.fromJson(
+          frontPorchExtensions!,
+          alternateGreetings: alternateGreetings,
+        );
       } catch (_) {}
     }
 

--- a/lib/services/character_gen_service.dart
+++ b/lib/services/character_gen_service.dart
@@ -497,7 +497,9 @@ class CharacterGenService {
           alts.add(_cleanGreeting(altOutput));
         }
       }
-      card.alternateGreetings = alts;
+      // Seeds are not authored with these rewritten alts — compact against
+      // empty so leftover source furious cannot land on Get out.
+      card.assignRewrittenAlternateGreetings(alts);
     }
     if (_aborted || _generationEpoch != currentEpoch) return null;
 

--- a/lib/services/chargen/character_gen_enhance.dart
+++ b/lib/services/chargen/character_gen_enhance.dart
@@ -215,7 +215,9 @@ extension GenEnhance on CharacterGenService {
             alts.add(_cleanGreeting(altOutput));
           }
         }
-        card.alternateGreetings = alts;
+        // Seeds are not authored with these rewritten alts — compact against
+        // empty so leftover source furious cannot land on Get out.
+        card.assignRewrittenAlternateGreetings(alts);
       }
     }
     if (_aborted || _generationEpoch != currentEpoch) return null;
@@ -225,10 +227,22 @@ extension GenEnhance on CharacterGenService {
     if (selection.porchLife) {
       onStatus?.call('Proposing wardrobe and ambitions...');
       onProgress?.call('');
-      card.frontPorchExtensions =
-          (source.frontPorchExtensions ??
-                  FrontPorchExtensions(needsSimEnabled: true))
-              .copyWith();
+      // copyWith() keeps source greetingSeeds. When greetings were rewritten
+      // without authored seeds, pass compact-empty so leftover furious cannot
+      // land on Get out. Authored enhance seeds (if any) pair as written.
+      final sourceExt =
+          source.frontPorchExtensions ??
+          FrontPorchExtensions(needsSimEnabled: true);
+      if (selection.greetings) {
+        card.frontPorchExtensions = sourceExt.copyWith(
+          greetingSeeds: compactRewrittenGreetingAlts(
+            card.alternateGreetings,
+            card.frontPorchExtensions?.greetingSeeds,
+          ).seeds,
+        );
+      } else {
+        card.frontPorchExtensions = sourceExt.copyWith();
+      }
       await _seedPorchLifeIdentity(
         card: card,
         name: name,

--- a/lib/services/chat/chat_service_chat_entry.dart
+++ b/lib/services/chat/chat_service_chat_entry.dart
@@ -201,6 +201,7 @@ extension ChatServiceChatEntry on ChatService {
         '[ChatService] 🟡 setActiveCharacter: clearing messages '
         '(had ${_messages.length}) for ${character?.name}, loading session...',
       );
+      await _invalidateGreetingEval();
       _messages.clear();
       _greetingIndex = 0;
       _history.reset();

--- a/lib/services/chat/chat_service_chat_entry.dart
+++ b/lib/services/chat/chat_service_chat_entry.dart
@@ -412,16 +412,26 @@ extension ChatServiceChatEntry on ChatService {
                 _storageService.realismSettings.objectivesEnabled;
           }
 
-          if (_activeCharacter!.firstMessage.isNotEmpty) {
+          final opening = _activeCharacter!.allGreetings;
+          if (opening.isNotEmpty) {
             _messages.add(
               ChatMessage(
-                text: _buildFirstMessage(_activeCharacter!),
+                text: _buildFirstMessage(
+                  _activeCharacter!,
+                  greetingText: opening.first,
+                ),
                 sender: _activeCharacter!.name,
                 isUser: false,
               ),
             );
             // Scan first message for lore (thin delegation to extracted scanner).
             _lorebookScanner.scanLatest();
+            if (_activeCharacter!.firstMessage.trim().isEmpty) {
+              await _applyGreetingOpeningSeed(
+                card: _activeCharacter!,
+                index: 0,
+              );
+            }
           }
           // Note: for the direct 0-session setActiveCharacter path (fresh import via home grid <=1 session),
           // _greetingEvalPending is left false here. The post-greeting baseline eval is scheduled only

--- a/lib/services/chat/chat_service_chat_entry.dart
+++ b/lib/services/chat/chat_service_chat_entry.dart
@@ -131,6 +131,10 @@ extension ChatServiceChatEntry on ChatService {
       // About to throw the live list away. Write it first so a slow-path
       // reload cannot hydrate a row that is still missing this turn.
       await flushPendingSaves();
+      // Detach before swapping the owner. Anything that saves between
+      // `_activeCharacter =` and `_loadLastSession` used to rebind this
+      // row to the incoming card (history/E2E then loadSession-ed Nightowl).
+      _currentSessionId = null;
 
       // Reset AFK idle state when switching to a different chat
       _cancelIdleTimer();

--- a/lib/services/chat/chat_service_chat_package.dart
+++ b/lib/services/chat/chat_service_chat_package.dart
@@ -165,6 +165,11 @@ extension ChatServiceChatPackage on ChatService {
       await _saveChat();
     }
 
+    // Stale unauthored RtR from a prior opening must not paint this import.
+    // _isTurnBusy does not wait _isProcessingGreeting, so a delayed eval
+    // is still in flight when the package transcript replaces first_mes.
+    await _invalidateGreetingEval();
+
     final decoded = await Isolate.run(() => decodeFpchatBytes(bytes));
     final root = decoded.chatJson;
     final kind = detectFpchatPayload(root);

--- a/lib/services/chat/chat_service_defaults.dart
+++ b/lib/services/chat/chat_service_defaults.dart
@@ -156,8 +156,8 @@ const String kSpatialStancePreTurn = 'spatial_stance_pre_turn';
 bool _realismEvalCancelled = false;
 
 /// Bumped by [_invalidateGreetingEval] (selectGreeting, startNewChat,
-/// setActiveCharacter, setActiveGroup) so a late unawaited
-/// [_runPostGreetingEval] cannot stomp a later opening.
+/// setActiveCharacter, setActiveGroup, loadSession, _loadLastSession) so a
+/// late unawaited [_runPostGreetingEval] cannot stomp a later opening.
 int _greetingEvalGen = 0;
 
 const Object _kGreetingEvalToken = #_greetingEvalToken;

--- a/lib/services/chat/chat_service_defaults.dart
+++ b/lib/services/chat/chat_service_defaults.dart
@@ -159,6 +159,14 @@ bool _realismEvalCancelled = false;
 /// [_runPostGreetingEval] cannot stomp a later swipe.
 int _greetingEvalGen = 0;
 
+/// Token captured when a greeting eval starts. Live apply checks this
+/// against [_greetingEvalGen]; a later swipe leaves the in-flight eval
+/// stale even if [_realismEvalCancelled] is the only other signal.
+int? _greetingEvalToken;
+
+bool _isStaleGreetingEval() =>
+    _greetingEvalToken != null && _greetingEvalToken != _greetingEvalGen;
+
 /// Set when [_runPostGreetingEval] passes its guards (not skipped solely
 /// because [_activeCharacter] is null). Tests prove group unauthored alts
 /// reach the eval path.

--- a/lib/services/chat/chat_service_defaults.dart
+++ b/lib/services/chat/chat_service_defaults.dart
@@ -156,7 +156,8 @@ const String kSpatialStancePreTurn = 'spatial_stance_pre_turn';
 bool _realismEvalCancelled = false;
 
 /// Bumped by [_invalidateGreetingEval] (selectGreeting, startNewChat,
-/// setActiveCharacter, setActiveGroup, loadSession, _loadLastSession) so a
+/// setActiveCharacter, setActiveGroup, loadSession, _loadLastSession,
+/// importChatPackage, forkFromMessage) so a
 /// late unawaited [_runPostGreetingEval] cannot stomp a later opening.
 int _greetingEvalGen = 0;
 

--- a/lib/services/chat/chat_service_defaults.dart
+++ b/lib/services/chat/chat_service_defaults.dart
@@ -155,6 +155,16 @@ const String kSpatialStancePreTurn = 'spatial_stance_pre_turn';
 // to the UI.
 bool _realismEvalCancelled = false;
 
+/// Bumped at the start of [selectGreeting] so a late unawaited
+/// [_runPostGreetingEval] cannot stomp a later swipe.
+int _greetingEvalGen = 0;
+
+/// Set when [_runPostGreetingEval] passes its guards (not skipped solely
+/// because [_activeCharacter] is null). Tests prove group unauthored alts
+/// reach the eval path.
+@visibleForTesting
+bool testPostGreetingEvalEntered = false;
+
 // GBNF grammar support for Realism Engine evals (incl. Needs simulation) removed
 // in the 0.9.8 clean port. All JSON outputs now rely on regex extraction + stop
 // sequences inside _fireLLMEval (no _buildKoboldGrammar, no _kGbnf* consts).

--- a/lib/services/chat/chat_service_defaults.dart
+++ b/lib/services/chat/chat_service_defaults.dart
@@ -159,11 +159,6 @@ bool _realismEvalCancelled = false;
 /// [_runPostGreetingEval] cannot stomp a later swipe.
 int _greetingEvalGen = 0;
 
-/// Latest-started greeting eval id. Apply gates do not use this slot —
-/// they read the per-eval Zone token so a later eval cannot un-stale an
-/// earlier apply by overwriting or finally-nulling a single global.
-int? _greetingEvalToken;
-
 const Object _kGreetingEvalToken = #_greetingEvalToken;
 const Object _kGreetingEvalIndex = #_greetingEvalIndex;
 

--- a/lib/services/chat/chat_service_defaults.dart
+++ b/lib/services/chat/chat_service_defaults.dart
@@ -155,16 +155,17 @@ const String kSpatialStancePreTurn = 'spatial_stance_pre_turn';
 // to the UI.
 bool _realismEvalCancelled = false;
 
-/// Bumped at the start of [selectGreeting] so a late unawaited
-/// [_runPostGreetingEval] cannot stomp a later swipe.
+/// Bumped by [_invalidateGreetingEval] (selectGreeting, startNewChat,
+/// setActiveCharacter, setActiveGroup) so a late unawaited
+/// [_runPostGreetingEval] cannot stomp a later opening.
 int _greetingEvalGen = 0;
 
 const Object _kGreetingEvalToken = #_greetingEvalToken;
 const Object _kGreetingEvalIndex = #_greetingEvalIndex;
 
 /// Stale when THIS eval's captured token is no longer the live gen.
-/// [selectGreeting] always bumps [_greetingEvalGen], so a later swipe
-/// stale-gates the earlier apply without a shared nullable slot.
+/// [_invalidateGreetingEval] always bumps [_greetingEvalGen], so a later
+/// opening stale-gates the earlier apply without a shared nullable slot.
 /// A missing Zone token is not a greeting apply (normal turn evals).
 bool _isStaleGreetingEval() {
   final token = Zone.current[_kGreetingEvalToken] as int?;

--- a/lib/services/chat/chat_service_defaults.dart
+++ b/lib/services/chat/chat_service_defaults.dart
@@ -159,13 +159,23 @@ bool _realismEvalCancelled = false;
 /// [_runPostGreetingEval] cannot stomp a later swipe.
 int _greetingEvalGen = 0;
 
-/// Token captured when a greeting eval starts. Live apply checks this
-/// against [_greetingEvalGen]; a later swipe leaves the in-flight eval
-/// stale even if [_realismEvalCancelled] is the only other signal.
+/// Latest-started greeting eval id. Apply gates do not use this slot —
+/// they read the per-eval Zone token so a later eval cannot un-stale an
+/// earlier apply by overwriting or finally-nulling a single global.
 int? _greetingEvalToken;
 
-bool _isStaleGreetingEval() =>
-    _greetingEvalToken != null && _greetingEvalToken != _greetingEvalGen;
+const Object _kGreetingEvalToken = #_greetingEvalToken;
+const Object _kGreetingEvalIndex = #_greetingEvalIndex;
+
+/// Stale when THIS eval's captured token is no longer the live gen.
+/// [selectGreeting] always bumps [_greetingEvalGen], so a later swipe
+/// stale-gates the earlier apply without a shared nullable slot.
+/// A missing Zone token is not a greeting apply (normal turn evals).
+bool _isStaleGreetingEval() {
+  final token = Zone.current[_kGreetingEvalToken] as int?;
+  if (token == null) return false;
+  return token != _greetingEvalGen;
+}
 
 /// Set when [_runPostGreetingEval] passes its guards (not skipped solely
 /// because [_activeCharacter] is null). Tests prove group unauthored alts

--- a/lib/services/chat/chat_service_greeting.dart
+++ b/lib/services/chat/chat_service_greeting.dart
@@ -164,71 +164,80 @@ extension ChatServiceGreeting on ChatService {
     }
     _greetingEvalPending = false; // consume the pending flag
     debugPrint('[Realism] Running post-greeting baseline eval...');
-    _isProcessingGreeting = true;
-    notifyListeners();
-    try {
-      await Future.wait([
-        // delegates to _llmEvalEngine (step 9 thins; full bodies excised)
-        _evaluateEmotionalStateCall(),
-        Future.delayed(
-          _kEvalDispatchStagger,
-          () => _evaluateRelationshipCall(),
-        ),
-        // WHERE SHE IS WHEN THE STORY OPENS. The greeting IS the opening scene
-        // — "she is rocking in the armchair when you walk in" — so the baseline
-        // is the earliest moment the opening position can be read, and reading
-        // it here means the sidebar shows a position before the user has typed
-        // anything. It is the SAME seed the pre-turn path uses, and the seed
-        // is single-flight (see _seedOpeningPosture): this one is a head
-        // start, and a pre-turn dance that arrives while it is still in flight
-        // waits for this answer instead of asking again.
-        Future.delayed(_kEvalDispatchStagger * 2, () => _seedOpeningPosture()),
-      ]);
+    await runZoned(() async {
+      _isProcessingGreeting = true;
+      notifyListeners();
+      try {
+        await Future.wait([
+          // delegates to _llmEvalEngine (step 9 thins; full bodies excised)
+          _evaluateEmotionalStateCall(),
+          Future.delayed(
+            _kEvalDispatchStagger,
+            () => _evaluateRelationshipCall(),
+          ),
+          // WHERE SHE IS WHEN THE STORY OPENS. The greeting IS the opening scene
+          // — "she is rocking in the armchair when you walk in" — so the baseline
+          // is the earliest moment the opening position can be read, and reading
+          // it here means the sidebar shows a position before the user has typed
+          // anything. It is the SAME seed the pre-turn path uses, and the seed
+          // is single-flight (see _seedOpeningPosture): this one is a head
+          // start, and a pre-turn dance that arrives while it is still in flight
+          // waits for this answer instead of asking again.
+          Future.delayed(_kEvalDispatchStagger * 2, () => _seedOpeningPosture()),
+        ]);
 
-      if (_realismEvalCancelled ||
-          token != _greetingEvalGen ||
-          indexStamp != _greetingIndex) {
-        debugPrint('[Realism] Post-greeting eval cancelled or stale');
-        _realismEvalCancelled = false;
-        return;
-      }
-
-      // Check for cancellation after each eval
-      if (_realismEvalCancelled ||
-          token != _greetingEvalGen ||
-          indexStamp != _greetingIndex) {
-        debugPrint('[Realism] Post-greeting eval cancelled or stale');
-        _realismEvalCancelled =
-            false; // Reset the flag so future messages can proceed
-        return;
-      }
-
-      // Store initial emotion in metadata on the greeting message itself
-      if (_messages.isNotEmpty) {
-        _messages.first.activeMetadata ??= {};
-        if (_characterEmotion.isNotEmpty) {
-          _messages.first.activeMetadata!['emotion_label'] = _characterEmotion;
-          _messages.first.activeMetadata!['realism_state'] =
-              _captureRealismState();
+        if (_realismEvalCancelled ||
+            token != _greetingEvalGen ||
+            indexStamp != _greetingIndex) {
+          debugPrint('[Realism] Post-greeting eval cancelled or stale');
+          _realismEvalCancelled = false;
+          return;
         }
+
+        // Check for cancellation after each eval
+        if (_realismEvalCancelled ||
+            token != _greetingEvalGen ||
+            indexStamp != _greetingIndex) {
+          debugPrint('[Realism] Post-greeting eval cancelled or stale');
+          _realismEvalCancelled =
+              false; // Reset the flag so future messages can proceed
+          return;
+        }
+
+        // Store initial emotion in metadata on the greeting message itself
+        if (_messages.isNotEmpty) {
+          _messages.first.activeMetadata ??= {};
+          if (_characterEmotion.isNotEmpty) {
+            _messages.first.activeMetadata!['emotion_label'] = _characterEmotion;
+            _messages.first.activeMetadata!['realism_state'] =
+                _captureRealismState();
+          }
+        }
+        // Unauthored group RtR writes live scalars only unless we put them
+        // back in the member slot before persist / first-speaker load.
+        if (_activeGroup != null) {
+          _writeBackGreetingEvalToGroupSlots(evalChar);
+        }
+        await _saveChat();
+        notifyListeners();
+        debugPrint(
+          '[Realism] Post-greeting baseline: emotion=$_characterEmotion, bond=${_relationshipService.affectionScore}, trust=${_relationshipService.trustLevel}',
+        );
+      } catch (e) {
+        debugPrint('[Realism] Post-greeting eval failed: $e');
+      } finally {
+        // Do not finally-null [_greetingEvalToken]. A later eval overwrites
+        // the slot; nulling the later one used to make an older apply look live.
+        if (_activeGroup != null) {
+          _activeCharacter = previousActive;
+        }
+        _isProcessingGreeting = false;
+        notifyListeners();
       }
-      await _saveChat();
-      notifyListeners();
-      debugPrint(
-        '[Realism] Post-greeting baseline: emotion=$_characterEmotion, bond=${_relationshipService.affectionScore}, trust=${_relationshipService.trustLevel}',
-      );
-    } catch (e) {
-      debugPrint('[Realism] Post-greeting eval failed: $e');
-    } finally {
-      if (_greetingEvalToken == token) {
-        _greetingEvalToken = null;
-      }
-      if (_activeGroup != null) {
-        _activeCharacter = previousActive;
-      }
-      _isProcessingGreeting = false;
-      notifyListeners();
-    }
+    }, zoneValues: {
+      _kGreetingEvalToken: token,
+      _kGreetingEvalIndex: indexStamp,
+    });
   }
 
   /// Retroactive baseline eval — fires when Realism is enabled mid-conversation

--- a/lib/services/chat/chat_service_greeting.dart
+++ b/lib/services/chat/chat_service_greeting.dart
@@ -315,7 +315,7 @@ extension ChatServiceGreeting on ChatService {
 
   /// Bump [_greetingEvalGen] and cancel any in-flight unauthored RtR so a
   /// late apply cannot paint the previous opening onto a newly loaded
-  /// first_mes (New Chat, switch character/group, swipe).
+  /// first_mes (New Chat, switch character/group, swipe, load, import, fork).
   Future<void> _invalidateGreetingEval() async {
     _greetingEvalGen++;
     await cancelRealismEval();

--- a/lib/services/chat/chat_service_greeting.dart
+++ b/lib/services/chat/chat_service_greeting.dart
@@ -147,7 +147,20 @@ extension ChatServiceGreeting on ChatService {
   /// Evaluates emotion + relationship baseline from the greeting message only.
   /// Runs once per new session, silently in the background.
   Future<void> _runPostGreetingEval() async {
-    if (!_realismEnabled || _activeCharacter == null) return;
+    if (!_realismEnabled) return;
+    final evalChar = _activeCharacter ??
+        _greetingOwnerCard() ??
+        (_groupCharacters.isNotEmpty ? _groupCharacters.first : null);
+    // Groups have a null _activeCharacter; still Read the Room when an
+    // unauthored opener reached this path.
+    if (evalChar == null && _activeGroup == null) return;
+    testPostGreetingEvalEntered = true;
+    final token = _greetingEvalGen;
+    final indexStamp = _greetingIndex;
+    final previousActive = _activeCharacter;
+    if (_activeCharacter == null && evalChar != null) {
+      _activeCharacter = evalChar;
+    }
     _greetingEvalPending = false; // consume the pending flag
     debugPrint('[Realism] Running post-greeting baseline eval...');
     _isProcessingGreeting = true;
@@ -171,15 +184,19 @@ extension ChatServiceGreeting on ChatService {
         Future.delayed(_kEvalDispatchStagger * 2, () => _seedOpeningPosture()),
       ]);
 
-      if (_realismEvalCancelled) {
-        debugPrint('[Realism] Post-greeting eval cancelled');
+      if (_realismEvalCancelled ||
+          token != _greetingEvalGen ||
+          indexStamp != _greetingIndex) {
+        debugPrint('[Realism] Post-greeting eval cancelled or stale');
         _realismEvalCancelled = false;
         return;
       }
 
       // Check for cancellation after each eval
-      if (_realismEvalCancelled) {
-        debugPrint('[Realism] Post-greeting eval cancelled');
+      if (_realismEvalCancelled ||
+          token != _greetingEvalGen ||
+          indexStamp != _greetingIndex) {
+        debugPrint('[Realism] Post-greeting eval cancelled or stale');
         _realismEvalCancelled =
             false; // Reset the flag so future messages can proceed
         return;
@@ -202,6 +219,9 @@ extension ChatServiceGreeting on ChatService {
     } catch (e) {
       debugPrint('[Realism] Post-greeting eval failed: $e');
     } finally {
+      if (_activeGroup != null) {
+        _activeCharacter = previousActive;
+      }
       _isProcessingGreeting = false;
       notifyListeners();
     }

--- a/lib/services/chat/chat_service_greeting.dart
+++ b/lib/services/chat/chat_service_greeting.dart
@@ -156,6 +156,7 @@ extension ChatServiceGreeting on ChatService {
     if (evalChar == null && _activeGroup == null) return;
     testPostGreetingEvalEntered = true;
     final token = _greetingEvalGen;
+    _greetingEvalToken = token;
     final indexStamp = _greetingIndex;
     final previousActive = _activeCharacter;
     if (_activeCharacter == null && evalChar != null) {
@@ -219,6 +220,9 @@ extension ChatServiceGreeting on ChatService {
     } catch (e) {
       debugPrint('[Realism] Post-greeting eval failed: $e');
     } finally {
+      if (_greetingEvalToken == token) {
+        _greetingEvalToken = null;
+      }
       if (_activeGroup != null) {
         _activeCharacter = previousActive;
       }

--- a/lib/services/chat/chat_service_greeting.dart
+++ b/lib/services/chat/chat_service_greeting.dart
@@ -313,6 +313,15 @@ extension ChatServiceGreeting on ChatService {
     }
   }
 
+  /// Bump [_greetingEvalGen] and cancel any in-flight unauthored RtR so a
+  /// late apply cannot paint the previous opening onto a newly loaded
+  /// first_mes (New Chat, switch character/group, swipe).
+  Future<void> _invalidateGreetingEval() async {
+    _greetingEvalGen++;
+    await cancelRealismEval();
+    _realismEvalCancelled = false;
+  }
+
   /// Cycle the first message through alternate greetings.
   /// Commit-once: the same [selectGreeting] path the picker uses.
   Future<void> cycleGreeting(int direction) async {
@@ -335,5 +344,14 @@ extension ChatServiceGreeting on ChatService {
       ),
       section: 'firstMessage',
     );
+  }
+
+  /// First displayed member greet — same as 1:1 [CharacterCard.allGreetings].
+  /// Empty when the member has no usable opening (whitespace first_mes and
+  /// no alts). Group open must not gate on [CharacterCard.firstMessage] alone.
+  String _memberOpeningGreetingText(CharacterCard member) {
+    final opening = member.allGreetings;
+    if (opening.isEmpty) return '';
+    return _buildFirstMessage(member, greetingText: opening.first);
   }
 }

--- a/lib/services/chat/chat_service_greeting.dart
+++ b/lib/services/chat/chat_service_greeting.dart
@@ -156,7 +156,6 @@ extension ChatServiceGreeting on ChatService {
     if (evalChar == null && _activeGroup == null) return;
     testPostGreetingEvalEntered = true;
     final token = _greetingEvalGen;
-    _greetingEvalToken = token;
     final indexStamp = _greetingIndex;
     final previousActive = _activeCharacter;
     if (_activeCharacter == null && evalChar != null) {
@@ -226,8 +225,7 @@ extension ChatServiceGreeting on ChatService {
       } catch (e) {
         debugPrint('[Realism] Post-greeting eval failed: $e');
       } finally {
-        // Do not finally-null [_greetingEvalToken]. A later eval overwrites
-        // the slot; nulling the later one used to make an older apply look live.
+        // Per-eval Zone token only. Do not reintroduce a global slot.
         if (_activeGroup != null) {
           _activeCharacter = previousActive;
         }

--- a/lib/services/chat/chat_service_greeting_seed.dart
+++ b/lib/services/chat/chat_service_greeting_seed.dart
@@ -315,19 +315,37 @@ extension ChatServiceGreetingSeed on ChatService {
     }
   }
 
-  /// After reload restores the greeting cursor, re-apply that index's overlay
-  /// so swipe-committed emotion/bonds/needs/clock survive hydrate.
+  /// After reload restores the greeting cursor, re-apply that index's
+  /// *authored* overlay so swipe-committed fury / {} survive hydrate.
+  /// Unauthored (null) overlays must not write inherit over a persisted
+  /// RtR — load already hydrated curious; re-eval is the named leftover.
   Future<void> _reapplyOpeningOverlayIfNeeded() async {
     if (!_isOpeningGreetingChat) return;
     final groupCustom =
         _activeGroup != null &&
         !greetingFirstMesEmpty(_activeGroup!.firstMessage);
     if (groupCustom) {
+      final authored = greetingOverlayAt(
+            _activeGroup!.greetingSeeds,
+            _greetingIndex,
+            firstMesEmpty: false,
+          ) !=
+          null;
+      if (!authored) return;
       await _applyGroupCustomGreetingSeed(_greetingIndex, scheduleEval: false);
       return;
     }
     final owner = _greetingOwnerCard() ?? _activeCharacter;
     if (owner != null) {
+      final ext = owner.frontPorchExtensions;
+      final firstMesEmpty = greetingFirstMesEmpty(owner.firstMessage);
+      final authored = greetingHasAuthoredSeed(
+        hasCardExtensions: ext != null,
+        seeds: ext?.greetingSeeds ?? const [],
+        greetingIndex: _greetingIndex,
+        firstMesEmpty: firstMesEmpty,
+      );
+      if (!authored) return;
       await _applyGreetingOpeningSeed(
         card: owner,
         index: _greetingIndex,

--- a/lib/services/chat/chat_service_greeting_seed.dart
+++ b/lib/services/chat/chat_service_greeting_seed.dart
@@ -194,9 +194,8 @@ extension ChatServiceGreetingSeed on ChatService {
   }
 
   /// Custom group first_message + alts: one overlay fans out to the story
-  /// clock and every member's opening slot. Groups never had reading-the-room
-  /// on the opener (`_activeCharacter` is null), so unauthored alts inherit
-  /// the group baselines instead of calling the 1:1 eval path.
+  /// clock and every member's opening slot. Unauthored alts Read the Room
+  /// like 1:1; an authored overlay (including `{}`) skips.
   Future<void> _applyGroupCustomGreetingSeed(int index) async {
     final group = _activeGroup;
     if (group == null) return;
@@ -259,8 +258,28 @@ extension ChatServiceGreetingSeed on ChatService {
       _messages.first.activeMetadata!['realism_state'] = _captureRealismState();
     }
 
-    if (_realismActiveThisMode) {
+    final authored = greetingOverlayAt(group.greetingSeeds, index) != null;
+    if (shouldReadRoomForGreeting(index, hasAuthoredSeed: authored) &&
+        _realismActiveThisMode) {
+      _runPostGreetingEval();
+    } else if (_realismActiveThisMode) {
       unawaited(_seedOpeningPosture().catchError((Object _) {}));
+    }
+  }
+
+  /// After reload restores the greeting cursor, re-apply that index's overlay
+  /// so swipe-committed emotion/bonds/needs/clock survive hydrate.
+  Future<void> _reapplyOpeningOverlayIfNeeded() async {
+    if (!_isOpeningGreetingChat) return;
+    final groupCustom =
+        _activeGroup != null && _activeGroup!.firstMessage.isNotEmpty;
+    if (groupCustom) {
+      await _applyGroupCustomGreetingSeed(_greetingIndex);
+      return;
+    }
+    final owner = _greetingOwnerCard() ?? _activeCharacter;
+    if (owner != null) {
+      await _applyGreetingOpeningSeed(card: owner, index: _greetingIndex);
     }
   }
 }

--- a/lib/services/chat/chat_service_greeting_seed.dart
+++ b/lib/services/chat/chat_service_greeting_seed.dart
@@ -87,6 +87,7 @@ extension ChatServiceGreetingSeed on ChatService {
   Future<void> _applyGreetingOpeningSeed({
     required CharacterCard card,
     required int index,
+    bool scheduleEval = true,
   }) async {
     final ext = card.frontPorchExtensions;
     final firstMesEmpty = greetingFirstMesEmpty(card.firstMessage);
@@ -166,6 +167,7 @@ extension ChatServiceGreetingSeed on ChatService {
       _messages.first.activeMetadata!['realism_state'] = _captureRealismState();
     }
 
+    if (!scheduleEval) return;
     final authored = greetingHasAuthoredSeed(
       hasCardExtensions: ext != null,
       seeds: ext?.greetingSeeds ?? const [],
@@ -206,7 +208,10 @@ extension ChatServiceGreetingSeed on ChatService {
   /// Custom group first_message + alts: one overlay fans out to the story
   /// clock and every member's opening slot. Unauthored alts Read the Room
   /// like 1:1; an authored overlay (including `{}`) skips.
-  Future<void> _applyGroupCustomGreetingSeed(int index) async {
+  Future<void> _applyGroupCustomGreetingSeed(
+    int index, {
+    bool scheduleEval = true,
+  }) async {
     final group = _activeGroup;
     if (group == null) return;
     final firstMesEmpty = greetingFirstMesEmpty(group.firstMessage);
@@ -273,6 +278,7 @@ extension ChatServiceGreetingSeed on ChatService {
       _messages.first.activeMetadata!['realism_state'] = _captureRealismState();
     }
 
+    if (!scheduleEval) return;
     final authored =
         greetingOverlayAt(
           group.greetingSeeds,
@@ -317,12 +323,16 @@ extension ChatServiceGreetingSeed on ChatService {
         _activeGroup != null &&
         !greetingFirstMesEmpty(_activeGroup!.firstMessage);
     if (groupCustom) {
-      await _applyGroupCustomGreetingSeed(_greetingIndex);
+      await _applyGroupCustomGreetingSeed(_greetingIndex, scheduleEval: false);
       return;
     }
     final owner = _greetingOwnerCard() ?? _activeCharacter;
     if (owner != null) {
-      await _applyGreetingOpeningSeed(card: owner, index: _greetingIndex);
+      await _applyGreetingOpeningSeed(
+        card: owner,
+        index: _greetingIndex,
+        scheduleEval: false,
+      );
     }
   }
 }

--- a/lib/services/chat/chat_service_greeting_seed.dart
+++ b/lib/services/chat/chat_service_greeting_seed.dart
@@ -89,7 +89,7 @@ extension ChatServiceGreetingSeed on ChatService {
     required int index,
   }) async {
     final ext = card.frontPorchExtensions;
-    final firstMesEmpty = card.firstMessage.trim().isEmpty;
+    final firstMesEmpty = greetingFirstMesEmpty(card.firstMessage);
     final overlay = greetingOverlayAt(
       ext?.greetingSeeds ?? const [],
       index,
@@ -209,7 +209,7 @@ extension ChatServiceGreetingSeed on ChatService {
   Future<void> _applyGroupCustomGreetingSeed(int index) async {
     final group = _activeGroup;
     if (group == null) return;
-    final firstMesEmpty = group.firstMessage.trim().isEmpty;
+    final firstMesEmpty = greetingFirstMesEmpty(group.firstMessage);
     final overlay = greetingOverlayAt(
       group.greetingSeeds,
       index,
@@ -273,7 +273,8 @@ extension ChatServiceGreetingSeed on ChatService {
       _messages.first.activeMetadata!['realism_state'] = _captureRealismState();
     }
 
-    final authored = greetingOverlayAt(
+    final authored =
+        greetingOverlayAt(
           group.greetingSeeds,
           index,
           firstMesEmpty: firstMesEmpty,
@@ -291,11 +292,13 @@ extension ChatServiceGreetingSeed on ChatService {
     }
   }
 
-  /// After unauthored group RtR, put live scalars back in the member slot
+  /// After unauthored group RtR, persist live scalars into the current cast
   /// so persist + first-speaker [_loadGroupRealismIntoScalars] keep the eval.
+  /// Member-greet and custom opener share this fan-out. Whitespace first_mes
+  /// is not a custom opener and must not write only [evalChar].
   void _writeBackGreetingEvalToGroupSlots(CharacterCard? evalChar) {
     if (_activeGroup == null) return;
-    if (_activeGroup!.firstMessage.isNotEmpty) {
+    if (_groupCharacters.isNotEmpty) {
       for (final c in _groupCharacters) {
         _saveScalarsIntoGroupRealism(_getCharacterIdFromCard(c));
       }
@@ -311,7 +314,8 @@ extension ChatServiceGreetingSeed on ChatService {
   Future<void> _reapplyOpeningOverlayIfNeeded() async {
     if (!_isOpeningGreetingChat) return;
     final groupCustom =
-        _activeGroup != null && _activeGroup!.firstMessage.isNotEmpty;
+        _activeGroup != null &&
+        !greetingFirstMesEmpty(_activeGroup!.firstMessage);
     if (groupCustom) {
       await _applyGroupCustomGreetingSeed(_greetingIndex);
       return;

--- a/lib/services/chat/chat_service_greeting_seed.dart
+++ b/lib/services/chat/chat_service_greeting_seed.dart
@@ -89,7 +89,12 @@ extension ChatServiceGreetingSeed on ChatService {
     required int index,
   }) async {
     final ext = card.frontPorchExtensions;
-    final overlay = greetingOverlayAt(ext?.greetingSeeds ?? const [], index);
+    final firstMesEmpty = card.firstMessage.trim().isEmpty;
+    final overlay = greetingOverlayAt(
+      ext?.greetingSeeds ?? const [],
+      index,
+      firstMesEmpty: firstMesEmpty,
+    );
     final memberId = _activeGroup == null
         ? null
         : _getCharacterIdFromCard(card);
@@ -165,8 +170,13 @@ extension ChatServiceGreetingSeed on ChatService {
       hasCardExtensions: ext != null,
       seeds: ext?.greetingSeeds ?? const [],
       greetingIndex: index,
+      firstMesEmpty: firstMesEmpty,
     );
-    if (shouldReadRoomForGreeting(index, hasAuthoredSeed: authored) &&
+    if (shouldReadRoomForGreeting(
+          index,
+          hasAuthoredSeed: authored,
+          firstMesEmpty: firstMesEmpty,
+        ) &&
         _realismActiveThisMode) {
       _runPostGreetingEval();
     } else if (_realismActiveThisMode) {
@@ -199,7 +209,12 @@ extension ChatServiceGreetingSeed on ChatService {
   Future<void> _applyGroupCustomGreetingSeed(int index) async {
     final group = _activeGroup;
     if (group == null) return;
-    final overlay = greetingOverlayAt(group.greetingSeeds, index);
+    final firstMesEmpty = group.firstMessage.trim().isEmpty;
+    final overlay = greetingOverlayAt(
+      group.greetingSeeds,
+      index,
+      firstMesEmpty: firstMesEmpty,
+    );
     final time = parseGroupTimeSeed(
       group.defaultMemberRealismState,
       group.baselineRealismState,
@@ -258,12 +273,36 @@ extension ChatServiceGreetingSeed on ChatService {
       _messages.first.activeMetadata!['realism_state'] = _captureRealismState();
     }
 
-    final authored = greetingOverlayAt(group.greetingSeeds, index) != null;
-    if (shouldReadRoomForGreeting(index, hasAuthoredSeed: authored) &&
+    final authored = greetingOverlayAt(
+          group.greetingSeeds,
+          index,
+          firstMesEmpty: firstMesEmpty,
+        ) !=
+        null;
+    if (shouldReadRoomForGreeting(
+          index,
+          hasAuthoredSeed: authored,
+          firstMesEmpty: firstMesEmpty,
+        ) &&
         _realismActiveThisMode) {
       _runPostGreetingEval();
     } else if (_realismActiveThisMode) {
       unawaited(_seedOpeningPosture().catchError((Object _) {}));
+    }
+  }
+
+  /// After unauthored group RtR, put live scalars back in the member slot
+  /// so persist + first-speaker [_loadGroupRealismIntoScalars] keep the eval.
+  void _writeBackGreetingEvalToGroupSlots(CharacterCard? evalChar) {
+    if (_activeGroup == null) return;
+    if (_activeGroup!.firstMessage.isNotEmpty) {
+      for (final c in _groupCharacters) {
+        _saveScalarsIntoGroupRealism(_getCharacterIdFromCard(c));
+      }
+      return;
+    }
+    if (evalChar != null) {
+      _saveScalarsIntoGroupRealism(_getCharacterIdFromCard(evalChar));
     }
   }
 

--- a/lib/services/chat/chat_service_group_entry.dart
+++ b/lib/services/chat/chat_service_group_entry.dart
@@ -310,7 +310,7 @@ extension ChatServiceGroupEntry on ChatService {
         String greetingSender;
         String? greetingCharId;
 
-        if (group.firstMessage.isNotEmpty) {
+        if (!greetingFirstMesEmpty(group.firstMessage)) {
           // Use custom group first message — attribute to "Narrator" or group name
           greetingText = _macroResolver.resolve(
             group.firstMessage,
@@ -322,7 +322,7 @@ extension ChatServiceGroupEntry on ChatService {
         } else {
           // Fall back to first character's greeting
           final first = _groupCharacters.first;
-          greetingText = first.firstMessage.isNotEmpty
+          greetingText = !greetingFirstMesEmpty(first.firstMessage)
               ? _buildFirstMessage(first)
               : '';
           greetingSender = first.name;

--- a/lib/services/chat/chat_service_group_entry.dart
+++ b/lib/services/chat/chat_service_group_entry.dart
@@ -117,6 +117,7 @@ extension ChatServiceGroupEntry on ChatService {
         '[ChatService] 🟡 setActiveGroup: clearing messages '
         '(had ${_messages.length}) for group ${group.name}',
       );
+      await _invalidateGreetingEval();
       _messages.clear();
       _greetingIndex = 0;
       _history.reset();
@@ -320,11 +321,9 @@ extension ChatServiceGroupEntry on ChatService {
           greetingSender = group.name;
           greetingCharId = null;
         } else {
-          // Fall back to first character's greeting
+          // Fall back to first member's allGreetings (same pairing as 1:1).
           final first = _groupCharacters.first;
-          greetingText = !greetingFirstMesEmpty(first.firstMessage)
-              ? _buildFirstMessage(first)
-              : '';
+          greetingText = _memberOpeningGreetingText(first);
           greetingSender = first.name;
           greetingCharId = _getCharacterIdFromCard(first);
         }
@@ -340,6 +339,13 @@ extension ChatServiceGroupEntry on ChatService {
           );
           // Thin delegation to scanner (group greeting scan).
           _lorebookScanner.scanLatest();
+          if (greetingFirstMesEmpty(group.firstMessage) &&
+              greetingFirstMesEmpty(_groupCharacters.first.firstMessage)) {
+            await _applyGreetingOpeningSeed(
+              card: _groupCharacters.first,
+              index: 0,
+            );
+          }
         }
         _currentSessionId = DateTime.now().millisecondsSinceEpoch.toString();
         // Seed chat worlds from the group's template (Living Worlds).

--- a/lib/services/chat/chat_service_group_realism_helpers.dart
+++ b/lib/services/chat/chat_service_group_realism_helpers.dart
@@ -93,6 +93,20 @@ extension ChatServiceGroupRealismHelpers on ChatService {
   String debugBuildPositionInjection() =>
       _behavioralInjection.buildPositionInjection();
 
+  /// Test-only: first-speaker [_loadGroupRealismIntoScalars] without a turn.
+  @visibleForTesting
+  void debugReloadFirstGroupSpeakerScalars() {
+    if (_groupCharacters.isEmpty) return;
+    _loadGroupRealismIntoScalars(
+      _getCharacterIdFromCard(_groupCharacters.first),
+    );
+  }
+
+  /// Test-only: emotion sitting in a group member slot (not live scalars).
+  @visibleForTesting
+  String debugGroupSlotEmotion(String charId) =>
+      _groupRealism[charId]?.emotion ?? '';
+
   // ── Per-character realism state access (group mode, typed — U7) ─────────
   /// The one write door to a member's typed state. Outside group mode it
   /// hands back a THROWAWAY object, so writes vanish — observationally the

--- a/lib/services/chat/chat_service_session_load.dart
+++ b/lib/services/chat/chat_service_session_load.dart
@@ -123,34 +123,46 @@ extension ChatServiceSessionLoad on ChatService {
     final lastSession = sessions.reduce(
       (a, b) => a.updatedAt.isAfter(b.updatedAt) ? a : b,
     );
+    // Activate THIS row's persona before _currentSessionId is set and
+    // before overlay-reapply / any hydrate save. setActiveCharacter then
+    // loadSession used to stamp the still-live previous chat (Nightowl)
+    // onto the first row; loadSession then skipped flush (same id) and
+    // "restored" Nightowl. Default is unmoved — setActivePersona is
+    // chat-scoped. Keep loadSession's restore too.
+    await _activateSessionPersona(lastSession);
     // Stale unauthored RtR from a prior opening must not paint this hydrate.
     await _invalidateGreetingEval();
-    _currentSessionId = lastSession.id;
-    // Sanitizer + first paint need gen settings and the tail ONLY.
-    // Growth/worlds/scalars used to run first and kept the spinner up
-    // for the same beat as loading 11k messages.
-    _sessionGenSettings = ChatGenerationSettings.fromJsonString(
-      lastSession.generationSettings,
-    );
+    _preserveSessionPersonaOf[this] = true;
     try {
-      await _openSessionMessages(lastSession.id);
-    } catch (e) {
-      print('Error loading chat session: $e');
-    }
-    await _reloadChatWorldIds();
-    await _hydrateSessionScalars(lastSession);
+      _currentSessionId = lastSession.id;
+      // Sanitizer + first paint need gen settings and the tail ONLY.
+      // Growth/worlds/scalars used to run first and kept the spinner up
+      // for the same beat as loading 11k messages.
+      _sessionGenSettings = ChatGenerationSettings.fromJsonString(
+        lastSession.generationSettings,
+      );
+      try {
+        await _openSessionMessages(lastSession.id);
+      } catch (e) {
+        print('Error loading chat session: $e');
+      }
+      await _reloadChatWorldIds();
+      await _hydrateSessionScalars(lastSession);
 
-    // v30: Load live per-character group realism/needs (bond/trust/emotion/fixation/arousal/relationships/needs)
-    // from the session column (or fall back to group defaults). Must happen for group entry paths
-    // so that _groupRealism is populated before any eval, prompt injection, or UI read.
-    if (_activeGroup != null) {
-      _loadGroupRealismStateFromSession(lastSession);
-    } else {
-      // 1:1 session: the group realism column ('{}' for plain sessions) may
-      // carry persisted Scene Guest (Lite NPC) dbIds. Tolerant of legacy/empty.
-      _loadSceneGuestsFromSession(lastSession);
+      // v30: Load live per-character group realism/needs (bond/trust/emotion/fixation/arousal/relationships/needs)
+      // from the session column (or fall back to group defaults). Must happen for group entry paths
+      // so that _groupRealism is populated before any eval, prompt injection, or UI read.
+      if (_activeGroup != null) {
+        _loadGroupRealismStateFromSession(lastSession);
+      } else {
+        // 1:1 session: the group realism column ('{}' for plain sessions) may
+        // carry persisted Scene Guest (Lite NPC) dbIds. Tolerant of legacy/empty.
+        _loadSceneGuestsFromSession(lastSession);
+      }
+      await _reapplyOpeningOverlayIfNeeded();
+    } finally {
+      _preserveSessionPersonaOf[this] = false;
     }
-    await _reapplyOpeningOverlayIfNeeded();
 
     // Load messages
     // Zero secondary objective flags in loaded path of _loadLast (before callers do _loadActiveObjectives / _loadObjectivesForCurrentSpeaker); incomplete zeroing hygiene.
@@ -347,9 +359,9 @@ extension ChatServiceSessionLoad on ChatService {
   /// Callers keep what genuinely differs: group-realism/scene-guest branch,
   /// objectives zeroing (library path only), per-chat gen settings placement
   /// (must precede message hydration for the retroactive sanitizer), and the
-  /// persona activation (picker path only, by design — restoring a specific
-  /// chat restores its persona; a library tap must not silently switch the
-  /// user's persona).
+  /// persona activation. Both load paths restore the row's persona so a
+  /// hydrate save cannot stamp the previous chat's live persona onto the
+  /// row. The default is still unmoved (setActivePersona is chat-scoped).
   Future<void> _hydrateSessionScalars(Session s) async {
     _authorNote = s.authorNote;
     _authorNoteStrength = s.authorNoteDepth;
@@ -508,6 +520,17 @@ extension ChatServiceSessionLoad on ChatService {
     await _refreshGrowthCache();
   }
 
+  /// Chat-scoped only — never moves [UserPersonaService.defaultPersonaId].
+  Future<void> _activateSessionPersona(Session session) async {
+    final sessionPersonaId = session.userPersonaId;
+    final knownPersona =
+        sessionPersonaId != null &&
+        _userPersonaService.personas.any((p) => p.id == sessionPersonaId);
+    await _userPersonaService.setActivePersona(
+      knownPersona ? sessionPersonaId : _userPersonaService.defaultPersonaId,
+    );
+  }
+
   Future<void> loadSession(String sessionId) async {
     if (_activeCharacter == null && _activeGroup == null) return;
 
@@ -523,10 +546,12 @@ extension ChatServiceSessionLoad on ChatService {
     // "restore" whatever was already live. That broke "reopening a chat
     // restores its persona" everywhere (Rawhide E2E red since 6192ddc:
     // persona_default_test + persona_folder_test; the picker flow after
-    // setActiveCharacter hits it because _loadLastSession sets
-    // _currentSessionId without activating the persona — by design). The
-    // same-session transcript needs no flush here: turns persist when
-    // taken, and _waitForTurnToSettle has already drained the save chain.
+    // setActiveCharacter then loadSession used to hit it because
+    // _loadLastSession set _currentSessionId before activating the
+    // persona). The same-session transcript needs no flush here: turns
+    // persist when taken, and _waitForTurnToSettle has already drained
+    // the save chain. _loadLastSession now activates the row persona
+    // before any hydrate save; the restore below still runs.
     if (_currentSessionId != sessionId) {
       await flushPendingSaves();
       _clearTodayPointer();
@@ -549,13 +574,7 @@ extension ChatServiceSessionLoad on ChatService {
     // binding (pre-v25 rows) or one naming a persona that has since been
     // DELETED falls back to the default — not to whatever the previously-open
     // chat left behind, which is what the old silent no-op did.
-    final sessionPersonaId = session.userPersonaId;
-    final knownPersona =
-        sessionPersonaId != null &&
-        _userPersonaService.personas.any((p) => p.id == sessionPersonaId);
-    await _userPersonaService.setActivePersona(
-      knownPersona ? sessionPersonaId : _userPersonaService.defaultPersonaId,
-    );
+    await _activateSessionPersona(session);
 
     // Load per-chat generation settings override for this session (must
     // happen before the message loop so retroactive sanitization can

--- a/lib/services/chat/chat_service_session_load.dart
+++ b/lib/services/chat/chat_service_session_load.dart
@@ -123,6 +123,8 @@ extension ChatServiceSessionLoad on ChatService {
     final lastSession = sessions.reduce(
       (a, b) => a.updatedAt.isAfter(b.updatedAt) ? a : b,
     );
+    // Stale unauthored RtR from a prior opening must not paint this hydrate.
+    await _invalidateGreetingEval();
     _currentSessionId = lastSession.id;
     // Sanitizer + first paint need gen settings and the tail ONLY.
     // Growth/worlds/scalars used to run first and kept the spinner up
@@ -536,6 +538,12 @@ extension ChatServiceSessionLoad on ChatService {
 
     final session = await _db.getSessionById(sessionId);
     if (session == null) return;
+
+    // Any path that loads a new opening first_mes must bump _greetingEvalGen
+    // before hydrate / _reapplyOpeningOverlayIfNeeded. _waitForTurnToSettle
+    // only drains _isTurnBusy, so a delayed unauthored RtR would still have
+    // a live Zone token and paint fury onto the loaded opening.
+    await _invalidateGreetingEval();
 
     // Speak as the persona this chat was chatted under. A session with no
     // binding (pre-v25 rows) or one naming a persona that has since been

--- a/lib/services/chat/chat_service_session_load.dart
+++ b/lib/services/chat/chat_service_session_load.dart
@@ -148,6 +148,7 @@ extension ChatServiceSessionLoad on ChatService {
       // carry persisted Scene Guest (Lite NPC) dbIds. Tolerant of legacy/empty.
       _loadSceneGuestsFromSession(lastSession);
     }
+    await _reapplyOpeningOverlayIfNeeded();
 
     // Load messages
     // Zero secondary objective flags in loaded path of _loadLast (before callers do _loadActiveObjectives / _loadObjectivesForCurrentSpeaker); incomplete zeroing hygiene.
@@ -606,6 +607,7 @@ extension ChatServiceSessionLoad on ChatService {
         _loadGroupRealismStateFromSession(session);
       }
       await _hydrateSessionScalars(session);
+      await _reapplyOpeningOverlayIfNeeded();
 
       // Quests are keyed (character, CHAT) — so switching chats has to reload
       // them, exactly like the scalars above. Nothing did: `_activeObjectives`

--- a/lib/services/chat/chat_service_session_manage.dart
+++ b/lib/services/chat/chat_service_session_manage.dart
@@ -143,7 +143,9 @@ extension ChatServiceSessionManage on ChatService {
     _messages.addAll(forkedMessages);
     _history.reset();
     _currentSessionId = DateTime.now().millisecondsSinceEpoch.toString();
-    _computeAbsenceGap(const []); // fresh session — no real-world gap (Living Time §2)
+    _computeAbsenceGap(
+      const [],
+    ); // fresh session — no real-world gap (Living Time §2)
     // Forks stay in the parent chat's place: carry the world attachments so
     // the climate/setting follow (mid-chat climate spans reset to the world
     // default, like every other new session).
@@ -393,7 +395,9 @@ extension ChatServiceSessionManage on ChatService {
 
     // Create new session ID for the new chat
     _currentSessionId = DateTime.now().millisecondsSinceEpoch.toString();
-    _computeAbsenceGap(const []); // fresh session — no real-world gap (Living Time §2)
+    _computeAbsenceGap(
+      const [],
+    ); // fresh session — no real-world gap (Living Time §2)
 
     // Clear memory sources to prevent old memories from being retrieved
     // Cross-character memory can still be re-selected by user after new chat starts
@@ -684,7 +688,7 @@ extension ChatServiceSessionManage on ChatService {
       String greetingSender;
       String? greetingCharId;
 
-      if (_activeGroup!.firstMessage.isNotEmpty) {
+      if (!greetingFirstMesEmpty(_activeGroup!.firstMessage)) {
         greetingText = _macroResolver.resolve(
           _activeGroup!.firstMessage,
           MacroContext(userName: _userPersonaService.persona.name),
@@ -694,7 +698,7 @@ extension ChatServiceSessionManage on ChatService {
         greetingCharId = null;
       } else {
         final first = _groupCharacters.first;
-        greetingText = first.firstMessage.isNotEmpty
+        greetingText = !greetingFirstMesEmpty(first.firstMessage)
             ? _buildFirstMessage(first)
             : '';
         greetingSender = first.name;
@@ -729,16 +733,15 @@ extension ChatServiceSessionManage on ChatService {
         );
         _lorebookScanner.scanLatest();
         if (_activeCharacter!.firstMessage.trim().isEmpty) {
-          await _applyGreetingOpeningSeed(
-            card: _activeCharacter!,
-            index: 0,
-          );
+          await _applyGreetingOpeningSeed(card: _activeCharacter!, index: 0);
         }
       }
     }
 
     _currentSessionId = DateTime.now().millisecondsSinceEpoch.toString();
-    _computeAbsenceGap(const []); // fresh session — no real-world gap (Living Time §2)
+    _computeAbsenceGap(
+      const [],
+    ); // fresh session — no real-world gap (Living Time §2)
     // Seed chat worlds for the fresh session (group template or the
     // character's attached worlds — Living Worlds).
     await _seedChatWorldsForNewSession();
@@ -751,8 +754,9 @@ extension ChatServiceSessionManage on ChatService {
         groupId: _activeGroup?.id,
       );
       if (lastThemeJson != null) {
-        _sessionThemeOverrides =
-            ChatThemeOverrides.fromJsonString(lastThemeJson);
+        _sessionThemeOverrides = ChatThemeOverrides.fromJsonString(
+          lastThemeJson,
+        );
       }
     } catch (_) {
       _sessionThemeOverrides = ChatThemeOverrides();

--- a/lib/services/chat/chat_service_session_manage.dart
+++ b/lib/services/chat/chat_service_session_manage.dart
@@ -715,15 +715,25 @@ extension ChatServiceSessionManage on ChatService {
       _groupManager?.resetTurnState();
     } else if (_activeCharacter != null) {
       // 1:1 mode
-      if (_activeCharacter!.firstMessage.isNotEmpty) {
+      final opening = _activeCharacter!.allGreetings;
+      if (opening.isNotEmpty) {
         _messages.add(
           ChatMessage(
-            text: _buildFirstMessage(_activeCharacter!),
+            text: _buildFirstMessage(
+              _activeCharacter!,
+              greetingText: opening.first,
+            ),
             sender: _activeCharacter!.name,
             isUser: false,
           ),
         );
         _lorebookScanner.scanLatest();
+        if (_activeCharacter!.firstMessage.trim().isEmpty) {
+          await _applyGreetingOpeningSeed(
+            card: _activeCharacter!,
+            index: 0,
+          );
+        }
       }
     }
 

--- a/lib/services/chat/chat_service_session_manage.dart
+++ b/lib/services/chat/chat_service_session_manage.dart
@@ -111,6 +111,11 @@ extension ChatServiceSessionManage on ChatService {
     final tip = await _resolveHydratedIndex(messageIndex);
     if (tip == null) return;
 
+    // Near-miss: fork copies the live greeting so eval would land on the
+    // same alt, but this is a new session opening. Bump gen before the
+    // forked transcript is live.
+    await _invalidateGreetingEval();
+
     final oldSessionId = _currentSessionId!;
     _clearTodayPointer();
     final forkedMessages = _messages

--- a/lib/services/chat/chat_service_session_manage.dart
+++ b/lib/services/chat/chat_service_session_manage.dart
@@ -340,6 +340,7 @@ extension ChatServiceSessionManage on ChatService {
     );
     // The open session's last exchange may still be memory-only.
     await flushPendingSaves();
+    await _invalidateGreetingEval();
     _messages.clear();
     _history.reset();
     _greetingIndex = 0;
@@ -683,7 +684,7 @@ extension ChatServiceSessionManage on ChatService {
     if (_activeGroup != null && _groupCharacters.isNotEmpty) {
       // Group mode: respect explicit group.firstMessage (custom group greeting set
       // by creator or Group Card) when present. Only fall back to the first
-      // participating character's firstMessage when the group has no custom opening.
+      // participating character's allGreetings when the group has no custom opening.
       String greetingText;
       String greetingSender;
       String? greetingCharId;
@@ -698,9 +699,7 @@ extension ChatServiceSessionManage on ChatService {
         greetingCharId = null;
       } else {
         final first = _groupCharacters.first;
-        greetingText = !greetingFirstMesEmpty(first.firstMessage)
-            ? _buildFirstMessage(first)
-            : '';
+        greetingText = _memberOpeningGreetingText(first);
         greetingSender = first.name;
         greetingCharId = _getCharacterIdFromCard(first);
       }
@@ -715,6 +714,13 @@ extension ChatServiceSessionManage on ChatService {
           ),
         );
         _lorebookScanner.scanLatest();
+        if (greetingFirstMesEmpty(_activeGroup!.firstMessage) &&
+            greetingFirstMesEmpty(_groupCharacters.first.firstMessage)) {
+          await _applyGreetingOpeningSeed(
+            card: _groupCharacters.first,
+            index: 0,
+          );
+        }
       }
       _groupManager?.resetTurnState();
     } else if (_activeCharacter != null) {

--- a/lib/services/chat/chat_service_session_manage.dart
+++ b/lib/services/chat/chat_service_session_manage.dart
@@ -252,6 +252,10 @@ extension ChatServiceSessionManage on ChatService {
     if (_activeCharacter == null && _activeGroup == null) return;
     _clearTodayPointer();
 
+    // Persist the departing chat as whoever we still are. Switching to
+    // the default first let flushPendingSaves stamp Nightowl onto the
+    // open row (persona_default_test / history last-session reopen).
+    await flushPendingSaves();
     await _userPersonaService.setActivePersona(
       personaId ?? _userPersonaService.defaultPersonaId,
     );
@@ -343,8 +347,7 @@ extension ChatServiceSessionManage on ChatService {
     debugPrint(
       '[ChatService] 🟡 startNewChat: clearing messages (had ${_messages.length})',
     );
-    // The open session's last exchange may still be memory-only.
-    await flushPendingSaves();
+    // Departing row was flushed above, before the default persona switch.
     await _invalidateGreetingEval();
     _messages.clear();
     _history.reset();

--- a/lib/services/chat/chat_service_session_manage.dart
+++ b/lib/services/chat/chat_service_session_manage.dart
@@ -719,8 +719,12 @@ extension ChatServiceSessionManage on ChatService {
           ),
         );
         _lorebookScanner.scanLatest();
-        if (greetingFirstMesEmpty(_activeGroup!.firstMessage) &&
-            greetingFirstMesEmpty(_groupCharacters.first.firstMessage)) {
+        // Overlay 0 / inherit baseline into live emotion and slots.
+        // Previously only the empty-empty path applied seed, so leftover
+        // swipe fury survived New Chat on a custom opener or member-greet.
+        if (!greetingFirstMesEmpty(_activeGroup!.firstMessage)) {
+          await _applyGroupCustomGreetingSeed(0);
+        } else {
           await _applyGreetingOpeningSeed(
             card: _groupCharacters.first,
             index: 0,

--- a/lib/services/chat/chat_service_session_state.dart
+++ b/lib/services/chat/chat_service_session_state.dart
@@ -315,13 +315,23 @@ extension ChatServiceSessionState on ChatService {
     // Hydrate must not overwrite the row's binding with the previous chat's
     // still-live persona. A partial omit is not possible on insertOnConflict
     // update (absent → default null), so keep the existing id when set.
+    // Same for character/group: a save after `_activeCharacter =` but
+    // before session detach used to rebind chat A onto the incoming card.
     var personaId = _userPersonaService.persona.id;
+    final existing = await _db.getSessionById(sessionId);
     if (_preserveSessionPersonaOf[this] == true) {
-      final existing = await _db.getSessionById(sessionId);
       final kept = existing?.userPersonaId;
       if (kept != null && kept.isNotEmpty) {
         personaId = kept;
       }
+    }
+    final keptChar = existing?.characterId;
+    if (keptChar != null && keptChar.isNotEmpty) {
+      characterDbId = keptChar;
+    }
+    final keptGroup = existing?.groupId;
+    if (keptGroup != null && keptGroup.isNotEmpty) {
+      groupDbId = keptGroup;
     }
 
     // Upsert session (INSERT OR REPLACE to avoid UNIQUE constraint errors)

--- a/lib/services/chat/chat_service_session_state.dart
+++ b/lib/services/chat/chat_service_session_state.dart
@@ -18,6 +18,10 @@
 
 part of '../chat_service.dart';
 
+/// While [_loadLastSession] hydrates, [_doSaveChat] must not stamp the
+/// still-live previous chat's persona onto the row being loaded.
+final Expando<bool> _preserveSessionPersonaOf = Expando();
+
 /// Session-state load/save — scene-guest + group-realism hydration and _saveChat/_doSaveChat. Extracted verbatim (zero behaviour change) to shrink the god file.
 extension ChatServiceSessionState on ChatService {
   // v30: Load per-character group realism/needs state.
@@ -308,6 +312,18 @@ extension ChatServiceSessionState on ChatService {
       characterDbId = _activeCharacter!.dbId;
     }
 
+    // Hydrate must not overwrite the row's binding with the previous chat's
+    // still-live persona. A partial omit is not possible on insertOnConflict
+    // update (absent → default null), so keep the existing id when set.
+    var personaId = _userPersonaService.persona.id;
+    if (_preserveSessionPersonaOf[this] == true) {
+      final existing = await _db.getSessionById(sessionId);
+      final kept = existing?.userPersonaId;
+      if (kept != null && kept.isNotEmpty) {
+        personaId = kept;
+      }
+    }
+
     // Upsert session (INSERT OR REPLACE to avoid UNIQUE constraint errors)
     final timestamp = int.tryParse(sessionId) ?? 0;
     final createdAt = timestamp > 0
@@ -320,7 +336,7 @@ extension ChatServiceSessionState on ChatService {
         groupId: drift.Value(groupDbId),
         name: drift.Value(_sessionName),
         description: drift.Value(_sessionDescription),
-        userPersonaId: drift.Value(_userPersonaService.persona.id),
+        userPersonaId: drift.Value(personaId),
         authorNote: drift.Value(_authorNote),
         authorNoteDepth: drift.Value(_authorNoteStrength),
         summary: drift.Value(_summary.isEmpty ? null : _summary),

--- a/lib/services/chat/chat_service_variants.dart
+++ b/lib/services/chat/chat_service_variants.dart
@@ -27,7 +27,8 @@ extension ChatServiceVariants on ChatService {
   List<String> get openingAllGreetings {
     if (isGroupMode) {
       final g = activeGroup;
-      if (g != null && g.firstMessage.isNotEmpty) return g.allGreetings;
+      if (g != null && !greetingFirstMesEmpty(g.firstMessage))
+        return g.allGreetings;
       if (messages.isEmpty) return const [];
       final cid = messages.first.characterId;
       if (cid == null || cid.isEmpty) return const [];
@@ -102,7 +103,8 @@ extension ChatServiceVariants on ChatService {
   /// back to index 0 restores the card/group base — it does not keep the
   /// previous alt's live mood. Re-selecting the same index is a no-op.
   List<String> _resolvedOpeningGreetings() {
-    if (_activeGroup != null && _activeGroup!.firstMessage.isNotEmpty) {
+    if (_activeGroup != null &&
+        !greetingFirstMesEmpty(_activeGroup!.firstMessage)) {
       return [
         for (final g in _activeGroup!.allGreetings)
           _macroResolver.resolve(
@@ -137,7 +139,8 @@ extension ChatServiceVariants on ChatService {
     if (index >= resolved.length) return;
     final old = _messages[0];
     final groupCustom =
-        _activeGroup != null && _activeGroup!.firstMessage.isNotEmpty;
+        _activeGroup != null &&
+        !greetingFirstMesEmpty(_activeGroup!.firstMessage);
     _messages[0] = ChatMessage(
       text: resolved[index],
       sender: groupCustom ? _activeGroup!.name : (old.sender),

--- a/lib/services/chat/chat_service_variants.dart
+++ b/lib/services/chat/chat_service_variants.dart
@@ -127,6 +127,11 @@ extension ChatServiceVariants on ChatService {
     if (index < 0 || index >= allGreetings.length) return;
     if (index == _greetingIndex) return;
 
+    _greetingEvalGen++;
+    testPostGreetingEvalEntered = false;
+    await cancelRealismEval();
+    _realismEvalCancelled = false;
+
     _greetingIndex = index;
     final resolved = _resolvedOpeningGreetings();
     if (index >= resolved.length) return;

--- a/lib/services/chat/chat_service_variants.dart
+++ b/lib/services/chat/chat_service_variants.dart
@@ -129,10 +129,8 @@ extension ChatServiceVariants on ChatService {
     if (index < 0 || index >= allGreetings.length) return;
     if (index == _greetingIndex) return;
 
-    _greetingEvalGen++;
+    await _invalidateGreetingEval();
     testPostGreetingEvalEntered = false;
-    await cancelRealismEval();
-    _realismEvalCancelled = false;
 
     _greetingIndex = index;
     final resolved = _resolvedOpeningGreetings();

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -74,7 +74,8 @@ extension ChatServiceWiringEvals on ChatService {
         if (k != null) await k.ensureServerIdle();
       },
       getIsCancellingRealismEval: () => _isCancellingRealismEval,
-      getRealismEvalCancelled: () => _realismEvalCancelled,
+      getRealismEvalCancelled: () =>
+          _realismEvalCancelled || _isStaleGreetingEval(),
       getPendingRealismMetadata: () => _pendingRealismMetadata ?? {},
       setPendingRealismMetadata: (v) => _pendingRealismMetadata = v,
       captureRealismState: _captureRealismState,
@@ -294,7 +295,10 @@ extension ChatServiceWiringEvals on ChatService {
       fireToolEval: _fireToolEval,
       probe: _toolProbe,
       getBackendIdentity: () => _evalBackendIdentity,
-      isEvalCancelled: () => _isCancellingRealismEval || _realismEvalCancelled,
+      isEvalCancelled: () =>
+          _isCancellingRealismEval ||
+          _realismEvalCancelled ||
+          _isStaleGreetingEval(),
       stripThinkBlocks: _stripThinkBlocks,
       extractJsonInt: _extractJsonInt,
       extractJsonBool: _extractJsonBool,

--- a/lib/services/chat/llm_eval_engine.dart
+++ b/lib/services/chat/llm_eval_engine.dart
@@ -492,7 +492,7 @@ class LlmEvalEngine {
               },
             )) {
           // If a cancellation has been requested, terminate streaming gracefully.
-          if (getIsCancellingRealismEval()) {
+          if (getIsCancellingRealismEval() || getRealismEvalCancelled()) {
             debugPrint('[Realism] streaming terminated via cancel');
             cancelledDuringStream = true;
             break;
@@ -526,6 +526,10 @@ class LlmEvalEngine {
           response += '\n';
         }
 
+        if (getIsCancellingRealismEval() || getRealismEvalCancelled()) {
+          debugPrint('[Realism] eval cancelled after stream; drop live apply');
+          return null;
+        }
         break; // stream completed cleanly — exit retry loop
       } catch (e) {
         debugPrint('[Realism:Eval] Stream error on attempt ${attempt + 1}: $e');

--- a/lib/services/chat/realism_evals.support.dart
+++ b/lib/services/chat/realism_evals.support.dart
@@ -38,6 +38,7 @@ extension _RealismEvalSupport on RealismEvals {
     String text, {
     required bool applyArousal,
   }) async {
+    if (isEvalCancelled()) return;
     final emotionMatch = RegExp(
       r'"emotion"\s*:\s*"([^"]+)"',
     ).firstMatch(text);
@@ -73,6 +74,7 @@ extension _RealismEvalSupport on RealismEvals {
   /// narrative eval text. Extracted here so the batch apply path can reuse the exact same
   /// side-effect logic (and dedup) without growing god or duplicating the json+regex fallbacks.
   Future<void> _applyNarrativeResults(String text) async {
+    if (isEvalCancelled()) return;
     // Robust extraction (survives Director reprocess/correction which may reformat/partial JSON).
     // Inline (no new named helper/method per rules for god; private here in leaf is fine).
     // Parse JSON once (both keys live in the same payload) rather than twice.
@@ -258,6 +260,15 @@ extension _RealismEvalSupport on RealismEvals {
     String trustReason,
   })
   _parseAndApplyRelationshipDeltas(String text, {required bool applyArousal}) {
+    if (isEvalCancelled()) {
+      return (
+        bondDelta: 0,
+        trustDelta: 0,
+        arousalDelta: 0,
+        bondReason: '',
+        trustReason: '',
+      );
+    }
     // Bond / relationship delta (per prompt range)
     final relDelta = extractJsonInt(text, 'relationship_delta');
     int bondDelta = 0;

--- a/lib/services/chat/variant_snippet.dart
+++ b/lib/services/chat/variant_snippet.dart
@@ -119,8 +119,12 @@ List<VariantOption> buildVariantOptions(
 /// First greet keeps the card's starting emotion. Alternative greets get
 /// reading-the-room only when the author did **not** attach a greeting seed
 /// (null slot). An authored overlay — even `{}` inherit — skips the eval.
-bool shouldReadRoomForGreeting(int index, {bool hasAuthoredSeed = false}) =>
-    index > 0 && !hasAuthoredSeed;
+bool shouldReadRoomForGreeting(
+  int index, {
+  bool hasAuthoredSeed = false,
+  bool firstMesEmpty = false,
+}) =>
+    (index > 0 || firstMesEmpty) && !hasAuthoredSeed;
 
 /// Opening-message picker shows card greets only while the chat is still
 /// the opening (no user reply yet) and that message has no stored regen

--- a/lib/services/group_card_importer.dart
+++ b/lib/services/group_card_importer.dart
@@ -22,6 +22,7 @@ import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/utils/group_stable_id.dart';
 import 'package:front_porch_ai/services/group_chat_repository.dart';
 import 'package:front_porch_ai/services/storage_service.dart';
+import 'package:front_porch_ai/utils/group_realism_blobs.dart';
 
 /// Outcome of importing a Group Card.
 class GroupImportResult {
@@ -320,6 +321,13 @@ class GroupCardImporter {
       defaultMemberRealismState: finalDefaultMember.isNotEmpty
           ? finalDefaultMember
           : '{}',
+      // Parse alts/seeds out of the blob so repo.save is a no-wipe round-trip.
+      alternateGreetings: parseGroupAlternateGreetings(
+        finalDefaultMember.isNotEmpty ? finalDefaultMember : '{}',
+      ),
+      greetingSeeds: parseGroupGreetingSeeds(
+        finalDefaultMember.isNotEmpty ? finalDefaultMember : '{}',
+      ),
       characterSystemPrompts: finalCharPrompts,
     );
 

--- a/lib/services/group_chat_repository.dart
+++ b/lib/services/group_chat_repository.dart
@@ -129,6 +129,15 @@ class GroupChatRepository extends ChangeNotifier {
     // Full removal of the previous Path B transitional blob logic that merged it
     // into defaultMemberRealismState. defaultMemberRealismState is written as-is.
     // characterIds is legacy dead weight (always '[]' — membership is in group_members).
+    final patchedBlob = withGroupOpeningAlts(
+      group.defaultMemberRealismState,
+      alternateGreetings: group.alternateGreetings,
+      greetingSeeds: group.greetingSeeds,
+    );
+    // Same-session export / cache reads must see the patched alts/seeds.
+    group.defaultMemberRealismState = patchedBlob;
+    group.alternateGreetings = parseGroupAlternateGreetings(patchedBlob);
+    group.greetingSeeds = parseGroupGreetingSeeds(patchedBlob);
     final companion = GroupsCompanion(
       id: Value(group.id),
       stableId: Value(group.stableId),
@@ -140,13 +149,7 @@ class GroupChatRepository extends ChangeNotifier {
       firstMessage: Value(group.firstMessage),
       scenario: Value(group.scenario),
       systemPrompt: Value(group.systemPrompt),
-      defaultMemberRealismState: Value(
-        withGroupOpeningAlts(
-          group.defaultMemberRealismState,
-          alternateGreetings: group.alternateGreetings,
-          greetingSeeds: group.greetingSeeds,
-        ),
-      ),
+      defaultMemberRealismState: Value(patchedBlob),
       characterSystemPrompts: Value(jsonEncode(group.characterSystemPrompts)),
       chaosModeEnabled: Value(group.chaosModeEnabled),
       chaosNsfwEnabled: Value(group.chaosNsfwEnabled),
@@ -176,13 +179,7 @@ class GroupChatRepository extends ChangeNotifier {
           firstMessage: Value(group.firstMessage),
           scenario: Value(group.scenario),
           systemPrompt: Value(group.systemPrompt),
-          defaultMemberRealismState: Value(
-            withGroupOpeningAlts(
-              group.defaultMemberRealismState,
-              alternateGreetings: group.alternateGreetings,
-              greetingSeeds: group.greetingSeeds,
-            ),
-          ),
+          defaultMemberRealismState: Value(patchedBlob),
           characterSystemPrompts: Value(
             jsonEncode(group.characterSystemPrompts),
           ),

--- a/lib/services/v2_card_service.dart
+++ b/lib/services/v2_card_service.dart
@@ -222,7 +222,7 @@ class V2CardService {
         return v is String && v.isNotEmpty ? [v] : const [];
       }
 
-      final rawAlts = strList(
+      final rawAlts = greetingSlotsFromRaw(
         data['alternate_greetings'] ?? jsonMap['alternate_greetings'],
       );
 

--- a/lib/services/v2_card_service.dart
+++ b/lib/services/v2_card_service.dart
@@ -222,6 +222,10 @@ class V2CardService {
         return v is String && v.isNotEmpty ? [v] : const [];
       }
 
+      final rawAlts = strList(
+        data['alternate_greetings'] ?? jsonMap['alternate_greetings'],
+      );
+
       // Parse V2.5 extensions (front_porch namespace + raw third-party keys)
       FrontPorchExtensions? fpExtensions;
       Map<String, dynamic>? rawExtensions;
@@ -232,6 +236,7 @@ class V2CardService {
           try {
             fpExtensions = FrontPorchExtensions.fromJson(
               Map<String, dynamic>.from(fp),
+              alternateGreetings: rawAlts,
             );
           } catch (e) {
             print('Card parse: ignoring malformed front_porch extensions: $e');
@@ -266,9 +271,10 @@ class V2CardService {
           data['post_history_instructions'] ??
               jsonMap['post_history_instructions'],
         ),
-        alternateGreetings: strList(
-          data['alternate_greetings'] ?? jsonMap['alternate_greetings'],
-        ),
+        alternateGreetings: compactGreetingPairs(
+          rawAlts,
+          fpExtensions?.greetingSeeds ?? const [],
+        ).greetings,
         tags: strList(data['tags'] ?? jsonMap['tags']),
         lorebook: lorebook,
         worldNames: strList(data['world_names'] ?? jsonMap['world_names']),

--- a/lib/services/web/facade/character_facade.dart
+++ b/lib/services/web/facade/character_facade.dart
@@ -283,11 +283,15 @@ class CharacterFacade {
     if (tags is List) card.tags = tags.map((e) => e.toString()).toList();
     final greetings = fields['alternateGreetings'];
     if (greetings is List) {
+      // Seeds omitted + alts present: compact against empty/null, not unpaired
+      // base leftovers. Group updateSettings writes both; frontPorchFromFields
+      // below writes the compacted seeds so leftover furious cannot land on
+      // Get out.
       final paired = compactGreetingPairs(
         greetingSlotsFromRaw(greetings),
         fields.containsKey('greetingSeeds')
             ? parseGreetingSeeds(fields['greetingSeeds'])
-            : (card.frontPorchExtensions?.greetingSeeds ?? const []),
+            : const [],
       );
       card.alternateGreetings = paired.greetings;
     }

--- a/lib/services/web/facade/character_facade.dart
+++ b/lib/services/web/facade/character_facade.dart
@@ -283,10 +283,13 @@ class CharacterFacade {
     if (tags is List) card.tags = tags.map((e) => e.toString()).toList();
     final greetings = fields['alternateGreetings'];
     if (greetings is List) {
-      card.alternateGreetings = greetings
-          .map((e) => e.toString())
-          .where((g) => g.trim().isNotEmpty)
-          .toList();
+      final paired = compactGreetingPairs(
+        greetingSlotsFromRaw(greetings),
+        fields.containsKey('greetingSeeds')
+            ? parseGreetingSeeds(fields['greetingSeeds'])
+            : (card.frontPorchExtensions?.greetingSeeds ?? const []),
+      );
+      card.alternateGreetings = paired.greetings;
     }
     // Linked worlds (attach worlds/lorebooks to a character). Worlds are keyed
     // by name; only replace when present so a partial edit doesn't clear them.
@@ -359,9 +362,10 @@ class CharacterFacade {
       systemPrompt: fields['systemPrompt']?.toString() ?? '',
       postHistoryInstructions:
           fields['postHistoryInstructions']?.toString() ?? '',
-      alternateGreetings: asStrList(
-        fields['alternateGreetings'],
-      ).where((g) => g.trim().isNotEmpty).toList(),
+      alternateGreetings: compactGreetingPairs(
+        greetingSlotsFromRaw(fields['alternateGreetings']),
+        parseGreetingSeeds(fields['greetingSeeds']),
+      ).greetings,
       tags: asStrList(fields['tags']),
       lorebook: buildLorebookFromJson(fields['lorebook']),
       frontPorchExtensions: fpExt,

--- a/lib/services/web/facade/group_facade.dart
+++ b/lib/services/web/facade/group_facade.dart
@@ -213,14 +213,19 @@ class GroupFacade {
     if (f['firstMessage'] is String) {
       g.firstMessage = f['firstMessage'] as String;
     }
-    if (f['alternateGreetings'] is List) {
-      g.alternateGreetings = [
-        for (final e in f['alternateGreetings'] as List)
-          if (e is String && e.trim().isNotEmpty) e,
-      ];
-    }
-    if (f.containsKey('greetingSeeds')) {
-      g.greetingSeeds = parseGreetingSeeds(f['greetingSeeds']);
+    if (f['alternateGreetings'] is List || f.containsKey('greetingSeeds')) {
+      final paired = compactGreetingPairs(
+        f['alternateGreetings'] is List
+            ? greetingSlotsFromRaw(f['alternateGreetings'])
+            : g.alternateGreetings,
+        f.containsKey('greetingSeeds')
+            ? parseGreetingSeeds(f['greetingSeeds'])
+            : g.greetingSeeds,
+      );
+      if (f['alternateGreetings'] is List) {
+        g.alternateGreetings = paired.greetings;
+      }
+      g.greetingSeeds = paired.seeds;
     }
     if (f['turnOrder'] is String) {
       g.turnOrder = f['turnOrder'] == 'random'

--- a/lib/services/web/facade/group_facade.dart
+++ b/lib/services/web/facade/group_facade.dart
@@ -214,13 +214,17 @@ class GroupFacade {
       g.firstMessage = f['firstMessage'] as String;
     }
     if (f['alternateGreetings'] is List || f.containsKey('greetingSeeds')) {
+      // Seeds omitted + alts present: compact against empty/null, not unpaired
+      // base leftovers. Same three-way as character update: omitted seeds +
+      // alts → empty; omitted alts keep base (this block is not entered);
+      // present seeds (including []) pair as posted.
       final paired = compactGreetingPairs(
         f['alternateGreetings'] is List
             ? greetingSlotsFromRaw(f['alternateGreetings'])
             : g.alternateGreetings,
         f.containsKey('greetingSeeds')
             ? parseGreetingSeeds(f['greetingSeeds'])
-            : g.greetingSeeds,
+            : const [],
       );
       if (f['alternateGreetings'] is List) {
         g.alternateGreetings = paired.greetings;

--- a/lib/services/web/util/realism_extensions_json.dart
+++ b/lib/services/web/util/realism_extensions_json.dart
@@ -123,9 +123,15 @@ FrontPorchExtensions frontPorchFromFields(
     // Same class of bug as inventory/storyStart: the React editor used to
     // omit greetingSeeds, and rebuilding without carrying the base wiped
     // per-alt opening state on every phone save.
-    greetingSeeds: fields.containsKey('greetingSeeds')
-        ? parseGreetingSeeds(fields['greetingSeeds'])
-        : b.greetingSeeds,
+    greetingSeeds: () {
+      if (!fields.containsKey('greetingSeeds')) return b.greetingSeeds;
+      final parsed = parseGreetingSeeds(fields['greetingSeeds']);
+      if (!fields.containsKey('alternateGreetings')) return parsed;
+      return compactGreetingPairs(
+        greetingSlotsFromRaw(fields['alternateGreetings']),
+        parsed,
+      ).seeds;
+    }(),
 
     // Realism Engine core.
     realismEnabled: asBool('realismEnabled', b.realismEnabled),

--- a/lib/services/web/util/realism_extensions_json.dart
+++ b/lib/services/web/util/realism_extensions_json.dart
@@ -122,11 +122,20 @@ FrontPorchExtensions frontPorchFromFields(
     favoriteAvatarId: b.favoriteAvatarId,
     // Same class of bug as inventory/storyStart: the React editor used to
     // omit greetingSeeds, and rebuilding without carrying the base wiped
-    // per-alt opening state on every phone save.
+    // per-alt opening state on every phone save. If the POST *does* rewrite
+    // alts but omits seeds, do not keep unpaired base leftovers — compact
+    // against empty/null so leftover furious cannot land on Get out.
     greetingSeeds: () {
-      if (!fields.containsKey('greetingSeeds')) return b.greetingSeeds;
+      final altsPresent = fields['alternateGreetings'] is List;
+      if (!fields.containsKey('greetingSeeds')) {
+        if (!altsPresent) return b.greetingSeeds;
+        return compactGreetingPairs(
+          greetingSlotsFromRaw(fields['alternateGreetings']),
+          const [],
+        ).seeds;
+      }
       final parsed = parseGreetingSeeds(fields['greetingSeeds']);
-      if (!fields.containsKey('alternateGreetings')) return parsed;
+      if (!altsPresent) return parsed;
       return compactGreetingPairs(
         greetingSlotsFromRaw(fields['alternateGreetings']),
         parsed,

--- a/lib/ui/character_creator/creator_state_engine.dart
+++ b/lib/ui/character_creator/creator_state_engine.dart
@@ -85,10 +85,11 @@ extension CreatorEngine on CreatorState {
       card.firstMessage = firstMessageController.text;
       card.mesExample = exampleDialogueController.text;
       card.systemPrompt = systemPromptController.text;
-      card.alternateGreetings = [
-        for (final c in altGreetingControllers)
-          if (c.text.trim().isNotEmpty) c.text,
-      ];
+      final greetingPairs = compactGreetingPairs(
+        [for (final c in altGreetingControllers) c.text],
+        greetingSeeds,
+      );
+      card.alternateGreetings = greetingPairs.greetings;
 
       // Always build the V2.5 extensions — even when realism is disabled — so
       // configured realism/needs values AND the stable tracking id survive the
@@ -142,9 +143,7 @@ extension CreatorEngine on CreatorState {
         needsDecayFun: needsDecayFun,
         needsDecayHygiene: needsDecayHygiene,
         needsDecayComfort: needsDecayComfort,
-        greetingSeeds: compactGreetingSeeds(
-          alignGreetingSeeds(greetingSeeds, card.alternateGreetings.length),
-        ),
+        greetingSeeds: greetingPairs.seeds,
       );
       // Save is MULTI-SHOT now (the Portrait & Avatars panel persists before
       // it generates; Save & Finish updates the same card), so identity

--- a/lib/ui/dialogs/group_settings/general_tab.dart
+++ b/lib/ui/dialogs/group_settings/general_tab.dart
@@ -133,8 +133,9 @@ class GroupGeneralTabState extends State<GroupGeneralTab>
     g.name = _nameController.text;
     g.scenario = _scenarioController.text;
     g.firstMessage = _firstMessageController.text;
-    g.alternateGreetings = List.from(_altGreetings);
-    g.greetingSeeds = List.from(_altGreetingSeeds);
+    final paired = compactGreetingPairs(_altGreetings, _altGreetingSeeds);
+    g.alternateGreetings = paired.greetings;
+    g.greetingSeeds = paired.seeds;
     g.turnOrder = _turnOrder;
     g.autoAdvance = _autoAdvance;
     g.directorMode = _directorModeDefault;

--- a/lib/ui/pages/create_character_page.save.dart
+++ b/lib/ui/pages/create_character_page.save.dart
@@ -106,9 +106,10 @@ extension _CreateCharacterSave on _CreateCharacterPageState {
         needsDecayFun: _needsDecayFun,
         needsDecayHygiene: _needsDecayHygiene,
         needsDecayComfort: _needsDecayComfort,
-        greetingSeeds: compactGreetingSeeds(
-          alignGreetingSeeds(_altGreetingSeeds, _altGreetingControllers.length),
-        ),
+        greetingSeeds: compactGreetingPairs(
+          [for (final c in _altGreetingControllers) c.text],
+          _altGreetingSeeds,
+        ).seeds,
       );
 
       fpExt.ensureStableId();
@@ -122,10 +123,10 @@ extension _CreateCharacterSave on _CreateCharacterPageState {
         mesExample: _exampleDialogueController.text,
         systemPrompt: _systemPromptController.text,
         postHistoryInstructions: _postHistoryController.text,
-        alternateGreetings: _altGreetingControllers
-            .map((c) => c.text)
-            .where((t) => t.trim().isNotEmpty)
-            .toList(),
+        alternateGreetings: compactGreetingPairs(
+          [for (final c in _altGreetingControllers) c.text],
+          _altGreetingSeeds,
+        ).greetings,
         tags: List.from(_tags),
         lorebook: _lorebookEntries.isNotEmpty
             ? Lorebook(entries: List.from(_lorebookEntries))

--- a/lib/ui/pages/edit_character_page.save.dart
+++ b/lib/ui/pages/edit_character_page.save.dart
@@ -33,10 +33,11 @@ extension _EditCharacterSave on _EditCharacterPageState {
     widget.character.mesExample = _mesExampleController.text;
     widget.character.systemPrompt = _systemPromptController.text;
     widget.character.postHistoryInstructions = _postHistoryController.text;
-    widget.character.alternateGreetings = _altGreetingControllers
-        .map((c) => c.text)
-        .where((t) => t.isNotEmpty)
-        .toList();
+    final greetingPairs = compactGreetingPairs(
+      [for (final c in _altGreetingControllers) c.text],
+      _altGreetingSeeds,
+    );
+    widget.character.alternateGreetings = greetingPairs.greetings;
     widget.character.tags = List.from(_tags);
     // Empty clears the per-character override so the character
     // follows the global Settings voice again (null, not '', so
@@ -144,9 +145,7 @@ extension _EditCharacterSave on _EditCharacterPageState {
         // above ended up disagreeing.
         inventory: Pockets.cardJsonFrom(worn: _worn, carrying: _carrying),
         currentTask: _realismCurrentTask,
-        greetingSeeds: compactGreetingSeeds(
-          alignGreetingSeeds(_altGreetingSeeds, _altGreetingControllers.length),
-        ),
+        greetingSeeds: greetingPairs.seeds,
         realismVerificationEnabled: _realismVerificationEnabled,
         realismVerificationMaxReprocesses: _realismVerificationMaxReprocesses,
         realismVerificationStrictness: _realismVerificationStrictness,

--- a/lib/ui/pages/home/enhance/enhance_review_body.dart
+++ b/lib/ui/pages/home/enhance/enhance_review_body.dart
@@ -25,6 +25,15 @@ import 'package:front_porch_ai/services/chargen/chargen.dart';
 import 'package:front_porch_ai/ui/pages/home/enhance/enhance_review_porch_life.dart';
 import 'package:front_porch_ai/ui/theme/app_colors.dart';
 
+/// Compact accepted Review greet texts against seeds authored with the
+/// enhance rewrite. Leftover source `ext.greetingSeeds` on the duplicate
+/// must not be passed — that loads furious onto Get out.
+({List<String> greetings, List<GreetingRealismSeed?> seeds})
+compactAcceptedEnhanceGreetings(
+  List<String> acceptedAlts,
+  List<GreetingRealismSeed?>? authoredSeeds,
+) => compactRewrittenGreetingAlts(acceptedAlts, authoredSeeds);
+
 /// Old-vs-new review of an AI Enhance run — the Review step's body inside
 /// [EnhanceWizardPage] (reworked from the old standalone EnhanceReviewPage;
 /// the wizard owns the chrome and the nav buttons now). Every rewritten
@@ -159,16 +168,19 @@ class EnhanceReviewBodyState extends State<EnhanceReviewBody> {
       if (widget.selection.greetings && (_use['greetings'] ?? false)) {
         copy.firstMessage = _controllers['firstMessage']!.text.trim();
         final ext = copy.frontPorchExtensions;
-        final greetingPairs = compactGreetingPairs(
-          [
-            for (var i = 0; i < widget.enhanced.alternateGreetings.length; i++)
-              _controllers['alt$i']!.text,
-          ],
-          ext?.greetingSeeds ?? const [],
-        );
+        // Compact against seeds the enhance step authored — not leftover
+        // source ext.greetingSeeds on the duplicate (furious on Get out).
+        final greetingPairs = compactAcceptedEnhanceGreetings([
+          for (var i = 0; i < widget.enhanced.alternateGreetings.length; i++)
+            _controllers['alt$i']!.text,
+        ], widget.enhanced.frontPorchExtensions?.greetingSeeds);
         copy.alternateGreetings = greetingPairs.greetings;
         if (ext != null) {
           ext.greetingSeeds = greetingPairs.seeds;
+        } else if (greetingPairs.seeds.isNotEmpty) {
+          copy.frontPorchExtensions = FrontPorchExtensions(
+            greetingSeeds: greetingPairs.seeds,
+          );
         }
       }
       final loreEntries = widget.enhanced.lorebook?.entries ?? [];

--- a/lib/ui/pages/home/enhance/enhance_review_body.dart
+++ b/lib/ui/pages/home/enhance/enhance_review_body.dart
@@ -158,18 +158,17 @@ class EnhanceReviewBodyState extends State<EnhanceReviewBody> {
       copy.scenario = accepted('scenario', copy.scenario);
       if (widget.selection.greetings && (_use['greetings'] ?? false)) {
         copy.firstMessage = _controllers['firstMessage']!.text.trim();
-        copy.alternateGreetings = [
-          for (var i = 0; i < widget.enhanced.alternateGreetings.length; i++)
-            _controllers['alt$i']!.text.trim(),
-        ]..removeWhere((g) => g.isEmpty);
         final ext = copy.frontPorchExtensions;
+        final greetingPairs = compactGreetingPairs(
+          [
+            for (var i = 0; i < widget.enhanced.alternateGreetings.length; i++)
+              _controllers['alt$i']!.text,
+          ],
+          ext?.greetingSeeds ?? const [],
+        );
+        copy.alternateGreetings = greetingPairs.greetings;
         if (ext != null) {
-          ext.greetingSeeds = compactGreetingSeeds(
-            alignGreetingSeeds(
-              ext.greetingSeeds,
-              copy.alternateGreetings.length,
-            ),
-          );
+          ext.greetingSeeds = greetingPairs.seeds;
         }
       }
       final loreEntries = widget.enhanced.lorebook?.entries ?? [];

--- a/lib/ui/widgets/greeting_seed_form.dart
+++ b/lib/ui/widgets/greeting_seed_form.dart
@@ -185,8 +185,10 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
               keyboardType: TextInputType.number,
               inputFormatters: [FilteringTextInputFormatter.digitsOnly],
               onChanged: (v) {
-                final n = int.tryParse(v);
-                if (n != null && n >= 1) {
+                final n = int.tryParse(v.trim());
+                if (v.trim().isEmpty) {
+                  widget.onChanged(s.copyWith(dayCount: null));
+                } else if (n != null && n >= 1) {
                   widget.onChanged(s.copyWith(dayCount: n));
                 }
               },
@@ -342,20 +344,22 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
     required ValueChanged<String?> onChanged,
   }) {
     final selected = value != null && items.contains(value) ? value : null;
+    final inheritStyle = TextStyle(
+      color: AppColors.textTertiary(context).withValues(alpha: 0.6),
+      fontSize: 13,
+    );
     return _labeledField(
       context,
       label: label,
       child: DropdownButtonFormField<String>(
         key: ValueKey('$label-${selected ?? 'inherit'}'),
         initialValue: selected,
-        hint: Text(
-          hint,
-          style: TextStyle(
-            color: AppColors.textTertiary(context).withValues(alpha: 0.6),
-            fontSize: 13,
-          ),
-        ),
+        hint: Text(hint, style: inheritStyle),
         items: [
+          DropdownMenuItem<String>(
+            value: null,
+            child: Text(hint, style: inheritStyle),
+          ),
           for (final i in items)
             DropdownMenuItem(value: i, child: Text(i.replaceAll('_', ' '))),
         ],

--- a/lib/ui/widgets/greeting_seed_form.dart
+++ b/lib/ui/widgets/greeting_seed_form.dart
@@ -144,6 +144,7 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
             divisions: 600,
             context: context,
             onChanged: (v) => widget.onChanged(s.copyWith(shortTermBond: v.round())),
+            onCleared: () => widget.onChanged(s.copyWith(shortTermBond: null)),
           ),
           SliderWithInput(
             label: 'Long-term bond',
@@ -155,6 +156,7 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
             divisions: 600,
             context: context,
             onChanged: (v) => widget.onChanged(s.copyWith(longTermBond: v.round())),
+            onCleared: () => widget.onChanged(s.copyWith(longTermBond: null)),
           ),
           SliderWithInput(
             label: 'Trust',
@@ -166,6 +168,7 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
             divisions: 200,
             context: context,
             onChanged: (v) => widget.onChanged(s.copyWith(trustLevel: v.round())),
+            onCleared: () => widget.onChanged(s.copyWith(trustLevel: null)),
           ),
           const SizedBox(height: 8),
           _dropdown(
@@ -244,6 +247,7 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
                 divisions: 100,
                 context: context,
                 onChanged: (v) => widget.onChanged(need.$3(s, v.round())),
+                onCleared: () => widget.onChanged(need.$4(s)),
               ),
           ],
           if (widget.showInventory) ...[
@@ -272,42 +276,50 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
           String,
           int? Function(GreetingRealismSeed),
           GreetingRealismSeed Function(GreetingRealismSeed, int),
+          GreetingRealismSeed Function(GreetingRealismSeed),
         )
       >[
         (
           'Hunger',
           (s) => s.needsBaselineHunger,
           (s, v) => s.copyWith(needsBaselineHunger: v),
+          (s) => s.copyWith(needsBaselineHunger: null),
         ),
         (
           'Bladder',
           (s) => s.needsBaselineBladder,
           (s, v) => s.copyWith(needsBaselineBladder: v),
+          (s) => s.copyWith(needsBaselineBladder: null),
         ),
         (
           'Energy',
           (s) => s.needsBaselineEnergy,
           (s, v) => s.copyWith(needsBaselineEnergy: v),
+          (s) => s.copyWith(needsBaselineEnergy: null),
         ),
         (
           'Social',
           (s) => s.needsBaselineSocial,
           (s, v) => s.copyWith(needsBaselineSocial: v),
+          (s) => s.copyWith(needsBaselineSocial: null),
         ),
         (
           'Fun',
           (s) => s.needsBaselineFun,
           (s, v) => s.copyWith(needsBaselineFun: v),
+          (s) => s.copyWith(needsBaselineFun: null),
         ),
         (
           'Hygiene',
           (s) => s.needsBaselineHygiene,
           (s, v) => s.copyWith(needsBaselineHygiene: v),
+          (s) => s.copyWith(needsBaselineHygiene: null),
         ),
         (
           'Comfort',
           (s) => s.needsBaselineComfort,
           (s, v) => s.copyWith(needsBaselineComfort: v),
+          (s) => s.copyWith(needsBaselineComfort: null),
         ),
       ];
 

--- a/lib/ui/widgets/greeting_seed_form.dart
+++ b/lib/ui/widgets/greeting_seed_form.dart
@@ -189,7 +189,7 @@ class _GreetingSeedFormState extends State<GreetingSeedForm> {
               inputFormatters: [FilteringTextInputFormatter.digitsOnly],
               onChanged: (v) {
                 final n = int.tryParse(v.trim());
-                if (v.trim().isEmpty) {
+                if (v.trim().isEmpty || n == 0) {
                   widget.onChanged(s.copyWith(dayCount: null));
                 } else if (n != null && n >= 1) {
                   widget.onChanged(s.copyWith(dayCount: n));

--- a/lib/ui/widgets/greeting_seed_form.dart
+++ b/lib/ui/widgets/greeting_seed_form.dart
@@ -16,7 +16,7 @@ import 'package:front_porch_ai/ui/widgets/synced_text_field.dart';
 ///
 /// Off (null) = this alt still gets reading-the-room. On = authored seed:
 /// empty fields inherit the card/group defaults at chat start.
-class GreetingSeedForm extends StatelessWidget {
+class GreetingSeedForm extends StatefulWidget {
   final GreetingRealismSeed? seed;
   final ValueChanged<GreetingRealismSeed?> onChanged;
   final bool showNeeds;
@@ -30,6 +30,30 @@ class GreetingSeedForm extends StatelessWidget {
     this.showInventory = false,
   });
 
+  @override
+  State<GreetingSeedForm> createState() => _GreetingSeedFormState();
+}
+
+class _GreetingSeedFormState extends State<GreetingSeedForm> {
+  GreetingRealismSeed? _stash;
+  bool _uiOn = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _stash = widget.seed;
+    _uiOn = widget.seed != null;
+  }
+
+  @override
+  void didUpdateWidget(covariant GreetingSeedForm oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.seed != null) {
+      _stash = widget.seed;
+      _uiOn = true;
+    }
+  }
+
   static const _times = [
     'dawn',
     'morning',
@@ -42,8 +66,8 @@ class GreetingSeedForm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final enabled = seed != null;
-    final s = seed ?? const GreetingRealismSeed();
+    final enabled = _uiOn || widget.seed != null;
+    final s = widget.seed ?? const GreetingRealismSeed();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -68,7 +92,18 @@ class GreetingSeedForm extends StatelessWidget {
             ),
           ),
           value: enabled,
-          onChanged: (on) => onChanged(on ? const GreetingRealismSeed() : null),
+          onChanged: (on) {
+            if (on) {
+              setState(() => _uiOn = true);
+              // Restore last authored seed (calendar / {}). Fresh enable
+              // persists null — not {} — until a field is set.
+              widget.onChanged(_stash);
+            } else {
+              _stash = widget.seed ?? _stash;
+              setState(() => _uiOn = false);
+              widget.onChanged(null);
+            }
+          },
         ),
         if (enabled) ...[
           const SizedBox(height: 8),
@@ -77,7 +112,7 @@ class GreetingSeedForm extends StatelessWidget {
             label: 'Emotion',
             child: SyncedTextField(
               value: s.characterEmotion ?? '',
-              onChanged: (v) => onChanged(
+              onChanged: (v) => widget.onChanged(
                 s.copyWith(
                   characterEmotion: v.trim().isEmpty ? null : v.trim(),
                 ),
@@ -93,78 +128,83 @@ class GreetingSeedForm extends StatelessWidget {
           _dropdown(
             context,
             label: 'Intensity',
-            value: s.emotionIntensity ?? 'moderate',
+            value: s.emotionIntensity,
             items: _intensities,
-            onChanged: (v) => onChanged(s.copyWith(emotionIntensity: v)),
+            hint: 'inherit (mild)',
+            onChanged: (v) => widget.onChanged(s.copyWith(emotionIntensity: v)),
           ),
           const SizedBox(height: 8),
           SliderWithInput(
             label: 'Short-term bond',
             value: (s.shortTermBond ?? 0).toDouble(),
+            unset: s.shortTermBond == null,
             min: -300,
             max: 300,
             isInteger: true,
             divisions: 600,
             context: context,
-            onChanged: (v) => onChanged(s.copyWith(shortTermBond: v.round())),
+            onChanged: (v) => widget.onChanged(s.copyWith(shortTermBond: v.round())),
           ),
           SliderWithInput(
             label: 'Long-term bond',
             value: (s.longTermBond ?? 0).toDouble(),
+            unset: s.longTermBond == null,
             min: -300,
             max: 300,
             isInteger: true,
             divisions: 600,
             context: context,
-            onChanged: (v) => onChanged(s.copyWith(longTermBond: v.round())),
+            onChanged: (v) => widget.onChanged(s.copyWith(longTermBond: v.round())),
           ),
           SliderWithInput(
             label: 'Trust',
             value: (s.trustLevel ?? 0).toDouble(),
+            unset: s.trustLevel == null,
             min: -100,
             max: 100,
             isInteger: true,
             divisions: 200,
             context: context,
-            onChanged: (v) => onChanged(s.copyWith(trustLevel: v.round())),
+            onChanged: (v) => widget.onChanged(s.copyWith(trustLevel: v.round())),
           ),
           const SizedBox(height: 8),
           _dropdown(
             context,
             label: 'Time of day',
-            value: s.timeOfDay ?? 'morning',
+            value: s.timeOfDay,
             items: _times,
-            onChanged: (v) => onChanged(s.copyWith(timeOfDay: v)),
+            hint: 'inherit (morning)',
+            onChanged: (v) => widget.onChanged(s.copyWith(timeOfDay: v)),
           ),
           const SizedBox(height: 8),
           _labeledField(
             context,
             label: 'Day number',
             child: SyncedTextField(
-              value: (s.dayCount ?? 1).toString(),
+              value: s.dayCount?.toString() ?? '',
               keyboardType: TextInputType.number,
               inputFormatters: [FilteringTextInputFormatter.digitsOnly],
               onChanged: (v) {
                 final n = int.tryParse(v);
                 if (n != null && n >= 1) {
-                  onChanged(s.copyWith(dayCount: n));
+                  widget.onChanged(s.copyWith(dayCount: n));
                 }
               },
               style: TextStyle(
                 color: AppColors.textPrimary(context),
                 fontSize: 14,
               ),
-              decoration: _deco(context, null),
+              decoration: _deco(context, 'inherit (day 1)'),
             ),
           ),
           const SizedBox(height: 8),
           StoryBeginsRow(
             storyStartDate: s.storyStartDate,
             onStoryStartDateChanged: (v) =>
-                onChanged(s.copyWith(storyStartDate: v)),
+                widget.onChanged(s.copyWith(storyStartDate: v)),
             storyStartTime: s.storyStartTime,
             onStoryStartTimeChanged: (v) =>
-                onChanged(s.copyWith(storyStartTime: v)),
+                widget.onChanged(s.copyWith(storyStartTime: v)),
           ),
           const SizedBox(height: 8),
           _labeledField(
@@ -172,7 +212,7 @@ class GreetingSeedForm extends StatelessWidget {
             label: 'Starting task',
             child: SyncedTextField(
               value: s.currentTask ?? '',
-              onChanged: (v) => onChanged(
+              onChanged: (v) => widget.onChanged(
                 s.copyWith(currentTask: v.trim().isEmpty ? null : v.trim()),
               ),
               style: TextStyle(
@@ -182,7 +222,7 @@ class GreetingSeedForm extends StatelessWidget {
               decoration: _deco(context, 'Optional in-voice objective'),
             ),
           ),
-          if (showNeeds) ...[
+          if (widget.showNeeds) ...[
             const SizedBox(height: 12),
             Text(
               'Needs baselines (0–100). Blank inherits the card.',
@@ -195,15 +235,16 @@ class GreetingSeedForm extends StatelessWidget {
               SliderWithInput(
                 label: need.$1,
                 value: (need.$2(s) ?? 80).toDouble(),
+                unset: need.$2(s) == null,
                 min: 0,
                 max: 100,
                 isInteger: true,
                 divisions: 100,
                 context: context,
-                onChanged: (v) => onChanged(need.$3(s, v.round())),
+                onChanged: (v) => widget.onChanged(need.$3(s, v.round())),
               ),
           ],
-          if (showInventory) ...[
+          if (widget.showInventory) ...[
             const SizedBox(height: 8),
             ChipListEditor(
               label: 'Wearing (this opening)',
@@ -289,30 +330,37 @@ class GreetingSeedForm extends StatelessWidget {
       worn: worn ?? _wornOf(s),
       carrying: carrying ?? _carryingOf(s),
     );
-    onChanged(s.copyWith(inventory: next.isEmpty ? null : next));
+    widget.onChanged(s.copyWith(inventory: next.isEmpty ? null : next));
   }
 
   Widget _dropdown(
     BuildContext context, {
     required String label,
-    required String value,
+    required String? value,
     required List<String> items,
-    required ValueChanged<String> onChanged,
+    required String hint,
+    required ValueChanged<String?> onChanged,
   }) {
+    final selected = value != null && items.contains(value) ? value : null;
     return _labeledField(
       context,
       label: label,
       child: DropdownButtonFormField<String>(
-        key: ValueKey('$label-$value'),
-        initialValue: items.contains(value) ? value : items.first,
+        key: ValueKey('$label-${selected ?? 'inherit'}'),
+        initialValue: selected,
+        hint: Text(
+          hint,
+          style: TextStyle(
+            color: AppColors.textTertiary(context).withValues(alpha: 0.6),
+            fontSize: 13,
+          ),
+        ),
         items: [
           for (final i in items)
             DropdownMenuItem(value: i, child: Text(i.replaceAll('_', ' '))),
         ],
-        onChanged: (v) {
-          if (v != null) onChanged(v);
-        },
-        decoration: _deco(context, null),
+        onChanged: onChanged,
+        decoration: _deco(context, hint),
         dropdownColor: AppColors.surfaceContainerOf(context),
         style: TextStyle(color: AppColors.textPrimary(context), fontSize: 14),
       ),

--- a/lib/ui/widgets/slider_with_input.dart
+++ b/lib/ui/widgets/slider_with_input.dart
@@ -15,6 +15,7 @@ class SliderWithInput extends StatefulWidget {
     this.isInteger = false,
     this.decimalPlaces = 2,
     this.unset = false,
+    this.onCleared,
   });
 
   final String label;
@@ -30,6 +31,9 @@ class SliderWithInput extends StatefulWidget {
   /// When true the number box stays empty and the slider is a visual rest
   /// — inherit, not a fake authored 0 / 80.
   final bool unset;
+
+  /// Empty number box writes inherit (null) instead of restoring the last value.
+  final VoidCallback? onCleared;
 
   @override
   State<SliderWithInput> createState() => _SliderWithInputState();
@@ -84,6 +88,10 @@ class _SliderWithInputState extends State<SliderWithInput> {
   void _commitValue() {
     final text = _controller.text.trim();
     if (text.isEmpty) {
+      if (widget.onCleared != null) {
+        widget.onCleared!();
+        return;
+      }
       if (widget.unset) return;
       _controller.text = _formattedValue;
       return;

--- a/lib/ui/widgets/slider_with_input.dart
+++ b/lib/ui/widgets/slider_with_input.dart
@@ -14,6 +14,7 @@ class SliderWithInput extends StatefulWidget {
     this.tooltip,
     this.isInteger = false,
     this.decimalPlaces = 2,
+    this.unset = false,
   });
 
   final String label;
@@ -26,6 +27,9 @@ class SliderWithInput extends StatefulWidget {
   final String? tooltip;
   final bool isInteger;
   final int decimalPlaces;
+  /// When true the number box stays empty and the slider is a visual rest
+  /// — inherit, not a fake authored 0 / 80.
+  final bool unset;
 
   @override
   State<SliderWithInput> createState() => _SliderWithInputState();
@@ -41,14 +45,8 @@ class _SliderWithInputState extends State<SliderWithInput> {
   void initState() {
     super.initState();
     _focusNode = FocusNode();
-    _controller = TextEditingController(
-      text: widget.isInteger
-          ? widget.value.toInt().toString()
-          : widget.value.toStringAsFixed(widget.decimalPlaces),
-    );
-    _formattedValue = widget.isInteger
-        ? widget.value.toInt().toString()
-        : widget.value.toStringAsFixed(widget.decimalPlaces);
+    _controller = TextEditingController(text: _textFor(widget));
+    _formattedValue = _textFor(widget);
 
     _focusNode.addListener(_onFocusChange);
   }
@@ -56,13 +54,9 @@ class _SliderWithInputState extends State<SliderWithInput> {
   @override
   void didUpdateWidget(covariant SliderWithInput oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.value != widget.value) {
-      _controller.text = widget.isInteger
-          ? widget.value.toInt().toString()
-          : widget.value.toStringAsFixed(widget.decimalPlaces);
-      _formattedValue = widget.isInteger
-          ? widget.value.toInt().toString()
-          : widget.value.toStringAsFixed(widget.decimalPlaces);
+    if (oldWidget.value != widget.value || oldWidget.unset != widget.unset) {
+      _controller.text = _textFor(widget);
+      _formattedValue = _textFor(widget);
     }
   }
 
@@ -80,9 +74,17 @@ class _SliderWithInputState extends State<SliderWithInput> {
     }
   }
 
+  String _textFor(SliderWithInput w) {
+    if (w.unset) return '';
+    return w.isInteger
+        ? w.value.toInt().toString()
+        : w.value.toStringAsFixed(w.decimalPlaces);
+  }
+
   void _commitValue() {
     final text = _controller.text.trim();
     if (text.isEmpty) {
+      if (widget.unset) return;
       _controller.text = _formattedValue;
       return;
     }
@@ -169,6 +171,7 @@ class _SliderWithInputState extends State<SliderWithInput> {
                   ),
                   filled: true,
                   fillColor: Colors.white.withValues(alpha: 0.05),
+                  hintText: widget.unset ? 'inherit' : null,
                 ),
                 onSubmitted: (_) => _commitValue(),
               ),
@@ -176,7 +179,7 @@ class _SliderWithInputState extends State<SliderWithInput> {
           ],
         ),
         Slider(
-          value: _dragValue ?? widget.value,
+          value: _dragValue ?? (widget.unset ? widget.min : widget.value),
           min: widget.min,
           max: widget.max,
           divisions: widget.divisions,

--- a/lib/utils/group_realism_blobs.dart
+++ b/lib/utils/group_realism_blobs.dart
@@ -272,12 +272,7 @@ Map<String, dynamic> _groupOpeningAltsFragment(
 ({List<String> greetings, List<GreetingRealismSeed?> seeds})
 parseGroupOpeningPairs(String defaultMemberJson) {
   final map = _decodeGroupBlob(defaultMemberJson);
-  final raw = map['alternateGreetings'];
-  final greets = <String>[
-    if (raw is List)
-      for (final e in raw)
-        if (e is String) e,
-  ];
+  final greets = greetingSlotsFromRaw(map['alternateGreetings']);
   return compactGreetingPairs(greets, parseGreetingSeeds(map['greetingSeeds']));
 }
 

--- a/lib/utils/group_realism_blobs.dart
+++ b/lib/utils/group_realism_blobs.dart
@@ -258,16 +258,11 @@ Map<String, dynamic> _groupOpeningAltsFragment(
   List<String> alternateGreetings,
   List<GreetingRealismSeed?> greetingSeeds,
 ) {
-  final alts = [
-    for (final g in alternateGreetings)
-      if (g.trim().isNotEmpty) g,
-  ];
-  final seeds = compactGreetingSeeds(
-    alignGreetingSeeds(greetingSeeds, alts.length),
-  );
+  final paired = compactGreetingPairs(alternateGreetings, greetingSeeds);
   return {
-    if (alts.isNotEmpty) 'alternateGreetings': alts,
-    if (seeds.isNotEmpty) 'greetingSeeds': [for (final s in seeds) s?.toJson()],
+    if (paired.greetings.isNotEmpty) 'alternateGreetings': paired.greetings,
+    if (paired.seeds.isNotEmpty)
+      'greetingSeeds': [for (final s in paired.seeds) s?.toJson()],
   };
 }
 

--- a/lib/utils/group_realism_blobs.dart
+++ b/lib/utils/group_realism_blobs.dart
@@ -269,19 +269,24 @@ Map<String, dynamic> _groupOpeningAltsFragment(
 /// Group-level alt openings (custom group first_message only). Stored next
 /// to the scene-time seed on `defaultMemberRealismState` so Group Cards
 /// round-trip without a schema bump — same home as timeOfDay/dayCount.
-List<String> parseGroupAlternateGreetings(String defaultMemberJson) {
-  final raw = _decodeGroupBlob(defaultMemberJson)['alternateGreetings'];
-  if (raw is! List) return const [];
-  return [
-    for (final e in raw)
-      if (e is String && e.trim().isNotEmpty) e,
+({List<String> greetings, List<GreetingRealismSeed?> seeds})
+parseGroupOpeningPairs(String defaultMemberJson) {
+  final map = _decodeGroupBlob(defaultMemberJson);
+  final raw = map['alternateGreetings'];
+  final greets = <String>[
+    if (raw is List)
+      for (final e in raw)
+        if (e is String) e,
   ];
+  return compactGreetingPairs(greets, parseGreetingSeeds(map['greetingSeeds']));
+}
+
+List<String> parseGroupAlternateGreetings(String defaultMemberJson) {
+  return parseGroupOpeningPairs(defaultMemberJson).greetings;
 }
 
 List<GreetingRealismSeed?> parseGroupGreetingSeeds(String defaultMemberJson) {
-  return parseGreetingSeeds(
-    _decodeGroupBlob(defaultMemberJson)['greetingSeeds'],
-  );
+  return parseGroupOpeningPairs(defaultMemberJson).seeds;
 }
 
 /// Patch alt greetings onto an existing group blob without touching perChar

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -142,4 +142,28 @@ void main() {
     expect(back.greetingSeeds.first!.shortTermBond, -40);
     expect(back.greetingSeeds.first!.needsBaselineHunger, 30);
   });
+
+  test('empty overlay inherits every card field including wardrobe', () {
+    const base = GreetingOpeningBase(
+      characterEmotion: 'warm',
+      emotionIntensity: 'mild',
+      shortTermBond: 20,
+      trustLevel: 10,
+      timeOfDay: 'morning',
+      needsBaselineHunger: 80,
+      inventory: {
+        'worn': [
+          {'name': 'flour-dusted apron'},
+        ],
+      },
+    );
+    final resolved = resolveGreetingOpening(base, const GreetingRealismSeed());
+    expect(resolved.characterEmotion, 'warm');
+    expect(resolved.emotionIntensity, 'mild');
+    expect(resolved.shortTermBond, 20);
+    expect(resolved.trustLevel, 10);
+    expect(resolved.timeOfDay, 'morning');
+    expect(resolved.needsBaselineHunger, 80);
+    expect(resolved.inventory, base.inventory);
+  });
 }

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -740,4 +740,37 @@ void main() {
       );
     },
   );
+
+  test(
+    'empty first_mes: displayed 0 is alt[0]/seeds[0], not a null card overlay',
+    () {
+      final warm = GreetingRealismSeed(characterEmotion: 'warm');
+      final furious = GreetingRealismSeed(characterEmotion: 'furious');
+      expect(
+        greetingOverlayAt([warm, furious], 0),
+        isNull,
+        reason: 'first_mes-with-text still uses the card seed',
+      );
+      expect(greetingOverlayAt([warm, furious], 1), warm);
+      expect(
+        greetingOverlayAt([warm, furious], 0, firstMesEmpty: true),
+        warm,
+        reason: 'empty first_mes: Stay. is displayed 0 and reads seeds[0]',
+      );
+      expect(
+        greetingOverlayAt([warm, furious], 1, firstMesEmpty: true),
+        furious,
+        reason: 'empty first_mes: Get out. reads seeds[1], not leftover warm',
+      );
+      expect(
+        greetingHasAuthoredSeed(
+          hasCardExtensions: true,
+          seeds: [warm, furious],
+          greetingIndex: 0,
+          firstMesEmpty: true,
+        ),
+        isTrue,
+      );
+    },
+  );
 }

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -375,6 +375,55 @@ void main() {
   );
 
   test(
+    'frontPorchFromFields pairs dirty empty greet so furious does not land on Get out',
+    () {
+      final back = frontPorchFromFields({
+        'alternateGreetings': ['', 'Get out.'],
+        'greetingSeeds': [
+          {'characterEmotion': 'furious'},
+        ],
+      });
+      expect(
+        back.greetingSeeds,
+        isEmpty,
+        reason: "['', 'Get out.']+[furious] must not load furious onto Get out",
+      );
+      expect(greetingOverlayAt(back.greetingSeeds, 1), isNull);
+    },
+  );
+
+  test(
+    'JSON-null greet slots stay as placeholders so zip keeps furious on Get out',
+    () {
+      final slots = greetingSlotsFromRaw([null, 'Get out.']);
+      expect(slots, ['', 'Get out.']);
+      final paired = compactGreetingPairs(
+        slots,
+        parseGreetingSeeds([
+          null,
+          {'character_emotion': 'furious'},
+        ]),
+      );
+      expect(paired.greetings, ['Get out.']);
+      expect(
+        paired.seeds.single!.characterEmotion,
+        'furious',
+        reason: 'null greet dropped with its null seed; Get out keeps furious',
+      );
+
+      final web = frontPorchFromFields({
+        'alternateGreetings': [null, 'Get out.'],
+        'greetingSeeds': [
+          null,
+          {'characterEmotion': 'furious'},
+        ],
+      });
+      expect(web.greetingSeeds, hasLength(1));
+      expect(web.greetingSeeds.single!.characterEmotion, 'furious');
+    },
+  );
+
+  test(
     'characters.md pins first_mes, skip-RtR, {} vs null, swipe-0, groups 1:1',
     () {
       final md = File('docs/characters.md').readAsStringSync();

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -523,6 +523,26 @@ void main() {
         reason:
             'facade.update omitted seeds must pass empty to compact, not leftover',
       );
+
+      final groups = File(
+        'lib/services/web/facade/group_facade.dart',
+      ).readAsStringSync();
+      final groupCompact = RegExp(
+        r"f\.containsKey\('greetingSeeds'\)\s*"
+        r"\? parseGreetingSeeds\(f\['greetingSeeds'\]\)\s*"
+        r": const \[\],",
+      );
+      expect(
+        groupCompact.hasMatch(groups),
+        isTrue,
+        reason:
+            'group updateSettings omitted seeds must pass empty to compact, not leftover',
+      );
+      expect(
+        RegExp(r': g\.greetingSeeds,').hasMatch(groups),
+        isFalse,
+        reason: 'must not compact alts-only against unpaired existing g.greetingSeeds',
+      );
     },
   );
 

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -610,6 +610,134 @@ void main() {
           .readAsStringSync();
       expect(groups.contains('compactGreetingPairs'), isTrue);
       expect(groups.contains('greetingSlotsFromRaw'), isTrue);
+
+      final enhance = File(
+        'lib/services/chargen/character_gen_enhance.dart',
+      ).readAsStringSync();
+      expect(
+        enhance.contains('assignRewrittenAlternateGreetings'),
+        isTrue,
+        reason: 'enhance must assign rewritten alts via compact-empty, not bare =',
+      );
+      expect(
+        enhance.contains('greetingSeeds: compactRewrittenGreetingAlts'),
+        isTrue,
+        reason:
+            'copyWith after alt rewrite must pass compact-empty/authored seeds',
+      );
+
+      final chargen = File(
+        'lib/services/character_gen_service.dart',
+      ).readAsStringSync();
+      expect(
+        chargen.contains('assignRewrittenAlternateGreetings'),
+        isTrue,
+        reason: 'chargen must assign rewritten alts via compact-empty, not bare =',
+      );
+      expect(
+        chargen.contains('card.alternateGreetings = alts;'),
+        isFalse,
+        reason: 'bare alt assign keeps leftover source seeds',
+      );
+
+      final review = File(
+        'lib/ui/pages/home/enhance/enhance_review_body.dart',
+      ).readAsStringSync();
+      expect(
+        review.contains('ext?.greetingSeeds'),
+        isFalse,
+        reason: 'must not compact accepted greets against leftover copy seeds',
+      );
+      expect(review.contains('compactAcceptedEnhanceGreetings'), isTrue);
+      expect(
+        review.contains(
+          'widget.enhanced.frontPorchExtensions?.greetingSeeds',
+        ),
+        isTrue,
+        reason: 'review must pair against enhance-authored seeds, or empty',
+      );
+    },
+  );
+
+  test(
+    'compactRewrittenGreetingAlts omits leftover furious on Get out',
+    () {
+      final leftover = [angry];
+      final omitted = compactRewrittenGreetingAlts(['Get out.']);
+      expect(omitted.greetings, ['Get out.']);
+      expect(
+        omitted.seeds,
+        isEmpty,
+        reason: "['Get out.'] omit seeds must not reuse unpaired [furious]",
+      );
+      expect(
+        greetingOverlayAt(omitted.seeds, 1),
+        isNull,
+        reason: 'Get out overlay is not leftover furious',
+      );
+      expect(
+        leftover.single!.characterEmotion,
+        'furious',
+        reason: 'source leftover stays on the source list, not the compact',
+      );
+    },
+  );
+
+  test(
+    'compactRewrittenGreetingAlts pairs a seed the enhance step authored',
+    () {
+      final authored = [GreetingRealismSeed(characterEmotion: 'cold')];
+      final paired = compactRewrittenGreetingAlts(['Get out.'], authored);
+      expect(paired.greetings, ['Get out.']);
+      expect(paired.seeds.single!.characterEmotion, 'cold');
+      expect(
+        greetingOverlayAt(paired.seeds, 1)!.characterEmotion,
+        'cold',
+      );
+    },
+  );
+
+  test(
+    'assignRewrittenAlternateGreetings drops leftover source furious on Get out',
+    () {
+      final card = CharacterCard(
+        name: 'Nina',
+        alternateGreetings: ['Stay.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: [angry]),
+      );
+      card.assignRewrittenAlternateGreetings(['Get out.']);
+      expect(card.alternateGreetings, ['Get out.']);
+      expect(
+        card.frontPorchExtensions!.greetingSeeds,
+        isEmpty,
+        reason:
+            "['Get out.'] omit seeds must not reuse unpaired source [furious]",
+      );
+      expect(
+        greetingOverlayAt(card.frontPorchExtensions!.greetingSeeds, 1),
+        isNull,
+        reason: 'Get out overlay is not leftover furious',
+      );
+    },
+  );
+
+  test(
+    'assignRewrittenAlternateGreetings keeps a seed authored with the new alts',
+    () {
+      final card = CharacterCard(
+        name: 'Nina',
+        alternateGreetings: ['Stay.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: [angry]),
+      );
+      card.assignRewrittenAlternateGreetings(
+        ['Get out.'],
+        authoredSeeds: [GreetingRealismSeed(characterEmotion: 'cold')],
+      );
+      expect(card.alternateGreetings, ['Get out.']);
+      expect(
+        card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+        'cold',
+      );
     },
   );
 }

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -393,6 +393,47 @@ void main() {
   );
 
   test(
+    'frontPorchFromFields omitted seeds + dirty alts drop leftover base furious',
+    () {
+      final seeded = FrontPorchExtensions(greetingSeeds: [angry]);
+      final dirty = frontPorchFromFields({
+        'alternateGreetings': ['', 'Get out.'],
+      }, base: seeded);
+      expect(
+        dirty.greetingSeeds,
+        isEmpty,
+        reason:
+            'alts-only POST must compact against empty seeds, not keep unpaired [furious]',
+      );
+      expect(
+        greetingOverlayAt(dirty.greetingSeeds, 1),
+        isNull,
+        reason: 'Get out overlay must not be leftover furious',
+      );
+
+      final clean = frontPorchFromFields({
+        'alternateGreetings': ['Get out.'],
+      }, base: seeded);
+      expect(
+        clean.greetingSeeds,
+        isEmpty,
+        reason: "['Get out.'] omit seeds must not reuse unpaired base [furious]",
+      );
+      expect(greetingOverlayAt(clean.greetingSeeds, 1), isNull);
+
+      final authoredEmpty = frontPorchFromFields({
+        'alternateGreetings': ['', 'Get out.'],
+        'greetingSeeds': [],
+      }, base: seeded);
+      expect(
+        authoredEmpty.greetingSeeds,
+        isEmpty,
+        reason: 'explicit empty greetingSeeds is authored-empty, not keep base',
+      );
+    },
+  );
+
+  test(
     'JSON-null greet slots stay as placeholders so zip keeps furious on Get out',
     () {
       final slots = greetingSlotsFromRaw([null, 'Get out.']);

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -434,6 +434,99 @@ void main() {
   );
 
   test(
+    'frontPorchFromFields explicit empty greetingSeeds stays authored-empty',
+    () {
+      final seeded = FrontPorchExtensions(greetingSeeds: [angry]);
+      final withAlts = frontPorchFromFields({
+        'alternateGreetings': ['', 'Get out.'],
+        'greetingSeeds': [],
+      }, base: seeded);
+      expect(
+        withAlts.greetingSeeds,
+        isEmpty,
+        reason:
+            'explicit empty greetingSeeds is authored-empty, not leftover furious',
+      );
+      expect(greetingOverlayAt(withAlts.greetingSeeds, 1), isNull);
+
+      final noAlts = frontPorchFromFields({
+        'greetingSeeds': [],
+        'trustLevel': 3,
+      }, base: seeded);
+      expect(
+        noAlts.greetingSeeds,
+        isEmpty,
+        reason: 'explicit empty is authored-empty, not dropped as omit',
+      );
+      expect(noAlts.trustLevel, 3);
+    },
+  );
+
+  test(
+    'frontPorchFromFields omitted alts keep base seeds',
+    () {
+      final seeded = FrontPorchExtensions(greetingSeeds: [angry]);
+      final back = frontPorchFromFields({
+        'trustLevel': 5,
+        'realismEnabled': true,
+      }, base: seeded);
+      expect(back.greetingSeeds, hasLength(1));
+      expect(
+        back.greetingSeeds.first!.characterEmotion,
+        'furious',
+        reason: 'omitted alts must not wipe leftover base seeds',
+      );
+      expect(back.trustLevel, 5);
+    },
+  );
+
+  test(
+    'omitted greetingSeeds become empty/null before compact at both call sites',
+    () {
+      final fp = File(
+        'lib/services/web/util/realism_extensions_json.dart',
+      ).readAsStringSync();
+      final omitted = RegExp(
+        r"if \(!fields\.containsKey\('greetingSeeds'\)\) \{([^}]+)\}",
+      ).firstMatch(fp);
+      expect(omitted, isNotNull);
+      final body = omitted!.group(1)!;
+      expect(
+        body.contains('if (!altsPresent) return b.greetingSeeds;'),
+        isTrue,
+        reason: 'omitted alts still keep base seeds',
+      );
+      expect(
+        body.contains('const []'),
+        isTrue,
+        reason: 'omitted seeds + alts compact against empty, not leftover',
+      );
+      expect(body.contains('compactGreetingPairs'), isTrue);
+      expect(
+        RegExp(r'compactGreetingPairs\([^)]*b\.greetingSeeds').hasMatch(body),
+        isFalse,
+        reason: 'must not compact against leftover base seeds',
+      );
+
+      final chars = File(
+        'lib/services/web/facade/character_facade.dart',
+      ).readAsStringSync();
+      final updateCompact = RegExp(
+        r"compactGreetingPairs\(\s*greetingSlotsFromRaw\(greetings\),\s*"
+        r"fields\.containsKey\('greetingSeeds'\)\s*"
+        r"\? parseGreetingSeeds\(fields\['greetingSeeds'\]\)\s*"
+        r": const \[\],",
+      );
+      expect(
+        updateCompact.hasMatch(chars),
+        isTrue,
+        reason:
+            'facade.update omitted seeds must pass empty to compact, not leftover',
+      );
+    },
+  );
+
+  test(
     'JSON-null greet slots stay as placeholders so zip keeps furious on Get out',
     () {
       final slots = greetingSlotsFromRaw([null, 'Get out.']);

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -182,6 +182,19 @@ void main() {
     );
   });
 
+  test('leftover furious on a blank greet row does not land on Get out', () {
+    final furious = GreetingRealismSeed(characterEmotion: 'furious');
+    // Dirty ['', 'Get out.'] + [furious]: blank row drops WITH its seed slot.
+    final paired = compactGreetingPairs(['', 'Get out.'], [furious]);
+    expect(paired.greetings, ['Get out.']);
+    expect(
+      paired.seeds,
+      isEmpty,
+      reason:
+          'furious sat on the blank; unpaired prefix-align would load it onto Get out',
+    );
+  });
+
   test(
     'prefix-align after dropping empty greets is the bug compactGreetingPairs fixes',
     () {
@@ -215,6 +228,47 @@ void main() {
         paired.seeds[1]!.characterEmotion,
         'furious',
         reason: 'blank row must drop with its slot; furious stays on Get out.',
+      );
+    },
+  );
+
+  test(
+    'parseGroupAlternateGreetings and parseGroupGreetingSeeds share compactGreetingPairs',
+    () {
+      final blobs = File(
+        'lib/utils/group_realism_blobs.dart',
+      ).readAsStringSync();
+      final alt = RegExp(
+        r'List<String> parseGroupAlternateGreetings\(String defaultMemberJson\) \{([^}]+)\}',
+      ).firstMatch(blobs);
+      final seeds = RegExp(
+        r'List<GreetingRealismSeed\?> parseGroupGreetingSeeds\(String defaultMemberJson\) \{([^}]+)\}',
+      ).firstMatch(blobs);
+      expect(alt, isNotNull);
+      expect(seeds, isNotNull);
+      expect(
+        alt!.group(1),
+        contains('parseGroupOpeningPairs'),
+        reason: 'alts must not compact greetings without the paired seed slots',
+      );
+      expect(
+        seeds!.group(1),
+        contains('parseGroupOpeningPairs'),
+        reason: 'seeds must not parse greetingSeeds without the paired greets',
+      );
+      expect(
+        blobs.contains(
+          "return compactGreetingPairs(greets, parseGreetingSeeds(map['greetingSeeds']));",
+        ),
+        isTrue,
+        reason: 'the shared helper is the compactGreetingPairs pairing',
+      );
+
+      final group = File('lib/models/group_chat.dart').readAsStringSync();
+      expect(
+        group.contains('compactGreetingPairs'),
+        isTrue,
+        reason: 'GroupChat.fromJson must use the same pairing',
       );
     },
   );

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -438,4 +438,24 @@ void main() {
       );
     },
   );
+
+  test(
+    'web/API call sites pair dirty greets through compactGreetingPairs',
+    () {
+      final fp = File('lib/services/web/util/realism_extensions_json.dart')
+          .readAsStringSync();
+      expect(fp.contains('compactGreetingPairs'), isTrue);
+      expect(fp.contains('greetingSlotsFromRaw'), isTrue);
+
+      final chars = File('lib/services/web/facade/character_facade.dart')
+          .readAsStringSync();
+      expect(chars.contains('compactGreetingPairs'), isTrue);
+      expect(chars.contains('greetingSlotsFromRaw'), isTrue);
+
+      final groups = File('lib/services/web/facade/group_facade.dart')
+          .readAsStringSync();
+      expect(groups.contains('compactGreetingPairs'), isTrue);
+      expect(groups.contains('greetingSlotsFromRaw'), isTrue);
+    },
+  );
 }

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -5,6 +5,8 @@
 // greetingOverlayAt / resolveGreetingOpening existed, an angry alt inherited
 // the friend first_mes seed (or fired reading-the-room and never restored).
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/web/util/util.dart';
@@ -170,10 +172,7 @@ void main() {
   test('compactGreetingPairs drops empty greet rows with their seed slots', () {
     final furious = GreetingRealismSeed(characterEmotion: 'furious');
     // Add / blank / Add / "Get out." / seed furious
-    final paired = compactGreetingPairs(
-      ['', 'Get out.'],
-      [null, furious],
-    );
+    final paired = compactGreetingPairs(['', 'Get out.'], [null, furious]);
     expect(paired.greetings, ['Get out.']);
     expect(paired.seeds, hasLength(1));
     expect(
@@ -183,15 +182,56 @@ void main() {
     );
   });
 
-  test('prefix-align after dropping empty greets is the bug compactGreetingPairs fixes', () {
-    final furious = GreetingRealismSeed(characterEmotion: 'furious');
-    final greets = ['', 'Get out.'];
-    final alts = [for (final g in greets) if (g.trim().isNotEmpty) g];
-    final wrong = alignGreetingSeeds([null, furious], alts.length);
-    expect(
-      wrong.first,
-      isNull,
-      reason: 'old prefix-align drops furious; compactGreetingPairs must not',
-    );
-  });
+  test(
+    'prefix-align after dropping empty greets is the bug compactGreetingPairs fixes',
+    () {
+      final furious = GreetingRealismSeed(characterEmotion: 'furious');
+      final greets = ['', 'Get out.'];
+      final alts = [
+        for (final g in greets)
+          if (g.trim().isNotEmpty) g,
+      ];
+      final wrong = alignGreetingSeeds([null, furious], alts.length);
+      expect(
+        wrong.first,
+        isNull,
+        reason: 'old prefix-align drops furious; compactGreetingPairs must not',
+      );
+    },
+  );
+
+  test(
+    'a blank middle row does not pair its seed with neighboring Get out',
+    () {
+      final furious = GreetingRealismSeed(characterEmotion: 'furious');
+      final paired = compactGreetingPairs(
+        ['Come in.', '', 'Get out.'],
+        [null, GreetingRealismSeed(characterEmotion: 'stolen'), furious],
+      );
+      expect(paired.greetings, ['Come in.', 'Get out.']);
+      expect(paired.seeds, hasLength(2));
+      expect(paired.seeds[0], isNull);
+      expect(
+        paired.seeds[1]!.characterEmotion,
+        'furious',
+        reason: 'blank row must drop with its slot; furious stays on Get out.',
+      );
+    },
+  );
+
+  test(
+    'characters.md pins first_mes, skip-RtR, {} vs null, swipe-0, groups 1:1',
+    () {
+      final md = File('docs/characters.md').readAsStringSync();
+      expect(md.contains('first_mes'), isTrue);
+      expect(md.contains('Reads the Room'), isTrue);
+      expect(md.contains('including empty `{}`'), isTrue);
+      expect(md.contains('Swipe 0'), isTrue);
+      expect(md.contains('Groups match 1:1'), isTrue);
+      expect(
+        md.contains('must not write `{}` just because the seed toggle is on'),
+        isTrue,
+      );
+    },
+  );
 }

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -676,7 +676,7 @@ void main() {
         reason: 'Get out overlay is not leftover furious',
       );
       expect(
-        leftover.single!.characterEmotion,
+        leftover.single.characterEmotion,
         'furious',
         reason: 'source leftover stays on the source list, not the compact',
       );

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -773,4 +773,77 @@ void main() {
       );
     },
   );
+
+  test(
+    'whitespace-only first_mes pairs like empty: displayed 0 is seeds[0]',
+    () {
+      final warm = GreetingRealismSeed(characterEmotion: 'warm');
+      final furious = GreetingRealismSeed(characterEmotion: 'furious');
+      expect(greetingFirstMesEmpty(''), isTrue);
+      expect(greetingFirstMesEmpty('   '), isTrue);
+      expect(greetingFirstMesEmpty('\n'), isTrue);
+      expect(greetingFirstMesEmpty('  \n'), isTrue);
+      expect(greetingFirstMesEmpty('Hello'), isFalse);
+      expect(greetingFirstMesEmpty(' Hello '), isFalse);
+      expect(
+        greetingOverlayAt(
+          [warm, furious],
+          0,
+          firstMesEmpty: greetingFirstMesEmpty('   '),
+        ),
+        warm,
+        reason: "first_mes '   ': Stay. is displayed 0 and reads seeds[0]",
+      );
+      expect(
+        greetingOverlayAt(
+          [warm, furious],
+          1,
+          firstMesEmpty: greetingFirstMesEmpty('   '),
+        ),
+        furious,
+        reason: "first_mes '   ': Get out. reads seeds[1], not leftover warm",
+      );
+    },
+  );
+
+  test('CharacterCard.allGreetings drops whitespace-only first_mes', () {
+    final card = CharacterCard(
+      name: 'Nemu',
+      firstMessage: '   ',
+      alternateGreetings: const ['Stay.', 'Get out.'],
+    );
+    expect(card.allGreetings, ['Stay.', 'Get out.']);
+    expect(
+      CharacterCard(
+        name: 'Nemu',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+      ).allGreetings,
+      ['Hello, friend.', 'Get out.'],
+      reason: 'real non-whitespace first_mes stays displayed 0',
+    );
+  });
+
+  test('GroupChat.allGreetings drops whitespace-only first_mes', () {
+    expect(
+      GroupChat(
+        id: 'g',
+        name: 'House',
+        firstMessage: '   ',
+        alternateGreetings: const ['Stay.', 'Get out.'],
+      ).allGreetings,
+      ['Stay.', 'Get out.'],
+    );
+    expect(
+      GroupChat(
+        id: 'g2',
+        name: 'House',
+        firstMessage: 'Come in.',
+        alternateGreetings: const ['Get out.'],
+      ).allGreetings,
+      ['Come in.', 'Get out.'],
+      reason: 'real non-whitespace group first_mes stays displayed 0',
+    );
+  });
+
 }

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -274,6 +274,44 @@ void main() {
   );
 
   test(
+    'FrontPorchExtensions.fromJson pairs empty-greet drop with compactGreetingPairs',
+    () {
+      final dirty = FrontPorchExtensions.fromJson(
+        {
+          'realism_engine': {
+            'enabled': true,
+            'greeting_seeds': [
+              {'character_emotion': 'furious'},
+            ],
+          },
+        },
+        alternateGreetings: ['', 'Get out.'],
+      );
+      expect(
+        dirty.greetingSeeds,
+        isEmpty,
+        reason: "['', 'Get out.']+[furious] must not load furious onto Get out",
+      );
+      expect(greetingOverlayAt(dirty.greetingSeeds, 1), isNull);
+
+      final kept = FrontPorchExtensions.fromJson(
+        {
+          'realism_engine': {
+            'enabled': true,
+            'greeting_seeds': [
+              null,
+              {'character_emotion': 'furious'},
+            ],
+          },
+        },
+        alternateGreetings: ['', 'Get out.'],
+      );
+      expect(kept.greetingSeeds, hasLength(1));
+      expect(kept.greetingSeeds.first!.characterEmotion, 'furious');
+    },
+  );
+
+  test(
     'characters.md pins first_mes, skip-RtR, {} vs null, swipe-0, groups 1:1',
     () {
       final md = File('docs/characters.md').readAsStringSync();

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -166,4 +166,32 @@ void main() {
     expect(resolved.needsBaselineHunger, 80);
     expect(resolved.inventory, base.inventory);
   });
+
+  test('compactGreetingPairs drops empty greet rows with their seed slots', () {
+    final furious = GreetingRealismSeed(characterEmotion: 'furious');
+    // Add / blank / Add / "Get out." / seed furious
+    final paired = compactGreetingPairs(
+      ['', 'Get out.'],
+      [null, furious],
+    );
+    expect(paired.greetings, ['Get out.']);
+    expect(paired.seeds, hasLength(1));
+    expect(
+      paired.seeds.first!.characterEmotion,
+      'furious',
+      reason: 'furious must stay on Get out., not shift onto the blank row',
+    );
+  });
+
+  test('prefix-align after dropping empty greets is the bug compactGreetingPairs fixes', () {
+    final furious = GreetingRealismSeed(characterEmotion: 'furious');
+    final greets = ['', 'Get out.'];
+    final alts = [for (final g in greets) if (g.trim().isNotEmpty) g];
+    final wrong = alignGreetingSeeds([null, furious], alts.length);
+    expect(
+      wrong.first,
+      isNull,
+      reason: 'old prefix-align drops furious; compactGreetingPairs must not',
+    );
+  });
 }

--- a/test/models/greeting_realism_seed_test.dart
+++ b/test/models/greeting_realism_seed_test.dart
@@ -308,6 +308,69 @@ void main() {
       );
       expect(kept.greetingSeeds, hasLength(1));
       expect(kept.greetingSeeds.first!.characterEmotion, 'furious');
+
+      // Extra: fromJson must call compactGreetingPairs when alts are present.
+      final fromJsonSrc = File('lib/models/character_card.dart').readAsStringSync();
+      expect(
+        fromJsonSrc.contains(
+          'return compactGreetingPairs(alternateGreetings, parsed).seeds;',
+        ),
+        isTrue,
+        reason: '1:1 fromJson pairs through compactGreetingPairs, not prefix-align',
+      );
+    },
+  );
+
+  test(
+    'toJson/fromJson without alts keeps sparse seed holes',
+    () {
+      final ext = FrontPorchExtensions(
+        greetingSeeds: [
+          null,
+          GreetingRealismSeed(characterEmotion: 'furious'),
+          null,
+          const GreetingRealismSeed(),
+        ],
+      );
+      final json = ext.toJson();
+      final seedsJson =
+          (json['realism_engine'] as Map)['greeting_seeds'] as List;
+      expect(
+        seedsJson,
+        hasLength(4),
+        reason: 'toJson must keep internal holes; only trailing nulls compact',
+      );
+      expect(seedsJson[0], isNull);
+      expect(seedsJson[2], isNull);
+
+      final restored = FrontPorchExtensions.fromJson(json);
+      expect(
+        restored.greetingSeeds,
+        hasLength(4),
+        reason: 'no-alts fromJson must not compact-pair holes away',
+      );
+      expect(restored.greetingSeeds[0], isNull);
+      expect(restored.greetingSeeds[1]!.characterEmotion, 'furious');
+      expect(restored.greetingSeeds[2], isNull);
+      expect(restored.greetingSeeds[3], isNotNull);
+      expect(restored.greetingSeeds[3]!.isEmpty, isTrue);
+
+      final emptyAlts = FrontPorchExtensions.fromJson(
+        json,
+        alternateGreetings: const [],
+      );
+      expect(
+        emptyAlts.greetingSeeds,
+        hasLength(4),
+        reason: 'explicit empty alts must still preserve sparse seed holes',
+      );
+      expect(emptyAlts.greetingSeeds[0], isNull);
+      expect(emptyAlts.greetingSeeds[1]!.characterEmotion, 'furious');
+      expect(greetingOverlayAt(emptyAlts.greetingSeeds, 1), isNull);
+      expect(
+        greetingOverlayAt(emptyAlts.greetingSeeds, 2)!.characterEmotion,
+        'furious',
+      );
     },
   );
 

--- a/test/services/chargen/character_gen_alts_seeds_test.dart
+++ b/test/services/chargen/character_gen_alts_seeds_test.dart
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Chargen / enhance alt rewrite must compact against empty when seeds are
+// not authored with the new alts. Leftover source [furious] must not land
+// on Get out.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/models/models.dart';
+
+void main() {
+  final furious = GreetingRealismSeed(characterEmotion: 'furious');
+
+  test(
+    'character_gen_service assign new alts without authored seeds drops leftover furious',
+    () {
+      final card = CharacterCard(
+        name: 'Nina',
+        alternateGreetings: ['Stay.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: [furious]),
+      );
+      // Same assign character_gen_service uses after rewriting alts.
+      card.assignRewrittenAlternateGreetings(['Get out.']);
+      expect(card.alternateGreetings, ['Get out.']);
+      expect(
+        card.frontPorchExtensions!.greetingSeeds,
+        isEmpty,
+        reason:
+            "['Get out.'] omit seeds must not reuse unpaired source [furious]",
+      );
+      expect(
+        greetingOverlayAt(card.frontPorchExtensions!.greetingSeeds, 1),
+        isNull,
+        reason: 'Get out overlay is not leftover furious',
+      );
+    },
+  );
+
+  test(
+    'character_gen_service assign keeps a seed authored with the new alts',
+    () {
+      final card = CharacterCard(
+        name: 'Nina',
+        alternateGreetings: ['Stay.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: [furious]),
+      );
+      card.assignRewrittenAlternateGreetings(
+        ['Get out.'],
+        authoredSeeds: [GreetingRealismSeed(characterEmotion: 'cold')],
+      );
+      expect(card.alternateGreetings, ['Get out.']);
+      expect(
+        card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+        'cold',
+      );
+    },
+  );
+}

--- a/test/services/chargen/character_gen_alts_seeds_test.dart
+++ b/test/services/chargen/character_gen_alts_seeds_test.dart
@@ -5,6 +5,8 @@
 // not authored with the new alts. Leftover source [furious] must not land
 // on Get out.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:front_porch_ai/models/models.dart';
 
@@ -52,6 +54,24 @@ void main() {
       expect(
         card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
         'cold',
+      );
+    },
+  );
+
+  test(
+    'character_gen_service assign call site omits leftover source seeds',
+    () {
+      final src = File('lib/services/character_gen_service.dart')
+          .readAsStringSync();
+      expect(
+        src.contains('card.assignRewrittenAlternateGreetings(alts);'),
+        isTrue,
+        reason: 'chargen must assign rewritten alts via compact-empty',
+      );
+      expect(
+        src.contains('card.alternateGreetings = alts;'),
+        isFalse,
+        reason: 'bare alt assign keeps leftover source seeds',
       );
     },
   );

--- a/test/services/chargen/character_gen_enhance_test.dart
+++ b/test/services/chargen/character_gen_enhance_test.dart
@@ -71,6 +71,9 @@ class _RoutedLlm extends LLMService {
       });
     }
     if (p.contains('Write an opening roleplay message')) {
+      if (p.contains('COMPLETELY DIFFERENT')) {
+        return 'Get out.';
+      }
       return 'The neon buzzed over the empty stools as I counted the till. '
           '"We\'re closed," I said — then saw it was {{user}} at the door.';
     }
@@ -283,4 +286,53 @@ void main() {
     expect(source.personality, 'Original personality of Nina.');
     expect(source.mesExample, contains('original example'));
   });
+
+  test(
+    'greetings rewrite to Get out drops leftover source furious',
+    () async {
+      final llm = _RoutedLlm();
+      final gen = CharacterGenService(llm);
+      final furious = GreetingRealismSeed(characterEmotion: 'furious');
+      final source = CharacterCard(
+        name: 'Nina',
+        description: 'Original description of Nina.',
+        personality: 'Original personality of Nina.',
+        scenario:
+            'Original scenario: a quiet bar after hours, {{user}} walks in.',
+        firstMessage: 'Original first message.',
+        mesExample: '<START>\n{{user}}: hi\n{{char}}: original example',
+        alternateGreetings: ['Stay.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: [furious]),
+      );
+      final result = await gen.enhanceCharacter(
+        source: source,
+        selection: const EnhanceSelection(
+          description: false,
+          personality: false,
+          exampleDialogue: false,
+          greetings: true,
+          porchLife: true,
+        ),
+        chatGrounding: _grounding,
+      );
+      expect(result, isNotNull);
+      expect(result!.alternateGreetings, ['Get out.']);
+      expect(
+        result.frontPorchExtensions!.greetingSeeds,
+        isEmpty,
+        reason:
+            "['Get out.'] omit seeds must not reuse unpaired source [furious]",
+      );
+      expect(
+        greetingOverlayAt(result.frontPorchExtensions!.greetingSeeds, 1),
+        isNull,
+        reason: 'Get out overlay is not leftover furious',
+      );
+      expect(
+        source.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+        'furious',
+        reason: 'source leftover must stay on the original card',
+      );
+    },
+  );
 }

--- a/test/services/chargen/character_gen_enhance_test.dart
+++ b/test/services/chargen/character_gen_enhance_test.dart
@@ -335,4 +335,70 @@ void main() {
       );
     },
   );
+
+  test(
+    'character_gen_enhance copyWith leftover furious does not land on Get out',
+    () {
+      final leftover = GreetingRealismSeed(characterEmotion: 'furious');
+      final sourceExt = FrontPorchExtensions(greetingSeeds: [leftover]);
+      final card = CharacterCard(
+        name: 'Nina',
+        alternateGreetings: ['Get out.'],
+      );
+      expect(
+        sourceExt.copyWith().greetingSeeds.single!.characterEmotion,
+        'furious',
+        reason: 'bare copyWith keeps leftover source [furious]',
+      );
+      card.frontPorchExtensions = sourceExt.copyWith(
+        greetingSeeds: compactRewrittenGreetingAlts(
+          card.alternateGreetings,
+          card.frontPorchExtensions?.greetingSeeds,
+        ).seeds,
+      );
+      expect(card.alternateGreetings, ['Get out.']);
+      expect(
+        card.frontPorchExtensions!.greetingSeeds,
+        isEmpty,
+        reason:
+            "copyWith(['Get out.'], omit seeds) must not load leftover [furious]",
+      );
+      expect(
+        greetingOverlayAt(card.frontPorchExtensions!.greetingSeeds, 1),
+        isNull,
+        reason: 'Get out overlay is not leftover furious',
+      );
+      expect(leftover.characterEmotion, 'furious');
+    },
+  );
+
+  test(
+    'character_gen_enhance copyWith authored seeds still pair on Get out',
+    () {
+      final leftover = GreetingRealismSeed(characterEmotion: 'furious');
+      final sourceExt = FrontPorchExtensions(greetingSeeds: [leftover]);
+      final authored = [GreetingRealismSeed(characterEmotion: 'cold')];
+      final card = CharacterCard(
+        name: 'Nina',
+        alternateGreetings: ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: authored),
+      );
+      card.frontPorchExtensions = sourceExt.copyWith(
+        greetingSeeds: compactRewrittenGreetingAlts(
+          card.alternateGreetings,
+          card.frontPorchExtensions?.greetingSeeds,
+        ).seeds,
+      );
+      expect(card.alternateGreetings, ['Get out.']);
+      expect(
+        card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+        'cold',
+      );
+      expect(
+        greetingOverlayAt(card.frontPorchExtensions!.greetingSeeds, 1)!
+            .characterEmotion,
+        'cold',
+      );
+    },
+  );
 }

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -1298,6 +1298,84 @@ void main() {
   );
 
   test(
+    'loadSession after delayed unauthored alt: fury must not paint loaded first_mes',
+    () async {
+      final llm = _PhasedGreetingLlm();
+      chat.testLlmServiceOverride = llm;
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-load-stale',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_load.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      final nemu = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_load.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: const [null],
+        ),
+      )..dbId = 'char-load-stale';
+      await chat.setActiveCharacter(nemu);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.messages.first.text, 'Hello, friend.');
+      final openingSessionId = chat.currentSessionId!;
+
+      await chat.startNewChat();
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.currentSessionId, isNot(openingSessionId));
+
+      llm.delay = const Duration(milliseconds: 180);
+      llm.payload = '{"emotion":"furious","emotion_intensity":"strong"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        testPostGreetingEvalEntered,
+        isTrue,
+        reason: 'unauthored alt must start eval so a stale future exists',
+      );
+
+      await chat.loadSession(openingSessionId);
+      expect(chat.greetingIndex, 0);
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+
+      await Future<void>.delayed(const Duration(milliseconds: 360));
+
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason:
+            'delayed eval-1 must not paint fury onto loadSession first_mes',
+      );
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+    },
+  );
+
+  test(
     'group blank first_mes + member empty first_mes opens Stay. with warm overlay',
     () async {
       final warm = GreetingRealismSeed(

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -42,6 +42,29 @@ class _DelayedStompLlm extends LLMService {
   String get backendName => 'DelayedStompLlm';
 }
 
+/// Captures delay + payload at stream start so a later swipe can change
+/// the next eval without rewriting an already-started one.
+class _PhasedGreetingLlm extends LLMService {
+  Duration delay = Duration.zero;
+  String payload = '{"emotion":"curious","emotion_intensity":"mild"}';
+
+  @override
+  Stream<String> generateStream(GenerationParams params) async* {
+    final wait = delay;
+    final body = payload;
+    if (wait > Duration.zero) {
+      await Future<void>.delayed(wait);
+    }
+    yield body;
+  }
+
+  @override
+  bool get isReady => true;
+
+  @override
+  String get backendName => 'PhasedGreetingLlm';
+}
+
 void _setupPathProviderMock() {
   const channel = MethodChannel('plugins.flutter.io/path_provider');
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -696,6 +719,253 @@ void main() {
       expect(chat.timeService.timeOfDay, 'morning');
       expect(chat.needsSimulation.vector['hunger'], 80);
       expect(chat.messages.first.text, 'Hello, friend.');
+    },
+  );
+
+  test(
+    'second unauthored alt then swipe 0: delayed eval-1 must not paint fury on first_mes',
+    () async {
+      final llm = _PhasedGreetingLlm();
+      chat.testLlmServiceOverride = llm;
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-two-eval',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_two.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out.","Who are you?"]'),
+        ),
+      );
+      final card = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_two.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.', 'Who are you?'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: const [null, null],
+        ),
+      )..dbId = 'char-two-eval';
+      await chat.setActiveCharacter(card);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.greetingIndex, 0);
+
+      llm.delay = const Duration(milliseconds: 180);
+      llm.payload = '{"emotion":"furious","emotion_intensity":"strong"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(testPostGreetingEvalEntered, isTrue);
+
+      llm.delay = Duration.zero;
+      llm.payload = '{"emotion":"curious","emotion_intensity":"mild"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(2);
+      expect(chat.greetingIndex, 2);
+      expect(chat.messages.first.text, 'Who are you?');
+      expect(testPostGreetingEvalEntered, isTrue);
+
+      await chat.selectGreeting(0);
+      expect(chat.greetingIndex, 0);
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+
+      await Future<void>.delayed(const Duration(milliseconds: 360));
+
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason:
+            'delayed eval-1 must not paint fury onto swipe-0 first_mes after eval-2 finally-nulls the global token',
+      );
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+      expect(chat.messages.first.text, 'Hello, friend.');
+    },
+  );
+
+  test(
+    'group custom unauthored alt persists RtR through first-speaker reload',
+    () async {
+      chat.testLlmServiceOverride = _PhasedGreetingLlm()
+        ..payload = '{"emotion":"curious","emotion_intensity":"mild"}';
+      final angry = GreetingRealismSeed(
+        characterEmotion: 'furious',
+        emotionIntensity: 'strong',
+      );
+      final blobs = buildGroupRealismBlobs(
+        seeds: {
+          'mem-a': defaultGroupMemberRealismSeed(),
+          'mem-b': defaultGroupMemberRealismSeed(),
+        },
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+        alternateGreetings: const [
+          'Get out of my house.',
+          'Same room.',
+          'Who are you?',
+        ],
+        greetingSeeds: [angry, const GreetingRealismSeed(), null],
+      );
+      await db.insertGroup(
+        GroupsCompanion.insert(
+          id: 'grp-rtr-persist',
+          name: 'The House',
+          firstMessage: const Value('Come in, friends.'),
+          defaultMemberRealismState: Value(blobs.defaultMemberJson),
+          baselineRealismState: Value(blobs.baselineJson),
+        ),
+      );
+      for (final m in [('mem-a', 'Ana'), ('mem-b', 'Bea')]) {
+        await db.insertGroupMember(
+          GroupMembersCompanion.insert(
+            id: m.$1,
+            groupId: 'grp-rtr-persist',
+            name: m.$2,
+            firstMessage: const Value('Hi.'),
+          ),
+        );
+      }
+      final group = GroupChat(
+        id: 'grp-rtr-persist',
+        name: 'The House',
+        firstMessage: 'Come in, friends.',
+        alternateGreetings: const [
+          'Get out of my house.',
+          'Same room.',
+          'Who are you?',
+        ],
+        greetingSeeds: [angry, const GreetingRealismSeed(), null],
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await chat.setActiveGroup(
+        group,
+        groupRepo: GroupChatRepository(storage, db),
+      );
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.characterEmotion, 'furious');
+      expect(testPostGreetingEvalEntered, isFalse);
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(2);
+      expect(testPostGreetingEvalEntered, isFalse);
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(3);
+      expect(chat.greetingIndex, 3);
+      expect(chat.messages.first.text, 'Who are you?');
+      expect(testPostGreetingEvalEntered, isTrue);
+
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (chat.isProcessingGreeting && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      expect(chat.isProcessingGreeting, isFalse);
+
+      expect(
+        chat.characterEmotion,
+        'curious',
+        reason: 'unauthored group alt must keep the RtR result on live scalars',
+      );
+      final firstId = chat.characterIdFor(chat.groupCharacters.first);
+      expect(
+        chat.debugGroupSlotEmotion(firstId),
+        'curious',
+        reason: 'eval must be written back into the member slot, not inherit',
+      );
+
+      chat.debugReloadFirstGroupSpeakerScalars();
+      expect(
+        chat.characterEmotion,
+        'curious',
+        reason:
+            'first-speaker reload must not throw RtR away for inherit baseline',
+      );
+    },
+  );
+
+  test(
+    'empty first_mes pairs Stay./Get out. with warm/furious, no leftover warm',
+    () async {
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-empty-first',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_empty.png'),
+          firstMessage: const Value(''),
+          alternateGreetings: const Value('["Stay.","Get out."]'),
+        ),
+      );
+      final card = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_empty.png',
+        firstMessage: '',
+        alternateGreetings: const ['Stay.', 'Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'lonely',
+          emotionIntensity: 'mild',
+          shortTermBond: 5,
+          trustLevel: 5,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: [
+            GreetingRealismSeed(
+              characterEmotion: 'warm',
+              emotionIntensity: 'mild',
+              shortTermBond: 20,
+            ),
+            GreetingRealismSeed(
+              characterEmotion: 'furious',
+              emotionIntensity: 'strong',
+              shortTermBond: -40,
+            ),
+          ],
+        ),
+      )..dbId = 'char-empty-first';
+      await chat.setActiveCharacter(card);
+
+      expect(chat.openingAllGreetings, ['Stay.', 'Get out.']);
+      expect(chat.messages, isNotEmpty);
+      expect(chat.messages.first.text, 'Stay.');
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason: 'empty first_mes: displayed 0 is alt[0] and overlay is seeds[0]',
+      );
+      expect(chat.relationshipService.affectionScore, 20);
+
+      await chat.selectGreeting(1);
+
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        chat.characterEmotion,
+        'furious',
+        reason: 'Get out. must read seeds[1], not leftover warm from seeds[0]',
+      );
+      expect(chat.characterEmotion, isNot('warm'));
+      expect(chat.relationshipService.affectionScore, -40);
     },
   );
 }

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -18,12 +18,29 @@ import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/character_repository.dart';
 import 'package:front_porch_ai/services/chat/chat.dart' show Pockets;
 import 'package:front_porch_ai/services/chat_service.dart';
+import 'package:front_porch_ai/services/group_card_importer.dart';
 import 'package:front_porch_ai/services/group_chat_repository.dart';
 import 'package:front_porch_ai/services/kobold_service.dart';
+import 'package:front_porch_ai/services/llm_service.dart';
 import 'package:front_porch_ai/services/storage_service.dart';
 import 'package:front_porch_ai/services/user_persona_service.dart';
 import 'package:front_porch_ai/services/world_repository.dart';
 import 'package:front_porch_ai/utils/group_realism_blobs.dart';
+
+/// Delayed eval payload that would stomp first_mes if a stale future applied.
+class _DelayedStompLlm extends LLMService {
+  @override
+  Stream<String> generateStream(GenerationParams params) async* {
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    yield '{"emotion":"ecstatic","emotion_intensity":"strong"}';
+  }
+
+  @override
+  bool get isReady => true;
+
+  @override
+  String get backendName => 'DelayedStompLlm';
+}
 
 void _setupPathProviderMock() {
   const channel = MethodChannel('plugins.flutter.io/path_provider');
@@ -285,7 +302,10 @@ void main() {
       await chat.setActiveCharacter(card);
 
       expect(chat.characterEmotion, 'warm');
-      expect(livePockets()!.worn.map((i) => i.name), contains('flour-dusted apron'));
+      expect(
+        livePockets()!.worn.map((i) => i.name),
+        contains('flour-dusted apron'),
+      );
       expect(livePockets()!.carrying.map((i) => i.name), contains('shop keys'));
 
       await chat.selectGreeting(1);
@@ -294,9 +314,18 @@ void main() {
       expect(chat.relationshipService.affectionScore, -40);
       expect(chat.needsSimulation.vector['hunger'], 25);
       expect(chat.timeService.timeOfDay, 'night');
-      expect(livePockets()!.worn.map((i) => i.name), contains('rain-soaked coat'));
-      expect(livePockets()!.carrying.map((i) => i.name), contains('house keys'));
-      expect(livePockets()!.worn.map((i) => i.name), isNot(contains('flour-dusted apron')));
+      expect(
+        livePockets()!.worn.map((i) => i.name),
+        contains('rain-soaked coat'),
+      );
+      expect(
+        livePockets()!.carrying.map((i) => i.name),
+        contains('house keys'),
+      );
+      expect(
+        livePockets()!.worn.map((i) => i.name),
+        isNot(contains('flour-dusted apron')),
+      );
 
       await chat.selectGreeting(0);
 
@@ -304,75 +333,77 @@ void main() {
       expect(chat.relationshipService.affectionScore, 20);
       expect(chat.needsSimulation.vector['hunger'], 80);
       expect(chat.timeService.timeOfDay, 'morning');
-      expect(livePockets()!.worn.map((i) => i.name), contains('flour-dusted apron'));
+      expect(
+        livePockets()!.worn.map((i) => i.name),
+        contains('flour-dusted apron'),
+      );
       expect(livePockets()!.carrying.map((i) => i.name), contains('shop keys'));
     },
   );
 
-  test(
-    'empty authored overlay does not wipe the card seed',
-    () async {
-      final cardOutfit = Pockets.cardJsonFrom(
-        worn: const ['flour-dusted apron (well-worn)'],
-        carrying: const ['shop keys'],
-      );
-      await db.insertCharacter(
-        CharactersCompanion.insert(
-          id: 'char-empty',
-          name: 'Nemu',
-          imagePath: const Value('/tmp/Nemu_e.png'),
-          firstMessage: const Value('Hello, friend.'),
-          alternateGreetings: const Value('["Get out."]'),
-        ),
-      );
-      final card = CharacterCard(
+  test('empty authored overlay does not wipe the card seed', () async {
+    final cardOutfit = Pockets.cardJsonFrom(
+      worn: const ['flour-dusted apron (well-worn)'],
+      carrying: const ['shop keys'],
+    );
+    await db.insertCharacter(
+      CharactersCompanion.insert(
+        id: 'char-empty',
         name: 'Nemu',
-        imagePath: '/tmp/Nemu_e.png',
-        firstMessage: 'Hello, friend.',
-        alternateGreetings: const ['Get out.'],
-        frontPorchExtensions: FrontPorchExtensions(
-          realismEnabled: true,
-          characterEmotion: 'warm',
-          emotionIntensity: 'mild',
-          shortTermBond: 20,
-          trustLevel: 10,
-          timeOfDay: 'morning',
-          needsSimEnabled: true,
-          needsBaselineHunger: 80,
-          inventory: cardOutfit,
-          greetingSeeds: const [GreetingRealismSeed()],
-        ),
-      )..dbId = 'char-empty';
-      await chat.setActiveCharacter(card);
+        imagePath: const Value('/tmp/Nemu_e.png'),
+        firstMessage: const Value('Hello, friend.'),
+        alternateGreetings: const Value('["Get out."]'),
+      ),
+    );
+    final card = CharacterCard(
+      name: 'Nemu',
+      imagePath: '/tmp/Nemu_e.png',
+      firstMessage: 'Hello, friend.',
+      alternateGreetings: const ['Get out.'],
+      frontPorchExtensions: FrontPorchExtensions(
+        realismEnabled: true,
+        characterEmotion: 'warm',
+        emotionIntensity: 'mild',
+        shortTermBond: 20,
+        trustLevel: 10,
+        timeOfDay: 'morning',
+        needsSimEnabled: true,
+        needsBaselineHunger: 80,
+        inventory: cardOutfit,
+        greetingSeeds: const [GreetingRealismSeed()],
+      ),
+    )..dbId = 'char-empty';
+    await chat.setActiveCharacter(card);
 
-      expect(chat.characterEmotion, 'warm');
-      expect(chat.relationshipService.affectionScore, 20);
-      expect(chat.relationshipService.trustLevel, 10);
-      expect(chat.timeService.timeOfDay, 'morning');
-      expect(chat.needsSimulation.vector['hunger'], 80);
-      expect(livePockets()!.worn.map((i) => i.name), contains('flour-dusted apron'));
+    expect(chat.characterEmotion, 'warm');
+    expect(chat.relationshipService.affectionScore, 20);
+    expect(chat.relationshipService.trustLevel, 10);
+    expect(chat.timeService.timeOfDay, 'morning');
+    expect(chat.needsSimulation.vector['hunger'], 80);
+    expect(
+      livePockets()!.worn.map((i) => i.name),
+      contains('flour-dusted apron'),
+    );
 
-      await chat.selectGreeting(1);
+    await chat.selectGreeting(1);
 
-      expect(chat.greetingIndex, 1);
-      expect(chat.messages.first.text, 'Get out.');
-      expect(
-        chat.characterEmotion,
-        'warm',
-        reason: 'empty {} overlay must inherit, not mute-wipe emotion',
-      );
-      expect(chat.relationshipService.affectionScore, 20);
-      expect(chat.relationshipService.trustLevel, 10);
-      expect(chat.timeService.timeOfDay, 'morning');
-      expect(chat.needsSimulation.vector['hunger'], 80);
-      expect(
-        livePockets()!.worn.map((i) => i.name),
-        contains('flour-dusted apron'),
-        reason: 'empty overlay must not strip the card wardrobe',
-      );
-    },
-  );
-
+    expect(chat.greetingIndex, 1);
+    expect(chat.messages.first.text, 'Get out.');
+    expect(
+      chat.characterEmotion,
+      'warm',
+      reason: 'empty {} overlay must inherit, not mute-wipe emotion',
+    );
+    expect(chat.relationshipService.affectionScore, 20);
+    expect(chat.relationshipService.trustLevel, 10);
+    expect(chat.timeService.timeOfDay, 'morning');
+    expect(chat.needsSimulation.vector['hunger'], 80);
+    expect(
+      livePockets()!.worn.map((i) => i.name),
+      contains('flour-dusted apron'),
+      reason: 'empty overlay must not strip the card wardrobe',
+    );
+  });
 
   test(
     'group import/save with empty lists keeps blob angry alt+seed',
@@ -434,16 +465,13 @@ void main() {
       group.alternateGreetings = ['Get out.'];
       group.greetingSeeds = [angry];
       await repo.save(group);
-      expect(
-        group.alternateGreetings,
-        ['Get out.'],
-        reason: 'same object, no reload',
-      );
+      expect(group.alternateGreetings, [
+        'Get out.',
+      ], reason: 'same object, no reload');
       expect(group.greetingSeeds.first!.characterEmotion, 'furious');
-      expect(
-        parseGroupAlternateGreetings(group.defaultMemberRealismState),
-        ['Get out.'],
-      );
+      expect(parseGroupAlternateGreetings(group.defaultMemberRealismState), [
+        'Get out.',
+      ]);
       expect(
         repo.getById('grp-mem-patch')!.greetingSeeds.first!.characterEmotion,
         'furious',
@@ -452,7 +480,7 @@ void main() {
   );
 
   test(
-    'unauthored group custom alt reaches RtR; authored furious skips',
+    'unauthored group custom alt reaches RtR; authored furious and {} skip',
     () async {
       final angry = GreetingRealismSeed(
         characterEmotion: 'furious',
@@ -466,8 +494,12 @@ void main() {
         needsEnabled: true,
         timeOfDay: 'morning',
         dayCount: 1,
-        alternateGreetings: const ['Get out of my house.', 'Who are you?'],
-        greetingSeeds: [angry, null],
+        alternateGreetings: const [
+          'Get out of my house.',
+          'Same room.',
+          'Who are you?',
+        ],
+        greetingSeeds: [angry, const GreetingRealismSeed(), null],
       );
       await db.insertGroup(
         GroupsCompanion.insert(
@@ -492,8 +524,12 @@ void main() {
         id: 'grp-rtr',
         name: 'The House',
         firstMessage: 'Come in, friends.',
-        alternateGreetings: const ['Get out of my house.', 'Who are you?'],
-        greetingSeeds: [angry, null],
+        alternateGreetings: const [
+          'Get out of my house.',
+          'Same room.',
+          'Who are you?',
+        ],
+        greetingSeeds: [angry, const GreetingRealismSeed(), null],
         defaultMemberRealismState: blobs.defaultMemberJson,
         baselineRealismState: blobs.baselineJson,
       );
@@ -514,17 +550,152 @@ void main() {
       testPostGreetingEvalEntered = false;
       await chat.selectGreeting(2);
       expect(chat.greetingIndex, 2);
+      expect(chat.messages.first.text, 'Same room.');
+      expect(
+        testPostGreetingEvalEntered,
+        isFalse,
+        reason: 'authored empty {} overlay must skip RtR',
+      );
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(3);
+      expect(chat.greetingIndex, 3);
       expect(chat.messages.first.text, 'Who are you?');
       expect(
         testPostGreetingEvalEntered,
         isTrue,
-        reason: 'unauthored group alt must reach eval, not skip for null _activeCharacter',
+        reason:
+            'unauthored group alt must reach eval, not skip for null _activeCharacter',
       );
 
       await chat.selectGreeting(0);
       expect(chat.greetingIndex, 0);
       expect(chat.messages.first.text, 'Come in, friends.');
       expect(chat.timeService.timeOfDay, 'morning');
+    },
+  );
+
+  test(
+    'GroupCardImporter construct+save+reload keeps alts and seeds on the blob',
+    () async {
+      final angry = GreetingRealismSeed(
+        characterEmotion: 'furious',
+        emotionIntensity: 'strong',
+        shortTermBond: -40,
+      );
+      final blobs = buildGroupRealismBlobs(
+        seeds: {'ana': defaultGroupMemberRealismSeed()},
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+        alternateGreetings: const ['Get out.'],
+        greetingSeeds: [angry],
+      );
+      final card = GroupCard(
+        name: 'Imported House',
+        members: [CharacterCard(name: 'Ana', firstMessage: 'Hi.')],
+        turnOrder: 'roundRobin',
+        firstMessage: 'Come in.',
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      final repo = GroupChatRepository(storage, db);
+      final result = await GroupCardImporter(
+        repo,
+        storage,
+        db,
+      ).importCard(card);
+      expect(
+        result.created,
+        isTrue,
+        reason: 'importer must materialize the group',
+      );
+      expect(result.successCount, greaterThan(0));
+      await repo.reload();
+      final loaded = repo.groups.singleWhere((g) => g.name == 'Imported House');
+      expect(loaded.alternateGreetings, ['Get out.']);
+      expect(loaded.greetingSeeds, isNotEmpty);
+      expect(loaded.greetingSeeds.first!.characterEmotion, 'furious');
+      expect(loaded.greetingSeeds.first!.shortTermBond, -40);
+      expect(parseGroupAlternateGreetings(loaded.defaultMemberRealismState), [
+        'Get out.',
+      ]);
+      expect(
+        parseGroupGreetingSeeds(
+          loaded.defaultMemberRealismState,
+        ).first!.characterEmotion,
+        'furious',
+      );
+    },
+  );
+
+  test(
+    'selectGreeting ignores a stale eval; swipe 0 still restores first_mes',
+    () async {
+      chat.testLlmServiceOverride = _DelayedStompLlm();
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-stale',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_stale.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      final card = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_stale.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: const [null],
+        ),
+      )..dbId = 'char-stale';
+      await chat.setActiveCharacter(card);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.greetingIndex, 0);
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        testPostGreetingEvalEntered,
+        isTrue,
+        reason: 'unauthored alt 1 must start eval so a stale future exists',
+      );
+
+      await chat.selectGreeting(0);
+      expect(chat.greetingIndex, 0);
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+
+      await Future<void>.delayed(const Duration(milliseconds: 280));
+
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason: 'stale eval must not apply ecstatic over swipe-0 first_mes',
+      );
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+      expect(chat.messages.first.text, 'Hello, friend.');
     },
   );
 }

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -8,6 +8,7 @@
 
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter/services.dart';
@@ -1458,6 +1459,89 @@ void main() {
         'warm',
         reason: 'New Chat must re-apply Stay./warm, not open empty',
       );
+    },
+  );
+
+  test(
+    'importChatPackage after delayed unauthored alt: fury must not paint imported first_mes',
+    () async {
+      final llm = _PhasedGreetingLlm();
+      chat.testLlmServiceOverride = llm;
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-import-stale',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_import.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      final nemu = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_import.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: const [null],
+        ),
+      )..dbId = 'char-import-stale';
+      await chat.setActiveCharacter(nemu);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.messages.first.text, 'Hello, friend.');
+
+      llm.delay = const Duration(milliseconds: 180);
+      llm.payload = '{"emotion":"furious","emotion_intensity":"strong"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        testPostGreetingEvalEntered,
+        isTrue,
+        reason: 'unauthored alt must start eval so a stale future exists',
+      );
+
+      final outcome = await chat.importChatPackage(
+        Uint8List.fromList(
+          utf8.encode(
+            jsonEncode({
+              'messages': [
+                {'name': 'Nemu', 'is_user': false, 'mes': 'Hello, friend.'},
+              ],
+            }),
+          ),
+        ),
+      );
+      expect(outcome.fullRestore, isFalse);
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+
+      await Future<void>.delayed(const Duration(milliseconds: 360));
+
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason:
+            'delayed eval-1 must not paint fury onto importChatPackage first_mes',
+      );
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
     },
   );
 }

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -16,6 +16,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:front_porch_ai/database/database.dart';
 import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/character_repository.dart';
+import 'package:front_porch_ai/services/chat/chat.dart' show Pockets;
 import 'package:front_porch_ai/services/chat_service.dart';
 import 'package:front_porch_ai/services/group_chat_repository.dart';
 import 'package:front_porch_ai/services/kobold_service.dart';
@@ -52,7 +53,8 @@ void main() {
     chat = ChatService(KoboldService(storage), personas, storage, worlds)
       ..setDatabase(db)
       ..setCharacterRepository(CharacterRepository(db, storage));
-    await Future<void>.delayed(const Duration(milliseconds: 50));
+    await storage.initialized;
+    await storage.realismSettings.setPocketsEnabled(true);
   });
 
   tearDown(() async {
@@ -214,6 +216,151 @@ void main() {
       expect(chat.messages.first.text, 'Get out of my house.');
       expect(chat.timeService.timeOfDay, 'night');
       expect(chat.characterEmotion, 'furious');
+    },
+  );
+
+  Pockets? livePockets() {
+    final c = chat.activeCharacter;
+    if (c == null) return null;
+    return chat.pocketsFor(chat.characterIdFor(c));
+  }
+
+  test(
+    'angry alt overlays wardrobe; swipe 0 restores the card outfit',
+    () async {
+      final cardOutfit = Pockets.cardJsonFrom(
+        worn: const ['flour-dusted apron (well-worn)'],
+        carrying: const ['shop keys'],
+      );
+      final altOutfit = Pockets.cardJsonFrom(
+        worn: const ['rain-soaked coat'],
+        carrying: const ['house keys'],
+      );
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-wardrobe',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_w.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      final card = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_w.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          inventory: cardOutfit,
+          greetingSeeds: [
+            GreetingRealismSeed(
+              characterEmotion: 'furious',
+              emotionIntensity: 'strong',
+              shortTermBond: -40,
+              trustLevel: -25,
+              timeOfDay: 'night',
+              needsBaselineHunger: 25,
+              inventory: altOutfit,
+            ),
+          ],
+        ),
+      )..dbId = 'char-wardrobe';
+      await chat.setActiveCharacter(card);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(livePockets()!.worn.map((i) => i.name), contains('flour-dusted apron'));
+      expect(livePockets()!.carrying.map((i) => i.name), contains('shop keys'));
+
+      await chat.selectGreeting(1);
+
+      expect(chat.characterEmotion, 'furious');
+      expect(chat.relationshipService.affectionScore, -40);
+      expect(chat.needsSimulation.vector['hunger'], 25);
+      expect(chat.timeService.timeOfDay, 'night');
+      expect(livePockets()!.worn.map((i) => i.name), contains('rain-soaked coat'));
+      expect(livePockets()!.carrying.map((i) => i.name), contains('house keys'));
+      expect(livePockets()!.worn.map((i) => i.name), isNot(contains('flour-dusted apron')));
+
+      await chat.selectGreeting(0);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.needsSimulation.vector['hunger'], 80);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(livePockets()!.worn.map((i) => i.name), contains('flour-dusted apron'));
+      expect(livePockets()!.carrying.map((i) => i.name), contains('shop keys'));
+    },
+  );
+
+  test(
+    'empty authored overlay does not wipe the card seed',
+    () async {
+      final cardOutfit = Pockets.cardJsonFrom(
+        worn: const ['flour-dusted apron (well-worn)'],
+        carrying: const ['shop keys'],
+      );
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-empty',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_e.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      final card = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_e.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          inventory: cardOutfit,
+          greetingSeeds: const [GreetingRealismSeed()],
+        ),
+      )..dbId = 'char-empty';
+      await chat.setActiveCharacter(card);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+      expect(livePockets()!.worn.map((i) => i.name), contains('flour-dusted apron'));
+
+      await chat.selectGreeting(1);
+
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason: 'empty {} overlay must inherit, not mute-wipe emotion',
+      );
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+      expect(
+        livePockets()!.worn.map((i) => i.name),
+        contains('flour-dusted apron'),
+        reason: 'empty overlay must not strip the card wardrobe',
+      );
     },
   );
 }

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -951,7 +951,8 @@ void main() {
       expect(
         chat.characterEmotion,
         'warm',
-        reason: 'empty first_mes: displayed 0 is alt[0] and overlay is seeds[0]',
+        reason:
+            'empty first_mes: displayed 0 is alt[0] and overlay is seeds[0]',
       );
       expect(chat.relationshipService.affectionScore, 20);
 
@@ -966,6 +967,170 @@ void main() {
       );
       expect(chat.characterEmotion, isNot('warm'));
       expect(chat.relationshipService.affectionScore, -40);
+    },
+  );
+
+  test(
+    "whitespace first_mes '   ' pairs Stay./warm and Get out./furious",
+    () async {
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-ws-first',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_ws.png'),
+          firstMessage: const Value('   '),
+          alternateGreetings: const Value('["Stay.","Get out."]'),
+        ),
+      );
+      final card = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_ws.png',
+        firstMessage: '   ',
+        alternateGreetings: const ['Stay.', 'Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'lonely',
+          emotionIntensity: 'mild',
+          shortTermBond: 5,
+          trustLevel: 5,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: [
+            GreetingRealismSeed(
+              characterEmotion: 'warm',
+              emotionIntensity: 'mild',
+              shortTermBond: 20,
+            ),
+            GreetingRealismSeed(
+              characterEmotion: 'furious',
+              emotionIntensity: 'strong',
+              shortTermBond: -40,
+            ),
+          ],
+        ),
+      )..dbId = 'char-ws-first';
+      await chat.setActiveCharacter(card);
+
+      expect(chat.openingAllGreetings, ['Stay.', 'Get out.']);
+      expect(chat.messages, isNotEmpty);
+      expect(chat.messages.first.text, 'Stay.');
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason:
+            "first_mes '   ': displayed 0 is alt[0] and overlay is seeds[0]",
+      );
+      expect(chat.relationshipService.affectionScore, 20);
+
+      await chat.selectGreeting(1);
+
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        chat.characterEmotion,
+        'furious',
+        reason: 'Get out. must read seeds[1], not leftover warm from seeds[0]',
+      );
+      expect(chat.characterEmotion, isNot('warm'));
+      expect(chat.relationshipService.affectionScore, -40);
+    },
+  );
+
+  test(
+    'member-greet unauthored RtR write-back persists eval into the whole cast',
+    () async {
+      chat.testLlmServiceOverride = _PhasedGreetingLlm()
+        ..payload = '{"emotion":"curious","emotion_intensity":"mild"}';
+      final blobs = buildGroupRealismBlobs(
+        seeds: {
+          'mem-a': defaultGroupMemberRealismSeed(),
+          'mem-b': defaultGroupMemberRealismSeed(),
+        },
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+      );
+      await db.insertGroup(
+        GroupsCompanion.insert(
+          id: 'grp-member-rtr',
+          name: 'The House',
+          firstMessage: const Value(''),
+          defaultMemberRealismState: Value(blobs.defaultMemberJson),
+          baselineRealismState: Value(blobs.baselineJson),
+        ),
+      );
+      await db.insertGroupMember(
+        GroupMembersCompanion.insert(
+          id: 'mem-a',
+          groupId: 'grp-member-rtr',
+          name: 'Ana',
+          firstMessage: const Value('Hi.'),
+          alternateGreetings: const Value('["Who are you?"]'),
+        ),
+      );
+      await db.insertGroupMember(
+        GroupMembersCompanion.insert(
+          id: 'mem-b',
+          groupId: 'grp-member-rtr',
+          name: 'Bea',
+          firstMessage: const Value('Hey.'),
+        ),
+      );
+      final group = GroupChat(
+        id: 'grp-member-rtr',
+        name: 'The House',
+        firstMessage: '',
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await chat.setActiveGroup(
+        group,
+        groupRepo: GroupChatRepository(storage, db),
+      );
+
+      expect(chat.messages, isNotEmpty);
+      expect(chat.messages.first.text, 'Hi.');
+      expect(chat.openingAllGreetings, ['Hi.', 'Who are you?']);
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Who are you?');
+      expect(
+        testPostGreetingEvalEntered,
+        isTrue,
+        reason: 'unauthored member-greet alt must reach RtR',
+      );
+
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (chat.isProcessingGreeting && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      expect(chat.isProcessingGreeting, isFalse);
+
+      expect(
+        chat.characterEmotion,
+        'curious',
+        reason: 'unauthored member-greet alt must keep the RtR result live',
+      );
+      for (final c in chat.groupCharacters) {
+        final id = chat.characterIdFor(c);
+        expect(
+          chat.debugGroupSlotEmotion(id),
+          'curious',
+          reason:
+              'member-greet RtR must persist into every current member slot, not only evalChar ($id)',
+        );
+      }
+
+      chat.debugReloadFirstGroupSpeakerScalars();
+      expect(
+        chat.characterEmotion,
+        'curious',
+        reason:
+            'first-speaker reload must not throw member-greet RtR away for inherit baseline',
+      );
     },
   );
 }

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -1544,4 +1544,189 @@ void main() {
       expect(chat.needsSimulation.vector['hunger'], 80);
     },
   );
+
+  test(
+    'group New Chat after completed unauthored fury reseeds inherit, not leftover fury',
+    () async {
+      final llm = _PhasedGreetingLlm();
+      chat.testLlmServiceOverride = llm;
+      final blobs = buildGroupRealismBlobs(
+        seeds: {
+          'mem-a': defaultGroupMemberRealismSeed(),
+          'mem-b': defaultGroupMemberRealismSeed(),
+        },
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+        alternateGreetings: const ['Get out.'],
+        greetingSeeds: const [null],
+      );
+      await db.insertGroup(
+        GroupsCompanion.insert(
+          id: 'grp-newchat-fury',
+          name: 'The House',
+          firstMessage: const Value('Come in, friends.'),
+          defaultMemberRealismState: Value(blobs.defaultMemberJson),
+          baselineRealismState: Value(blobs.baselineJson),
+        ),
+      );
+      for (final m in [('mem-a', 'Ana'), ('mem-b', 'Bea')]) {
+        await db.insertGroupMember(
+          GroupMembersCompanion.insert(
+            id: m.$1,
+            groupId: 'grp-newchat-fury',
+            name: m.$2,
+            firstMessage: const Value('Hi.'),
+          ),
+        );
+      }
+      final group = GroupChat(
+        id: 'grp-newchat-fury',
+        name: 'The House',
+        firstMessage: 'Come in, friends.',
+        alternateGreetings: const ['Get out.'],
+        greetingSeeds: const [null],
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await chat.setActiveGroup(
+        group,
+        groupRepo: GroupChatRepository(storage, db),
+      );
+
+      expect(chat.messages.first.text, 'Come in, friends.');
+
+      llm.delay = Duration.zero;
+      llm.payload = '{"emotion":"furious","emotion_intensity":"strong"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        testPostGreetingEvalEntered,
+        isTrue,
+        reason: 'unauthored group alt must start RtR',
+      );
+
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (chat.isProcessingGreeting && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      expect(chat.isProcessingGreeting, isFalse);
+      expect(
+        chat.characterEmotion,
+        'furious',
+        reason: 'completed unauthored RtR must land fury before New Chat',
+      );
+
+      await chat.startNewChat();
+      expect(chat.greetingIndex, 0);
+      expect(chat.messages.first.text, 'Come in, friends.');
+      expect(
+        chat.characterEmotion,
+        isNot('furious'),
+        reason:
+            'New Chat custom opener must apply overlay 0 / inherit, not leftover fury',
+      );
+      expect(
+        ['', 'neutral'].contains(chat.characterEmotion),
+        isTrue,
+        reason: 'inherit/baseline (card inherit or member-seed), not leftover fury',
+      );
+      for (final c in chat.groupCharacters) {
+        final id = chat.characterIdFor(c);
+        expect(
+          chat.debugGroupSlotEmotion(id),
+          isNot('furious'),
+          reason: 'New Chat must reseed member slots, not leave fury ($id)',
+        );
+      }
+    },
+  );
+
+  test(
+    'member-greet New Chat after completed fury reseeds inherit, not leftover fury',
+    () async {
+      final llm = _PhasedGreetingLlm();
+      chat.testLlmServiceOverride = llm;
+      final blobs = buildGroupRealismBlobs(
+        seeds: {
+          'mem-a': defaultGroupMemberRealismSeed(),
+          'mem-b': defaultGroupMemberRealismSeed(),
+        },
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+      );
+      await db.insertGroup(
+        GroupsCompanion.insert(
+          id: 'grp-member-newchat-fury',
+          name: 'The House',
+          firstMessage: const Value(''),
+          defaultMemberRealismState: Value(blobs.defaultMemberJson),
+          baselineRealismState: Value(blobs.baselineJson),
+        ),
+      );
+      await db.insertGroupMember(
+        GroupMembersCompanion.insert(
+          id: 'mem-a',
+          groupId: 'grp-member-newchat-fury',
+          name: 'Ana',
+          firstMessage: const Value('Hi.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      await db.insertGroupMember(
+        GroupMembersCompanion.insert(
+          id: 'mem-b',
+          groupId: 'grp-member-newchat-fury',
+          name: 'Bea',
+          firstMessage: const Value('Hey.'),
+        ),
+      );
+      final group = GroupChat(
+        id: 'grp-member-newchat-fury',
+        name: 'The House',
+        firstMessage: '',
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await chat.setActiveGroup(
+        group,
+        groupRepo: GroupChatRepository(storage, db),
+      );
+
+      expect(chat.messages.first.text, 'Hi.');
+      expect(chat.openingAllGreetings, ['Hi.', 'Get out.']);
+
+      llm.delay = Duration.zero;
+      llm.payload = '{"emotion":"furious","emotion_intensity":"strong"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(testPostGreetingEvalEntered, isTrue);
+
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (chat.isProcessingGreeting && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      expect(chat.isProcessingGreeting, isFalse);
+      expect(chat.characterEmotion, 'furious');
+
+      await chat.startNewChat();
+      expect(chat.messages.first.text, 'Hi.');
+      expect(chat.greetingIndex, 0);
+      expect(
+        chat.characterEmotion,
+        isNot('furious'),
+        reason:
+            'New Chat member-greet must apply overlay 0 / inherit, not leftover fury',
+      );
+      expect(
+        ['', 'neutral'].contains(chat.characterEmotion),
+        isTrue,
+        reason: 'inherit/baseline (card inherit or member-seed), not leftover fury',
+      );
+    },
+  );
 }

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -6,6 +6,7 @@
 // _applyGreetingOpeningSeed, selectGreeting only swapped text and either
 // kept the friend seed or overwrote it with reading-the-room, never restored.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:drift/drift.dart' show Value;
@@ -1130,6 +1131,254 @@ void main() {
         'curious',
         reason:
             'first-speaker reload must not throw member-greet RtR away for inherit baseline',
+      );
+    },
+  );
+
+  test(
+    'startNewChat after delayed unauthored alt: fury must not paint first_mes',
+    () async {
+      final llm = _PhasedGreetingLlm();
+      chat.testLlmServiceOverride = llm;
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-newchat-stale',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_newchat.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      final card = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_newchat.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: const [null],
+        ),
+      )..dbId = 'char-newchat-stale';
+      await chat.setActiveCharacter(card);
+
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.messages.first.text, 'Hello, friend.');
+
+      llm.delay = const Duration(milliseconds: 180);
+      llm.payload = '{"emotion":"furious","emotion_intensity":"strong"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.greetingIndex, 1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(
+        testPostGreetingEvalEntered,
+        isTrue,
+        reason: 'unauthored alt must start eval so a stale future exists',
+      );
+
+      await chat.startNewChat();
+      expect(chat.greetingIndex, 0);
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+
+      await Future<void>.delayed(const Duration(milliseconds: 360));
+
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason:
+            'delayed eval-1 must not paint fury onto New Chat first_mes',
+      );
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+    },
+  );
+
+  test(
+    'setActiveCharacter after delayed unauthored alt: fury must not paint next first_mes',
+    () async {
+      final llm = _PhasedGreetingLlm();
+      chat.testLlmServiceOverride = llm;
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-switch-a',
+          name: 'Nemu',
+          imagePath: const Value('/tmp/Nemu_switch.png'),
+          firstMessage: const Value('Hello, friend.'),
+          alternateGreetings: const Value('["Get out."]'),
+        ),
+      );
+      await db.insertCharacter(
+        CharactersCompanion.insert(
+          id: 'char-switch-b',
+          name: 'Mira',
+          imagePath: const Value('/tmp/Mira_switch.png'),
+          firstMessage: const Value('Hello, friend.'),
+        ),
+      );
+      final nemu = CharacterCard(
+        name: 'Nemu',
+        imagePath: '/tmp/Nemu_switch.png',
+        firstMessage: 'Hello, friend.',
+        alternateGreetings: const ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+          greetingSeeds: const [null],
+        ),
+      )..dbId = 'char-switch-a';
+      await chat.setActiveCharacter(nemu);
+
+      llm.delay = const Duration(milliseconds: 180);
+      llm.payload = '{"emotion":"furious","emotion_intensity":"strong"}';
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.messages.first.text, 'Get out.');
+      expect(testPostGreetingEvalEntered, isTrue);
+
+      final mira = CharacterCard(
+        name: 'Mira',
+        imagePath: '/tmp/Mira_switch.png',
+        firstMessage: 'Hello, friend.',
+        frontPorchExtensions: FrontPorchExtensions(
+          realismEnabled: true,
+          characterEmotion: 'warm',
+          emotionIntensity: 'mild',
+          shortTermBond: 20,
+          trustLevel: 10,
+          timeOfDay: 'morning',
+          needsSimEnabled: true,
+          needsBaselineHunger: 80,
+        ),
+      )..dbId = 'char-switch-b';
+      await chat.setActiveCharacter(mira);
+
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.characterEmotion, 'warm');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+
+      await Future<void>.delayed(const Duration(milliseconds: 360));
+
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason:
+            'delayed Nemu eval must not paint fury onto Mira first_mes',
+      );
+      expect(chat.messages.first.text, 'Hello, friend.');
+      expect(chat.activeCharacter?.name, 'Mira');
+      expect(chat.relationshipService.affectionScore, 20);
+      expect(chat.relationshipService.trustLevel, 10);
+      expect(chat.timeService.timeOfDay, 'morning');
+      expect(chat.needsSimulation.vector['hunger'], 80);
+    },
+  );
+
+  test(
+    'group blank first_mes + member empty first_mes opens Stay. with warm overlay',
+    () async {
+      final warm = GreetingRealismSeed(
+        characterEmotion: 'warm',
+        emotionIntensity: 'mild',
+        shortTermBond: 20,
+      );
+      final furious = GreetingRealismSeed(
+        characterEmotion: 'furious',
+        emotionIntensity: 'strong',
+        shortTermBond: -40,
+      );
+      final ext = FrontPorchExtensions(
+        realismEnabled: true,
+        characterEmotion: 'lonely',
+        emotionIntensity: 'mild',
+        shortTermBond: 5,
+        trustLevel: 5,
+        timeOfDay: 'morning',
+        needsSimEnabled: true,
+        needsBaselineHunger: 80,
+        greetingSeeds: [warm, furious],
+      );
+      final blobs = buildGroupRealismBlobs(
+        seeds: {'mem-nemu': defaultGroupMemberRealismSeed()},
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+      );
+      await db.insertGroup(
+        GroupsCompanion.insert(
+          id: 'grp-blank-member',
+          name: 'The House',
+          firstMessage: const Value(''),
+          defaultMemberRealismState: Value(blobs.defaultMemberJson),
+          baselineRealismState: Value(blobs.baselineJson),
+        ),
+      );
+      await db.insertGroupMember(
+        GroupMembersCompanion.insert(
+          id: 'mem-nemu',
+          groupId: 'grp-blank-member',
+          name: 'Nemu',
+          firstMessage: const Value(''),
+          alternateGreetings: const Value('["Stay.","Get out."]'),
+          frontPorchExtensions: Value(jsonEncode(ext.toJson())),
+        ),
+      );
+      final group = GroupChat(
+        id: 'grp-blank-member',
+        name: 'The House',
+        firstMessage: '',
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await chat.setActiveGroup(
+        group,
+        groupRepo: GroupChatRepository(storage, db),
+      );
+
+      expect(chat.messages, isNotEmpty, reason: 'member allGreetings must open');
+      expect(chat.messages.first.text, 'Stay.');
+      expect(chat.openingAllGreetings, ['Stay.', 'Get out.']);
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason: 'empty first_mes: displayed 0 is alt[0] and overlay is seeds[0]',
+      );
+      expect(chat.relationshipService.affectionScore, 20);
+
+      await chat.startNewChat();
+      expect(
+        chat.messages,
+        isNotEmpty,
+        reason: 'New Chat in the group must also use member allGreetings',
+      );
+      expect(chat.messages.first.text, 'Stay.');
+      expect(
+        chat.characterEmotion,
+        'warm',
+        reason: 'New Chat must re-apply Stay./warm, not open empty',
       );
     },
   );

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -906,6 +906,81 @@ void main() {
   );
 
   test(
+    'reopen after persisted unauthored RtR keeps curious, not inherit',
+    () async {
+      chat.testLlmServiceOverride = _PhasedGreetingLlm()
+        ..payload = '{"emotion":"curious","emotion_intensity":"mild"}';
+      final blobs = buildGroupRealismBlobs(
+        seeds: {
+          'mem-a': defaultGroupMemberRealismSeed(),
+          'mem-b': defaultGroupMemberRealismSeed(),
+        },
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+        alternateGreetings: const ['Who are you?'],
+        greetingSeeds: [null],
+      );
+      await db.insertGroup(
+        GroupsCompanion.insert(
+          id: 'grp-rtr-reopen',
+          name: 'The House',
+          firstMessage: const Value('Come in, friends.'),
+          defaultMemberRealismState: Value(blobs.defaultMemberJson),
+          baselineRealismState: Value(blobs.baselineJson),
+        ),
+      );
+      for (final m in [('mem-a', 'Ana'), ('mem-b', 'Bea')]) {
+        await db.insertGroupMember(
+          GroupMembersCompanion.insert(
+            id: m.$1,
+            groupId: 'grp-rtr-reopen',
+            name: m.$2,
+            firstMessage: const Value('Hi.'),
+          ),
+        );
+      }
+      final group = GroupChat(
+        id: 'grp-rtr-reopen',
+        name: 'The House',
+        firstMessage: 'Come in, friends.',
+        alternateGreetings: const ['Who are you?'],
+        greetingSeeds: const [null],
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      final repo = GroupChatRepository(storage, db);
+      await chat.setActiveGroup(group, groupRepo: repo);
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.messages.first.text, 'Who are you?');
+      expect(testPostGreetingEvalEntered, isTrue);
+      final deadline = DateTime.now().add(const Duration(seconds: 3));
+      while (chat.isProcessingGreeting && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+      expect(chat.characterEmotion, 'curious');
+      final sessionId = chat.currentSessionId!;
+
+      await chat.setActiveGroup(group, groupRepo: repo);
+      await chat.loadSession(sessionId);
+      expect(chat.messages.first.text, 'Who are you?');
+      expect(
+        chat.characterEmotion,
+        'curious',
+        reason: 'reopen must keep persisted unauthored RtR, not inherit',
+      );
+      final firstId = chat.characterIdFor(chat.groupCharacters.first);
+      expect(
+        chat.debugGroupSlotEmotion(firstId),
+        'curious',
+        reason: 'member slots must still hold curious after reopen',
+      );
+    },
+  );
+
+  test(
     'empty first_mes pairs Stay./Get out. with warm/furious, no leftover warm',
     () async {
       await db.insertCharacter(

--- a/test/services/chat/greeting_opening_seed_test.dart
+++ b/test/services/chat/greeting_opening_seed_test.dart
@@ -147,6 +147,15 @@ void main() {
     // setActiveCharacter already ran; loadSession rehydrates the same card.
     expect(chat.greetingIndex, 1, reason: 'cursor must survive reload');
     expect(chat.messages.first.text, 'Get out.');
+    expect(
+      chat.characterEmotion,
+      'furious',
+      reason: 'overlay emotion must survive reload, not first_mes friend',
+    );
+    expect(chat.relationshipService.affectionScore, -40);
+    expect(chat.relationshipService.trustLevel, -25);
+    expect(chat.timeService.timeOfDay, 'night');
+    expect(chat.needsSimulation.vector['hunger'], 25);
 
     // A second ChatService on the same DB (app restart) uses the same card.
     expect(card.alternateGreetings, isNotEmpty);
@@ -361,6 +370,161 @@ void main() {
         contains('flour-dusted apron'),
         reason: 'empty overlay must not strip the card wardrobe',
       );
+    },
+  );
+
+
+  test(
+    'group import/save with empty lists keeps blob angry alt+seed',
+    () async {
+      final angry = GreetingRealismSeed(
+        characterEmotion: 'furious',
+        emotionIntensity: 'strong',
+        shortTermBond: -40,
+      );
+      final blobs = buildGroupRealismBlobs(
+        seeds: {'mem-a': defaultGroupMemberRealismSeed()},
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+        alternateGreetings: const ['Get out.'],
+        greetingSeeds: [angry],
+      );
+      final blob = blobs.defaultMemberJson;
+      final repo = GroupChatRepository(storage, db);
+      // Import-equivalent: parse alts/seeds out of the blob (empty lists
+      // would wipe). Then save is a no-wipe round-trip.
+      final group = GroupChat(
+        id: 'grp-import-wipe',
+        name: 'The House',
+        firstMessage: 'Come in.',
+        alternateGreetings: parseGroupAlternateGreetings(blob),
+        greetingSeeds: parseGroupGreetingSeeds(blob),
+        defaultMemberRealismState: blob,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await repo.save(group);
+      await repo.reload();
+      final loaded = repo.getById('grp-import-wipe')!;
+      expect(loaded.alternateGreetings, ['Get out.']);
+      expect(loaded.greetingSeeds.first!.characterEmotion, 'furious');
+      expect(loaded.greetingSeeds.first!.emotionIntensity, 'strong');
+    },
+  );
+
+  test(
+    'repo.save writes patched alts/seeds back onto the in-memory GroupChat',
+    () async {
+      final angry = GreetingRealismSeed(characterEmotion: 'furious');
+      final blobs = buildGroupRealismBlobs(
+        seeds: {'mem-a': defaultGroupMemberRealismSeed()},
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+      );
+      final repo = GroupChatRepository(storage, db);
+      final group = GroupChat(
+        id: 'grp-mem-patch',
+        name: 'The House',
+        firstMessage: 'Come in.',
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await repo.save(group);
+      group.alternateGreetings = ['Get out.'];
+      group.greetingSeeds = [angry];
+      await repo.save(group);
+      expect(
+        group.alternateGreetings,
+        ['Get out.'],
+        reason: 'same object, no reload',
+      );
+      expect(group.greetingSeeds.first!.characterEmotion, 'furious');
+      expect(
+        parseGroupAlternateGreetings(group.defaultMemberRealismState),
+        ['Get out.'],
+      );
+      expect(
+        repo.getById('grp-mem-patch')!.greetingSeeds.first!.characterEmotion,
+        'furious',
+      );
+    },
+  );
+
+  test(
+    'unauthored group custom alt reaches RtR; authored furious skips',
+    () async {
+      final angry = GreetingRealismSeed(
+        characterEmotion: 'furious',
+        emotionIntensity: 'strong',
+      );
+      final blobs = buildGroupRealismBlobs(
+        seeds: {
+          'mem-a': defaultGroupMemberRealismSeed(),
+          'mem-b': defaultGroupMemberRealismSeed(),
+        },
+        needsEnabled: true,
+        timeOfDay: 'morning',
+        dayCount: 1,
+        alternateGreetings: const ['Get out of my house.', 'Who are you?'],
+        greetingSeeds: [angry, null],
+      );
+      await db.insertGroup(
+        GroupsCompanion.insert(
+          id: 'grp-rtr',
+          name: 'The House',
+          firstMessage: const Value('Come in, friends.'),
+          defaultMemberRealismState: Value(blobs.defaultMemberJson),
+          baselineRealismState: Value(blobs.baselineJson),
+        ),
+      );
+      for (final m in [('mem-a', 'Ana'), ('mem-b', 'Bea')]) {
+        await db.insertGroupMember(
+          GroupMembersCompanion.insert(
+            id: m.$1,
+            groupId: 'grp-rtr',
+            name: m.$2,
+            firstMessage: const Value('Hi.'),
+          ),
+        );
+      }
+      final group = GroupChat(
+        id: 'grp-rtr',
+        name: 'The House',
+        firstMessage: 'Come in, friends.',
+        alternateGreetings: const ['Get out of my house.', 'Who are you?'],
+        greetingSeeds: [angry, null],
+        defaultMemberRealismState: blobs.defaultMemberJson,
+        baselineRealismState: blobs.baselineJson,
+      );
+      await chat.setActiveGroup(
+        group,
+        groupRepo: GroupChatRepository(storage, db),
+      );
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(1);
+      expect(chat.characterEmotion, 'furious');
+      expect(
+        testPostGreetingEvalEntered,
+        isFalse,
+        reason: 'authored furious overlay must skip RtR',
+      );
+
+      testPostGreetingEvalEntered = false;
+      await chat.selectGreeting(2);
+      expect(chat.greetingIndex, 2);
+      expect(chat.messages.first.text, 'Who are you?');
+      expect(
+        testPostGreetingEvalEntered,
+        isTrue,
+        reason: 'unauthored group alt must reach eval, not skip for null _activeCharacter',
+      );
+
+      await chat.selectGreeting(0);
+      expect(chat.greetingIndex, 0);
+      expect(chat.messages.first.text, 'Come in, friends.');
+      expect(chat.timeService.timeOfDay, 'morning');
     },
   );
 }

--- a/test/services/chat/session_reload_persona_test.dart
+++ b/test/services/chat/session_reload_persona_test.dart
@@ -83,8 +83,12 @@ void main() {
     repo = CharacterRepository(db, storage);
     personas = UserPersonaService(db);
     chat =
-        ChatService(KoboldService(storage), personas, storage,
-            WorldRepository(storage, db))
+        ChatService(
+            KoboldService(storage),
+            personas,
+            storage,
+            WorldRepository(storage, db),
+          )
           ..setDatabase(db)
           ..setCharacterRepository(repo)
           ..testLlmServiceOverride = _InertLlm();
@@ -134,8 +138,92 @@ void main() {
     expect(
       (await db.getSessionById(sessionId))!.userPersonaId,
       porchy,
-      reason: 'the reload must not have rewritten the row binding first — '
+      reason:
+          'the reload must not have rewritten the row binding first — '
           'that is the write-before-read bug this suite pins',
     );
   });
+
+  // Matches persona_default_test E2E step 4: setActiveCharacter(first) then
+  // loadSession(A). The same-session pin above never hydrates via
+  // _loadLastSession while Nightowl is live, so it stays green if only
+  // loadSession's flush gate is correct.
+  test(
+    'setActiveCharacter then loadSession restores Porchy after a Nightowl new chat',
+    () async {
+      await personas.createPersona('Porchy', 'Porchy', 'porch tester', null);
+      final porchy = personas.persona.id;
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      await personas.createPersona('Nightowl', 'Nightowl', 'late shift', null);
+      final nightowl = personas.persona.id;
+      expect(nightowl, isNot(porchy));
+      await personas.setDefaultPersona(porchy);
+      await personas.setActivePersona(porchy);
+
+      Future<CharacterCard> seed(String name) async {
+        final card = CharacterCard(
+          name: name,
+          description: 'E2E-twin persona card.',
+          firstMessage: 'Evening. Pull up a chair.',
+          frontPorchExtensions: FrontPorchExtensions(
+            realismEnabled: false,
+            needsSimEnabled: false,
+            chaosModeEnabled: false,
+          ),
+        );
+        await repo.addCharacter(card);
+        return card;
+      }
+
+      final first = await seed('Porch Sitter');
+      final second = await seed('Late Riser');
+
+      await chat.setActiveCharacter(first);
+      await chat.startNewChat();
+      await chat.sendMessage('Still me, still here.');
+      final firstSessionId = chat.currentSessionId!;
+      expect((await db.getSessionById(firstSessionId))!.userPersonaId, porchy);
+      expect(personas.persona.id, porchy);
+
+      await personas.setDefaultPersona(nightowl);
+      expect(personas.persona.id, porchy);
+      expect(personas.defaultPersonaId, nightowl);
+
+      await chat.setActiveCharacter(second);
+      await chat.startNewChat();
+      expect(personas.persona.id, nightowl);
+      expect(personas.defaultPersonaId, nightowl);
+
+      expect(
+        (await db.getSessionById(firstSessionId))!.userPersonaId,
+        porchy,
+        reason: 'Nightowl new chat must not have rewritten chat A',
+      );
+
+      await chat.setActiveCharacter(first);
+      // Same write _loadLastSession overlay-reapply / flushPendingSaves can
+      // do after setting _currentSessionId while Nightowl is still live.
+      await chat.flushPendingSaves();
+      expect(
+        (await db.getSessionById(firstSessionId))!.userPersonaId,
+        porchy,
+        reason:
+            '_loadLastSession hydrate must not stamp live Nightowl onto chat A',
+      );
+
+      await chat.loadSession(firstSessionId);
+      expect(
+        personas.persona.id,
+        porchy,
+        reason:
+            'setActiveCharacter then loadSession must restore chat A\'s Porchy',
+      );
+      expect(
+        personas.defaultPersonaId,
+        nightowl,
+        reason: 'reopening a chat must not drag the default back',
+      );
+      expect((await db.getSessionById(firstSessionId))!.userPersonaId, porchy);
+    },
+  );
 }

--- a/test/services/chat/session_reload_persona_test.dart
+++ b/test/services/chat/session_reload_persona_test.dart
@@ -226,4 +226,88 @@ void main() {
       expect((await db.getSessionById(firstSessionId))!.userPersonaId, porchy);
     },
   );
+
+  // persona_default_test E2E step 4 + home_page_history _openHistorySession:
+  // setActiveCharacter(first) then loadSession(A), no flush in between.
+  // The service twin above inserts flushPendingSaves and stays green while
+  // the sandboxed E2E still times out on Nightowl. This is that reopen.
+  test(
+    'history reopen setActiveCharacter then loadSession restores Porchy with no flush',
+    () async {
+      await personas.createPersona('', 'Porchy', 'Sits on the steps.', null);
+      final porchy = personas.persona.id;
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      await personas.createPersona('', 'Nightowl', 'Up too late.', null);
+      final nightowl = personas.persona.id;
+      expect(nightowl, isNot(porchy));
+      await personas.setDefaultPersona(porchy);
+      await personas.setActivePersona(porchy);
+
+      Future<CharacterCard> seed(String name) async {
+        final card = CharacterCard(
+          name: name,
+          description: 'Exists only inside the persona-default E2E.',
+          firstMessage: 'Evening. Pull up a chair.',
+          frontPorchExtensions: FrontPorchExtensions(
+            realismEnabled: false,
+            needsSimEnabled: false,
+            chaosModeEnabled: false,
+          ),
+        );
+        await repo.addCharacter(card);
+        return card;
+      }
+
+      final first = await seed('Porch Sitter');
+      final second = await seed('Late Riser');
+
+      await chat.setActiveCharacter(first);
+      await chat.startNewChat();
+      await chat.sendMessage('Still me, still here.');
+      final firstSessionId = chat.currentSessionId!;
+      expect((await db.getSessionById(firstSessionId))!.userPersonaId, porchy);
+      expect(
+        (await db.getSessionById(firstSessionId))!.characterId,
+        first.dbId,
+      );
+
+      await personas.setDefaultPersona(nightowl);
+      expect(personas.persona.id, porchy);
+
+      await chat.setActiveCharacter(second);
+      await chat.startNewChat();
+      expect(personas.persona.id, nightowl);
+
+      final afterNightowl = await db.getSessionById(firstSessionId);
+      expect(
+        afterNightowl!.userPersonaId,
+        porchy,
+        reason: 'Nightowl New Chat must not stamp chat A',
+      );
+      expect(
+        afterNightowl.characterId,
+        first.dbId,
+        reason: 'Nightowl New Chat must not rebind chat A onto Late Riser',
+      );
+
+      await chat.setActiveCharacter(first);
+      expect(
+        personas.persona.id,
+        porchy,
+        reason:
+            '_loadLastSession (library / last-session path) must restore Porchy',
+      );
+
+      await chat.loadSession(firstSessionId);
+      expect(
+        personas.persona.id,
+        porchy,
+        reason:
+            'history reopen (setActiveCharacter then loadSession, no flush) '
+            'must restore chat A\'s Porchy',
+      );
+      expect(personas.defaultPersonaId, nightowl);
+      expect((await db.getSessionById(firstSessionId))!.userPersonaId, porchy);
+    },
+  );
 }

--- a/test/services/chat/variant_snippet_test.dart
+++ b/test/services/chat/variant_snippet_test.dart
@@ -62,5 +62,17 @@ void main() {
     test('an authored overlay skips reading-the-room', () {
       expect(shouldReadRoomForGreeting(1, hasAuthoredSeed: true), isFalse);
     });
+
+    test('empty first_mes: displayed 0 Reads the Room when unauthored', () {
+      expect(shouldReadRoomForGreeting(0, firstMesEmpty: true), isTrue);
+      expect(
+        shouldReadRoomForGreeting(
+          0,
+          hasAuthoredSeed: true,
+          firstMesEmpty: true,
+        ),
+        isFalse,
+      );
+    });
   });
 }

--- a/test/services/v2_card_hostile_json_test.dart
+++ b/test/services/v2_card_hostile_json_test.dart
@@ -115,6 +115,37 @@ void main() {
     expect(card.worldNames, ['Sunset Row']);
   });
 
+  test(
+    'null greet slot stays aligned so furious stays on Get out',
+    () {
+      final card = service.parseCardJson(
+        jsonEncode(
+          cardWith({
+            'alternate_greetings': [null, 'Get out.'],
+            'extensions': {
+              'front_porch': {
+                'realism_engine': {
+                  'enabled': true,
+                  'greeting_seeds': [
+                    null,
+                    {'character_emotion': 'furious'},
+                  ],
+                },
+              },
+            },
+          }),
+        ),
+      );
+      expect(card, isNotNull);
+      expect(card!.alternateGreetings, ['Get out.']);
+      expect(
+        card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+        'furious',
+        reason: 'whereType skip of JSON-null would zip furious off Get out',
+      );
+    },
+  );
+
   test('input that is not a JSON object stays null (genuinely not a card)', () {
     expect(service.parseCardJson('[]'), isNull);
     expect(service.parseCardJson('"hello"'), isNull);

--- a/test/services/web/character_create_test.dart
+++ b/test/services/web/character_create_test.dart
@@ -241,5 +241,112 @@ void main() {
         );
       },
     );
+
+    test(
+      'update explicit empty greetingSeeds stays authored-empty',
+      () async {
+        final res = await facade.create({
+          'name': 'AuthoredEmptySeeds',
+          'firstMessage': 'Come in.',
+          'alternateGreetings': ['Stay.'],
+          'greetingSeeds': [
+            {'characterEmotion': 'furious'},
+          ],
+        });
+        final id = res!['id'] as String;
+        expect(
+          facade
+              .cardByDbId(id)!
+              .frontPorchExtensions!
+              .greetingSeeds
+              .single!
+              .characterEmotion,
+          'furious',
+        );
+
+        expect(
+          await facade.update(id, {
+            'alternateGreetings': ['', 'Get out.'],
+            'greetingSeeds': [],
+          }),
+          isTrue,
+        );
+        final dirty = facade.cardByDbId(id)!;
+        expect(dirty.alternateGreetings, ['Get out.']);
+        expect(
+          dirty.frontPorchExtensions!.greetingSeeds,
+          isEmpty,
+          reason:
+              'explicit empty greetingSeeds is authored-empty, not leftover furious',
+        );
+        expect(
+          greetingOverlayAt(dirty.frontPorchExtensions!.greetingSeeds, 1),
+          isNull,
+        );
+
+        expect(
+          await facade.update(id, {
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          facade
+              .cardByDbId(id)!
+              .frontPorchExtensions!
+              .greetingSeeds
+              .single!
+              .characterEmotion,
+          'furious',
+        );
+        expect(
+          await facade.update(id, {
+            'greetingSeeds': [],
+          }),
+          isTrue,
+        );
+        final emptied = facade.cardByDbId(id)!;
+        expect(emptied.alternateGreetings, ['Stay.']);
+        expect(
+          emptied.frontPorchExtensions!.greetingSeeds,
+          isEmpty,
+          reason: 'explicit empty is authored-empty, not dropped as omit',
+        );
+      },
+    );
+
+    test(
+      'update omitted alts keep base seeds',
+      () async {
+        final res = await facade.create({
+          'name': 'KeepBaseSeeds',
+          'firstMessage': 'Come in.',
+          'alternateGreetings': ['Stay.'],
+          'greetingSeeds': [
+            {'characterEmotion': 'furious'},
+          ],
+        });
+        final id = res!['id'] as String;
+        expect(
+          await facade.update(id, {
+            'trustLevel': 7,
+            'name': 'KeepBaseSeeds-renamed',
+          }),
+          isTrue,
+        );
+        final card = facade.cardByDbId(id)!;
+        expect(card.name, 'KeepBaseSeeds-renamed');
+        expect(card.alternateGreetings, ['Stay.']);
+        expect(
+          card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+          'furious',
+          reason: 'omitted alts must not wipe leftover base seeds',
+        );
+        expect(card.frontPorchExtensions!.trustLevel, 7);
+      },
+    );
   });
 }

--- a/test/services/web/character_create_test.dart
+++ b/test/services/web/character_create_test.dart
@@ -198,5 +198,48 @@ void main() {
         );
       },
     );
+
+    test(
+      'update dirty alts-only POST drops leftover [furious] off Get out',
+      () async {
+        final res = await facade.create({
+          'name': 'AltsOnlyUpdate',
+          'firstMessage': 'Come in.',
+          'alternateGreetings': ['Stay.'],
+          'greetingSeeds': [
+            {'characterEmotion': 'furious'},
+          ],
+        });
+        final id = res!['id'] as String;
+        expect(
+          facade
+              .cardByDbId(id)!
+              .frontPorchExtensions!
+              .greetingSeeds
+              .single!
+              .characterEmotion,
+          'furious',
+        );
+        expect(
+          await facade.update(id, {
+            'alternateGreetings': ['', 'Get out.'],
+          }),
+          isTrue,
+        );
+        final card = facade.cardByDbId(id)!;
+        expect(card.alternateGreetings, ['Get out.']);
+        expect(
+          card.frontPorchExtensions!.greetingSeeds,
+          isEmpty,
+          reason:
+              'dirty alts-only + existing [furious] must not load furious onto Get out',
+        );
+        expect(
+          greetingOverlayAt(card.frontPorchExtensions!.greetingSeeds, 1),
+          isNull,
+          reason: 'Get out overlay is not leftover furious',
+        );
+      },
+    );
   });
 }

--- a/test/services/web/character_create_test.dart
+++ b/test/services/web/character_create_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:front_porch_ai/database/database.dart';
+import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/character_repository.dart';
 import 'package:front_porch_ai/services/storage_service.dart';
 import 'package:front_porch_ai/services/web/facade/character_facade.dart';
@@ -94,5 +95,108 @@ void main() {
       expect(await facade.create({'name': '   '}), isNull);
       expect(await facade.create(const {}), isNull);
     });
+
+    test(
+      'create compact-pairs dirty empty greet so furious does not land on Get out',
+      () async {
+        final res = await facade.create({
+          'name': 'PairCreate',
+          'firstMessage': 'Come in.',
+          'alternateGreetings': ['', 'Get out.'],
+          'greetingSeeds': [
+            {'characterEmotion': 'furious'},
+          ],
+        });
+        expect(res, isNotNull);
+        final card = facade.cardByDbId(res!['id'] as String);
+        expect(card, isNotNull);
+        expect(card!.alternateGreetings, ['Get out.']);
+        expect(
+          card.frontPorchExtensions!.greetingSeeds,
+          isEmpty,
+          reason:
+              "['', 'Get out.']+[furious] must not load furious onto Get out",
+        );
+        expect(
+          greetingOverlayAt(card.frontPorchExtensions!.greetingSeeds, 1),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'create JSON-null greet slot keeps furious on Get out',
+      () async {
+        final res = await facade.create({
+          'name': 'NullSlotCreate',
+          'firstMessage': 'Come in.',
+          'alternateGreetings': [null, 'Get out.'],
+          'greetingSeeds': [
+            null,
+            {'characterEmotion': 'furious'},
+          ],
+        });
+        expect(res, isNotNull);
+        final card = facade.cardByDbId(res!['id'] as String)!;
+        expect(card.alternateGreetings, ['Get out.']);
+        expect(
+          card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+          'furious',
+        );
+      },
+    );
+
+    test(
+      'update compact-pairs dirty empty greet so furious does not land on Get out',
+      () async {
+        final res = await facade.create({'name': 'PairUpdate'});
+        final id = res!['id'] as String;
+        expect(
+          await facade.update(id, {
+            'alternateGreetings': ['', 'Get out.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        final card = facade.cardByDbId(id)!;
+        expect(card.alternateGreetings, ['Get out.']);
+        expect(
+          card.frontPorchExtensions!.greetingSeeds,
+          isEmpty,
+          reason:
+              "['', 'Get out.']+[furious] must not load furious onto Get out",
+        );
+        expect(
+          greetingOverlayAt(card.frontPorchExtensions!.greetingSeeds, 1),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'update JSON-null greet slot keeps furious on Get out',
+      () async {
+        final res = await facade.create({'name': 'NullSlotUpdate'});
+        final id = res!['id'] as String;
+        expect(
+          await facade.update(id, {
+            'alternateGreetings': [null, 'Get out.'],
+            'greetingSeeds': [
+              null,
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        final card = facade.cardByDbId(id)!;
+        expect(card.alternateGreetings, ['Get out.']);
+        expect(
+          card.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+          'furious',
+        );
+      },
+    );
   });
 }

--- a/test/services/web/group_settings_test.dart
+++ b/test/services/web/group_settings_test.dart
@@ -264,5 +264,112 @@ void main() {
         );
       },
     );
+
+    test(
+      'updateSettings dirty alts + explicit empty greetingSeeds stays authored-empty',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          await facade.updateSettings('g1', {
+            'alternateGreetings': ['', 'Get out.'],
+            'greetingSeeds': [],
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Get out.']);
+        expect(
+          g.greetingSeeds,
+          isEmpty,
+          reason:
+              'explicit [] on dirty alts is authored-empty, not leftover furious',
+        );
+        expect(greetingOverlayAt(g.greetingSeeds, 1), isNull);
+      },
+    );
+
+    test(
+      'updateSettings explicit empty greetingSeeds without alts stays authored-empty',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          await facade.updateSettings('g1', {
+            'greetingSeeds': [],
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Stay.']);
+        expect(
+          g.greetingSeeds,
+          isEmpty,
+          reason: 'explicit empty is authored-empty, not dropped as omit',
+        );
+        expect(greetingOverlayAt(g.greetingSeeds, 1), isNull);
+      },
+    );
+
+    test(
+      'updateSettings omitted seeds persist empty after reload and toJson/fromJson',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          await facade.updateSettings('g1', {
+            'alternateGreetings': ['Get out.'],
+          }),
+          isTrue,
+        );
+        await groups.reload();
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Get out.']);
+        expect(
+          g.greetingSeeds,
+          isEmpty,
+          reason:
+              "reload after ['Get out.'] omit seeds must not load leftover furious",
+        );
+        expect(
+          greetingOverlayAt(g.greetingSeeds, 1),
+          isNull,
+          reason: 'persisted Get out overlay is not leftover furious',
+        );
+
+        final restored = GroupChat.fromJson(g.toJson());
+        expect(restored.alternateGreetings, ['Get out.']);
+        expect(
+          restored.greetingSeeds,
+          isEmpty,
+          reason: '1:1 apply/restore must not resurrect leftover furious',
+        );
+        expect(greetingOverlayAt(restored.greetingSeeds, 1), isNull);
+      },
+    );
   });
 }

--- a/test/services/web/group_settings_test.dart
+++ b/test/services/web/group_settings_test.dart
@@ -127,5 +127,142 @@ void main() {
         );
       },
     );
+
+    test(
+      'updateSettings clean alts-only POST drops leftover [furious] off Get out',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          groups.getById('g1')!.greetingSeeds.single!.characterEmotion,
+          'furious',
+        );
+        expect(
+          await facade.updateSettings('g1', {
+            'alternateGreetings': ['Get out.'],
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Get out.']);
+        expect(
+          g.greetingSeeds,
+          isEmpty,
+          reason:
+              "['Get out.'] omit seeds must not reuse unpaired existing [furious]",
+        );
+        expect(
+          greetingOverlayAt(g.greetingSeeds, 1),
+          isNull,
+          reason: 'Get out overlay is not leftover furious',
+        );
+      },
+    );
+
+    test(
+      'updateSettings dirty alts-only POST drops leftover [furious] off Get out',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          await facade.updateSettings('g1', {
+            'alternateGreetings': ['', 'Get out.'],
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Get out.']);
+        expect(
+          g.greetingSeeds,
+          isEmpty,
+          reason:
+              'dirty alts-only + existing [furious] must not load furious onto Get out',
+        );
+        expect(
+          greetingOverlayAt(g.greetingSeeds, 1),
+          isNull,
+          reason: 'Get out overlay is not leftover furious',
+        );
+      },
+    );
+
+    test(
+      'updateSettings explicit empty greetingSeeds stays authored-empty',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          await facade.updateSettings('g1', {
+            'alternateGreetings': ['Get out.'],
+            'greetingSeeds': [],
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Get out.']);
+        expect(
+          g.greetingSeeds,
+          isEmpty,
+          reason:
+              'explicit empty greetingSeeds is authored-empty, not leftover furious',
+        );
+        expect(greetingOverlayAt(g.greetingSeeds, 1), isNull);
+      },
+    );
+
+    test(
+      'updateSettings omitted alts keep base seeds',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['Stay.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        expect(
+          await facade.updateSettings('g1', {
+            'name': 'Renamed-keep-seeds',
+            'systemPrompt': 'Be terse.',
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.name, 'Renamed-keep-seeds');
+        expect(g.alternateGreetings, ['Stay.']);
+        expect(
+          g.greetingSeeds.single!.characterEmotion,
+          'furious',
+          reason: 'omitted alts must not wipe leftover base seeds',
+        );
+      },
+    );
   });
 }

--- a/test/services/web/group_settings_test.dart
+++ b/test/services/web/group_settings_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:front_porch_ai/database/database.dart';
+import 'package:front_porch_ai/models/greeting_realism_seed.dart';
 import 'package:front_porch_ai/models/group_chat.dart';
 import 'package:front_porch_ai/services/group_chat_repository.dart';
 import 'package:front_porch_ai/services/storage_service.dart';
@@ -72,5 +73,59 @@ void main() {
     test('unknown group returns false', () async {
       expect(await facade.updateSettings('nope', {'name': 'x'}), isFalse);
     });
+
+    test(
+      'updateSettings compact-pairs dirty empty greet so furious does not land on Get out',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': ['', 'Get out.'],
+            'greetingSeeds': [
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Get out.']);
+        expect(
+          g.greetingSeeds,
+          isEmpty,
+          reason:
+              "['', 'Get out.']+[furious] must not load furious onto Get out",
+        );
+        expect(g.allGreetings, ['Come in.', 'Get out.']);
+        expect(
+          greetingOverlayAt(g.greetingSeeds, 1),
+          isNull,
+          reason: 'live overlay must already be paired, not only after reload',
+        );
+      },
+    );
+
+    test(
+      'updateSettings JSON-null greet slot keeps furious on Get out',
+      () async {
+        expect(
+          await facade.updateSettings('g1', {
+            'firstMessage': 'Come in.',
+            'alternateGreetings': [null, 'Get out.'],
+            'greetingSeeds': [
+              null,
+              {'characterEmotion': 'furious'},
+            ],
+          }),
+          isTrue,
+        );
+        final g = groups.getById('g1')!;
+        expect(g.alternateGreetings, ['Get out.']);
+        expect(g.greetingSeeds.single!.characterEmotion, 'furious');
+        expect(
+          greetingOverlayAt(g.greetingSeeds, 1)!.characterEmotion,
+          'furious',
+        );
+      },
+    );
   });
 }

--- a/test/ui/dialogs/group_settings_done_commits_test.dart
+++ b/test/ui/dialogs/group_settings_done_commits_test.dart
@@ -22,6 +22,7 @@ import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/services.dart';
 import 'package:front_porch_ai/ui/dialogs/group_settings/group_settings.dart';
 import 'package:front_porch_ai/ui/dialogs/group_settings_dialog.dart';
+import 'package:front_porch_ai/ui/widgets/group_alternate_greetings_editor.dart';
 
 import '../../golden/support/fakes.dart';
 
@@ -100,4 +101,55 @@ void main() {
     expect(repo.saved, same(group));
     expect(repo.saved!.name, 'The New Fellowship');
   });
+
+  testWidgets(
+    'applyToLiveGroup compact-pairs dirty greets so live overlay is not mis-paired',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final group = GroupChat(
+        id: 'g-live-pair',
+        name: 'The House',
+        firstMessage: 'Come in.',
+      );
+      final chat = _ChatWithGroup(group);
+      addTearDown(chat.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: GroupGeneralTab(chatService: chat)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final editor = tester.widget<GroupAlternateGreetingsEditor>(
+        find.byType(GroupAlternateGreetingsEditor),
+      );
+      final furious = GreetingRealismSeed(characterEmotion: 'furious');
+      editor.onChanged(['', 'Get out.'], [furious]);
+      await tester.pump();
+
+      tester
+          .state<GroupGeneralTabState>(find.byType(GroupGeneralTab))
+          .applyToLiveGroup();
+
+      expect(
+        group.alternateGreetings,
+        ['Get out.'],
+        reason: 'live write must compact, not keep the blank row',
+      );
+      expect(
+        group.greetingSeeds,
+        isEmpty,
+        reason: 'furious sat on the blank; live allGreetings must not see it on Get out',
+      );
+      expect(group.allGreetings, ['Come in.', 'Get out.']);
+      expect(
+        greetingOverlayAt(group.greetingSeeds, 1),
+        isNull,
+        reason: 'overlay index 1 is Get out — leftover furious would have landed here',
+      );
+    },
+  );
 }

--- a/test/ui/pages/home/enhance_porch_review_test.dart
+++ b/test/ui/pages/home/enhance_porch_review_test.dart
@@ -211,7 +211,7 @@ void main() {
         isNull,
         reason: 'Get out overlay is not leftover furious',
       );
-      expect(leftover.single!.characterEmotion, 'furious');
+      expect(leftover.single.characterEmotion, 'furious');
     },
   );
 

--- a/test/ui/pages/home/enhance_porch_review_test.dart
+++ b/test/ui/pages/home/enhance_porch_review_test.dart
@@ -222,4 +222,78 @@ void main() {
     expect(paired.seeds.single!.characterEmotion, 'cold');
     expect(greetingOverlayAt(paired.seeds, 1)!.characterEmotion, 'cold');
   });
+
+  test(
+    'enhance_review_body accept leftover furious on duplicate does not land on Get out',
+    () {
+      final leftover = GreetingRealismSeed(characterEmotion: 'furious');
+      final copy = CharacterCard(
+        name: 'Nina (Enhanced)',
+        firstMessage: 'Stay.',
+        alternateGreetings: ['Stay.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: [leftover]),
+      );
+      final enhanced = CharacterCard(
+        name: 'Nina',
+        firstMessage: 'Hey.',
+        alternateGreetings: ['Get out.'],
+      );
+      final greetingPairs = compactAcceptedEnhanceGreetings(
+        enhanced.alternateGreetings,
+        enhanced.frontPorchExtensions?.greetingSeeds,
+      );
+      copy.alternateGreetings = greetingPairs.greetings;
+      copy.frontPorchExtensions!.greetingSeeds = greetingPairs.seeds;
+      expect(copy.alternateGreetings, ['Get out.']);
+      expect(
+        copy.frontPorchExtensions!.greetingSeeds,
+        isEmpty,
+        reason:
+            "accept ['Get out.'] must not load leftover duplicate [furious]",
+      );
+      expect(
+        greetingOverlayAt(copy.frontPorchExtensions!.greetingSeeds, 1),
+        isNull,
+        reason: 'Get out overlay is not leftover furious',
+      );
+      expect(leftover.characterEmotion, 'furious');
+    },
+  );
+
+  test(
+    'enhance_review_body accept authored enhance seeds still pair',
+    () {
+      final leftover = GreetingRealismSeed(characterEmotion: 'furious');
+      final copy = CharacterCard(
+        name: 'Nina (Enhanced)',
+        firstMessage: 'Stay.',
+        alternateGreetings: ['Stay.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: [leftover]),
+      );
+      final authored = [GreetingRealismSeed(characterEmotion: 'cold')];
+      final enhanced = CharacterCard(
+        name: 'Nina',
+        firstMessage: 'Hey.',
+        alternateGreetings: ['Get out.'],
+        frontPorchExtensions: FrontPorchExtensions(greetingSeeds: authored),
+      );
+      final greetingPairs = compactAcceptedEnhanceGreetings(
+        enhanced.alternateGreetings,
+        enhanced.frontPorchExtensions?.greetingSeeds,
+      );
+      copy.alternateGreetings = greetingPairs.greetings;
+      copy.frontPorchExtensions!.greetingSeeds = greetingPairs.seeds;
+      expect(copy.alternateGreetings, ['Get out.']);
+      expect(
+        copy.frontPorchExtensions!.greetingSeeds.single!.characterEmotion,
+        'cold',
+      );
+      expect(
+        greetingOverlayAt(copy.frontPorchExtensions!.greetingSeeds, 1)!
+            .characterEmotion,
+        'cold',
+      );
+      expect(leftover.characterEmotion, 'furious');
+    },
+  );
 }

--- a/test/ui/pages/home/enhance_porch_review_test.dart
+++ b/test/ui/pages/home/enhance_porch_review_test.dart
@@ -191,4 +191,35 @@ void main() {
     expect(save, contains('applyPorchLifeProposal'));
     expect(save.contains('ext.copyWith('), isFalse);
   });
+
+  test(
+    'accept new greet texts vs leftover ext.greetingSeeds drops furious on Get out',
+    () {
+      final leftover = [GreetingRealismSeed(characterEmotion: 'furious')];
+      // Review must compact against enhance-authored seeds (null here), not
+      // leftover source ext.greetingSeeds on the duplicate.
+      final paired = compactAcceptedEnhanceGreetings(['Get out.'], null);
+      expect(paired.greetings, ['Get out.']);
+      expect(
+        paired.seeds,
+        isEmpty,
+        reason:
+            "['Get out.'] omit seeds must not reuse unpaired leftover [furious]",
+      );
+      expect(
+        greetingOverlayAt(paired.seeds, 1),
+        isNull,
+        reason: 'Get out overlay is not leftover furious',
+      );
+      expect(leftover.single!.characterEmotion, 'furious');
+    },
+  );
+
+  test('accept new greet texts pairs a seed the enhance step authored', () {
+    final authored = [GreetingRealismSeed(characterEmotion: 'cold')];
+    final paired = compactAcceptedEnhanceGreetings(['Get out.'], authored);
+    expect(paired.greetings, ['Get out.']);
+    expect(paired.seeds.single!.characterEmotion, 'cold');
+    expect(greetingOverlayAt(paired.seeds, 1)!.characterEmotion, 'cold');
+  });
 }

--- a/test/ui/widgets/greeting_seed_form_test.dart
+++ b/test/ui/widgets/greeting_seed_form_test.dart
@@ -155,4 +155,57 @@ void main() {
     expect(live, isNull);
     expect(find.byType(StoryBeginsRow), findsOneWidget);
   });
+
+  testWidgets('desktop seed fields can return to inherit', (tester) async {
+    tester.view.physicalSize = const Size(1400, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    GreetingRealismSeed? live = const GreetingRealismSeed(
+      emotionIntensity: 'strong',
+      timeOfDay: 'night',
+      dayCount: 4,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return SingleChildScrollView(
+                child: GreetingSeedForm(
+                  seed: live,
+                  onChanged: (next) => setState(() => live = next),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, '4'), '');
+    await tester.pumpAndSettle();
+    expect(live!.dayCount, isNull, reason: 'empty day number returns to inherit');
+
+    await tester.tap(find.text('strong'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('inherit (mild)').last);
+    await tester.pumpAndSettle();
+    expect(
+      live!.emotionIntensity,
+      isNull,
+      reason: 'intensity dropdown must offer inherit after a pick',
+    );
+
+    await tester.tap(find.text('night'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('inherit (morning)').last);
+    await tester.pumpAndSettle();
+    expect(
+      live!.timeOfDay,
+      isNull,
+      reason: 'time dropdown must offer inherit after a pick',
+    );
+  });
 }

--- a/test/ui/widgets/greeting_seed_form_test.dart
+++ b/test/ui/widgets/greeting_seed_form_test.dart
@@ -186,7 +186,16 @@ void main() {
 
     await tester.enterText(find.widgetWithText(TextField, '4'), '');
     await tester.pumpAndSettle();
-    expect(live!.dayCount, isNull, reason: 'empty day number returns to inherit');
+    expect(
+      live!.dayCount,
+      isNull,
+      reason: 'empty day number returns to inherit',
+    );
+    expect(
+      live!.dayCount,
+      isNot(0),
+      reason: 'empty day must write null, not 0',
+    );
 
     await tester.tap(find.text('strong'));
     await tester.pumpAndSettle();
@@ -207,5 +216,80 @@ void main() {
       isNull,
       reason: 'time dropdown must offer inherit after a pick',
     );
+    expect(live!.dayCount, isNull);
+    expect(live!.emotionIntensity, isNull);
+    expect(live!.timeOfDay, isNull);
   });
+
+  testWidgets(
+    'set strong / night / day 4 then inherit-clear persists all three null',
+    (tester) async {
+      tester.view.physicalSize = const Size(1400, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      GreetingRealismSeed? live = const GreetingRealismSeed();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                return SingleChildScrollView(
+                  child: GreetingSeedForm(
+                    seed: live,
+                    onChanged: (next) => setState(() => live = next),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('inherit (mild)').first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('strong').last);
+      await tester.pumpAndSettle();
+      expect(live!.emotionIntensity, 'strong');
+
+      await tester.tap(find.text('inherit (morning)').first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('night').last);
+      await tester.pumpAndSettle();
+      expect(live!.timeOfDay, 'night');
+
+      final dayField = find.byWidgetPredicate(
+        (w) => w is TextField && w.decoration?.hintText == 'inherit (day 1)',
+      );
+      await tester.enterText(dayField, '4');
+      await tester.pumpAndSettle();
+      expect(live!.dayCount, 4);
+
+      await tester.enterText(find.widgetWithText(TextField, '4'), '');
+      await tester.pumpAndSettle();
+      expect(
+        live!.dayCount,
+        isNull,
+        reason: 'empty day number writes null, not leftover 4 or 0',
+      );
+      expect(live!.dayCount, isNot(0));
+
+      await tester.tap(find.text('strong'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('inherit (mild)').last);
+      await tester.pumpAndSettle();
+      expect(live!.emotionIntensity, isNull);
+
+      await tester.tap(find.text('night'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('inherit (morning)').last);
+      await tester.pumpAndSettle();
+      expect(live!.timeOfDay, isNull);
+
+      expect(live!.emotionIntensity, isNull);
+      expect(live!.timeOfDay, isNull);
+      expect(live!.dayCount, isNull);
+    },
+  );
 }

--- a/test/ui/widgets/greeting_seed_form_test.dart
+++ b/test/ui/widgets/greeting_seed_form_test.dart
@@ -292,4 +292,55 @@ void main() {
       expect(live!.dayCount, isNull);
     },
   );
+
+  testWidgets('bond/trust/needs sliders can return to inherit', (tester) async {
+    tester.view.physicalSize = const Size(1400, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    GreetingRealismSeed? live = const GreetingRealismSeed(
+      shortTermBond: 20,
+      trustLevel: 10,
+      needsBaselineHunger: 25,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return SingleChildScrollView(
+                child: GreetingSeedForm(
+                  seed: live,
+                  onChanged: (next) => setState(() => live = next),
+                  showNeeds: true,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Future<void> clearBox(String shown) async {
+      final field = find.widgetWithText(TextField, shown);
+      expect(field, findsOneWidget);
+      await tester.enterText(field, '');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+    }
+
+    await clearBox('20');
+    expect(live!.shortTermBond, isNull, reason: 'bond slider empty writes inherit');
+
+    await clearBox('10');
+    expect(live!.trustLevel, isNull, reason: 'trust slider empty writes inherit');
+
+    await clearBox('25');
+    expect(
+      live!.needsBaselineHunger,
+      isNull,
+      reason: 'needs slider empty writes inherit',
+    );
+  });
 }

--- a/test/ui/widgets/greeting_seed_form_test.dart
+++ b/test/ui/widgets/greeting_seed_form_test.dart
@@ -293,6 +293,46 @@ void main() {
     },
   );
 
+  testWidgets('typed day 0 persist-clears to inherit, not ignored', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    GreetingRealismSeed? live = const GreetingRealismSeed(dayCount: 4);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return SingleChildScrollView(
+                child: GreetingSeedForm(
+                  seed: live,
+                  onChanged: (next) => setState(() => live = next),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final dayField = find.byWidgetPredicate(
+      (w) => w is TextField && w.decoration?.hintText == 'inherit (day 1)',
+    );
+    expect(dayField, findsOneWidget);
+    await tester.enterText(dayField, '0');
+    await tester.pumpAndSettle();
+    expect(
+      live!.dayCount,
+      isNull,
+      reason: 'typed 0 must inherit-clear, not keep leftover 4',
+    );
+    expect(live!.dayCount, isNot(0), reason: '0 is inherit, not calendar day 0');
+  });
+
   testWidgets('bond/trust/needs sliders can return to inherit', (tester) async {
     tester.view.physicalSize = const Size(1400, 2400);
     tester.view.devicePixelRatio = 1.0;

--- a/test/ui/widgets/greeting_seed_form_test.dart
+++ b/test/ui/widgets/greeting_seed_form_test.dart
@@ -297,11 +297,7 @@ void main() {
     tester.view.physicalSize = const Size(1400, 2400);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
-    GreetingRealismSeed? live = const GreetingRealismSeed(
-      shortTermBond: 20,
-      trustLevel: 10,
-      needsBaselineHunger: 25,
-    );
+    GreetingRealismSeed? live = const GreetingRealismSeed();
 
     await tester.pumpWidget(
       MaterialApp(
@@ -322,25 +318,68 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    Future<void> clearBox(String shown) async {
-      final field = find.widgetWithText(TextField, shown);
-      expect(field, findsOneWidget);
+    Finder boxFor(String label) {
+      return find.descendant(
+        of: find.byWidgetPredicate(
+          (w) => w is SliderWithInput && w.label == label,
+        ),
+        matching: find.byType(TextField),
+      );
+    }
+
+    Future<void> authorBox(String label, String value) async {
+      final field = boxFor(label);
+      expect(field, findsOneWidget, reason: 'number box for $label');
+      await tester.enterText(field, value);
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> inheritBox(String label) async {
+      final field = boxFor(label);
+      expect(field, findsOneWidget, reason: 'inherit box for $label');
       await tester.enterText(field, '');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
     }
 
-    await clearBox('20');
-    expect(live!.shortTermBond, isNull, reason: 'bond slider empty writes inherit');
+    await authorBox('Short-term bond', '20');
+    expect(live!.shortTermBond, 20);
+    await authorBox('Trust', '10');
+    expect(live!.trustLevel, 10);
+    await authorBox('Hunger', '25');
+    expect(live!.needsBaselineHunger, 25);
 
-    await clearBox('10');
-    expect(live!.trustLevel, isNull, reason: 'trust slider empty writes inherit');
+    await inheritBox('Short-term bond');
+    expect(
+      live!.shortTermBond,
+      isNull,
+      reason: 'bond empty number box writes inherit, not leftover 20 or 0',
+    );
+    expect(live!.shortTermBond, isNot(0));
 
-    await clearBox('25');
+    await inheritBox('Trust');
+    expect(
+      live!.trustLevel,
+      isNull,
+      reason: 'trust empty number box writes inherit, not leftover 10 or 0',
+    );
+    expect(live!.trustLevel, isNot(0));
+
+    await inheritBox('Hunger');
     expect(
       live!.needsBaselineHunger,
       isNull,
-      reason: 'needs slider empty writes inherit',
+      reason: 'needs empty number box writes inherit, not leftover 25 or 0',
     );
+    expect(live!.needsBaselineHunger, isNot(0));
+
+    await tester.pumpAndSettle();
+    expect(live!.shortTermBond, isNull);
+    expect(live!.trustLevel, isNull);
+    expect(live!.needsBaselineHunger, isNull);
+    expect(live!.shortTermBond, isNot(0));
+    expect(live!.trustLevel, isNot(0));
+    expect(live!.needsBaselineHunger, isNot(0));
   });
 }

--- a/test/ui/widgets/greeting_seed_form_test.dart
+++ b/test/ui/widgets/greeting_seed_form_test.dart
@@ -1,0 +1,158 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// GreetingSeedForm: Story begins is date+time, {} looks inherit (mild) /
+// sliders unset, toggle off/on stashes, fresh enable persists null not {}.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/ui/widgets/greeting_seed_form.dart';
+import 'package:front_porch_ai/ui/widgets/slider_with_input.dart';
+import 'package:front_porch_ai/ui/widgets/story_begins_row.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> pumpForm(
+    WidgetTester tester, {
+    required GreetingRealismSeed? seed,
+    required ValueChanged<GreetingRealismSeed?> onChanged,
+  }) async {
+    tester.view.physicalSize = const Size(1400, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: GreetingSeedForm(
+              seed: seed,
+              onChanged: onChanged,
+              showNeeds: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('empty overlay {} looks inherit (mild) and sliders are unset', (
+    tester,
+  ) async {
+    await pumpForm(
+      tester,
+      seed: const GreetingRealismSeed(),
+      onChanged: (_) {},
+    );
+
+    expect(find.text('inherit (mild)'), findsWidgets);
+    expect(find.text('inherit (morning)'), findsWidgets);
+    expect(find.text('moderate'), findsNothing);
+
+    final sliders = tester
+        .widgetList<SliderWithInput>(find.byType(SliderWithInput))
+        .toList();
+    expect(sliders, isNotEmpty);
+    for (final slider in sliders) {
+      expect(
+        slider.unset,
+        isTrue,
+        reason:
+            '{} must not author a moderate / 0 / 80 default on ${slider.label}',
+      );
+    }
+  });
+
+  testWidgets('Story begins has date and time chips', (tester) async {
+    await pumpForm(
+      tester,
+      seed: const GreetingRealismSeed(),
+      onChanged: (_) {},
+    );
+
+    expect(find.byType(StoryBeginsRow), findsOneWidget);
+    expect(find.textContaining('Story begins'), findsOneWidget);
+    expect(find.textContaining('Opens at'), findsOneWidget);
+  });
+
+  testWidgets('toggle off then on stashes the prior authored seed', (
+    tester,
+  ) async {
+    GreetingRealismSeed? live = const GreetingRealismSeed(
+      characterEmotion: 'furious',
+      storyStartDate: '1887-06-01',
+      storyStartTime: '23:47',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return SingleChildScrollView(
+                child: GreetingSeedForm(
+                  seed: live,
+                  onChanged: (next) => setState(() => live = next),
+                  showNeeds: true,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+    expect(live, isNull, reason: 'toggle off persists null (read the room)');
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+    expect(live, isNotNull);
+    expect(live!.characterEmotion, 'furious');
+    expect(live!.storyStartDate, '1887-06-01');
+    expect(live!.storyStartTime, '23:47');
+  });
+
+  testWidgets('fresh enable persists null, not empty {}', (tester) async {
+    GreetingRealismSeed? live;
+    Object? lastEmitted = 'unset';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              return SingleChildScrollView(
+                child: GreetingSeedForm(
+                  seed: live,
+                  onChanged: (next) {
+                    lastEmitted = next;
+                    setState(() => live = next);
+                  },
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Story begins'), findsNothing);
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(
+      lastEmitted,
+      isNull,
+      reason: 'fresh enable must persist null, not {}',
+    );
+    expect(live, isNull);
+    expect(find.byType(StoryBeginsRow), findsOneWidget);
+  });
+}

--- a/test/utils/group_realism_blobs_test.dart
+++ b/test/utils/group_realism_blobs_test.dart
@@ -191,6 +191,31 @@ void main() {
       });
 
       test(
+        'blank greet row does not steal furious off Get out on the blob',
+        () {
+          final furious = GreetingRealismSeed(characterEmotion: 'furious');
+          final blobs = buildGroupRealismBlobs(
+            seeds: {'a': defaultGroupMemberRealismSeed()},
+            needsEnabled: true,
+            timeOfDay: 'morning',
+            dayCount: 1,
+            alternateGreetings: ['', 'Get out.'],
+            greetingSeeds: [null, furious],
+          );
+          expect(parseGroupAlternateGreetings(blobs.defaultMemberJson), [
+            'Get out.',
+          ]);
+          final seeds = parseGroupGreetingSeeds(blobs.defaultMemberJson);
+          expect(seeds, hasLength(1));
+          expect(
+            seeds.first!.characterEmotion,
+            'furious',
+            reason: 'compactGreetingPairs must keep furious on Get out.',
+          );
+        },
+      );
+
+      test(
         'reads the canonical top-level keys buildGroupRealismBlobs writes',
         () {
           final blobs = buildGroupRealismBlobs(

--- a/test/utils/group_realism_blobs_test.dart
+++ b/test/utils/group_realism_blobs_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:front_porch_ai/models/character_card.dart';
 import 'package:front_porch_ai/models/greeting_realism_seed.dart';
+import 'package:front_porch_ai/models/group_chat.dart';
 import 'package:front_porch_ai/models/group_member.dart';
 import 'package:front_porch_ai/utils/character_id.dart';
 import 'package:front_porch_ai/utils/group_realism_blobs.dart';
@@ -189,6 +190,64 @@ void main() {
           'night',
         );
       });
+
+      test(
+        'dirty blob empty-greet drop is paired; prefix leftover stays off Get out',
+        () {
+          const prefixDirty =
+              '{"alternateGreetings":["","Get out."],"greetingSeeds":[{"character_emotion":"furious"}]}';
+          expect(parseGroupAlternateGreetings(prefixDirty), ['Get out.']);
+          expect(
+            parseGroupGreetingSeeds(prefixDirty),
+            isEmpty,
+            reason:
+                'furious sat on the blank row; unpaired drop would load it onto Get out',
+          );
+
+          const pairedDirty =
+              '{"alternateGreetings":["","Get out."],"greetingSeeds":[null,{"character_emotion":"furious"}]}';
+          expect(parseGroupAlternateGreetings(pairedDirty), ['Get out.']);
+          expect(
+            parseGroupGreetingSeeds(pairedDirty).first!.characterEmotion,
+            'furious',
+            reason: 'paired slot 1 stays on Get out',
+          );
+        },
+      );
+
+      test(
+        'GroupChat.fromJson pairs empty-greet drop with the seed index',
+        () {
+          final g = GroupChat.fromJson({
+            'id': 'g1',
+            'name': 'House',
+            'first_message': 'Come in.',
+            'alternate_greetings': ['', 'Get out.'],
+            'greeting_seeds': [
+              {'character_emotion': 'furious'},
+            ],
+          });
+          expect(g.alternateGreetings, ['Get out.']);
+          expect(
+            g.greetingSeeds,
+            isEmpty,
+            reason: 'prefix leftover must not load furious onto Get out',
+          );
+
+          final kept = GroupChat.fromJson({
+            'id': 'g2',
+            'name': 'House',
+            'first_message': 'Come in.',
+            'alternate_greetings': ['', 'Get out.'],
+            'greeting_seeds': [
+              null,
+              {'character_emotion': 'furious'},
+            ],
+          });
+          expect(kept.alternateGreetings, ['Get out.']);
+          expect(kept.greetingSeeds.single!.characterEmotion, 'furious');
+        },
+      );
 
       test(
         'blank greet row does not steal furious off Get out on the blob',

--- a/test/utils/group_realism_blobs_test.dart
+++ b/test/utils/group_realism_blobs_test.dart
@@ -250,6 +250,54 @@ void main() {
       );
 
       test(
+        'JSON-null greet slots stay aligned then compact keeps furious on Get out',
+        () {
+          const blob =
+              '{"alternateGreetings":[null,"Get out."],"greetingSeeds":[null,{"character_emotion":"furious"}]}';
+          expect(parseGroupAlternateGreetings(blob), ['Get out.']);
+          expect(
+            parseGroupGreetingSeeds(blob).single!.characterEmotion,
+            'furious',
+            reason: 'dropping the null greet first would lose or mis-zip furious',
+          );
+
+          final g = GroupChat.fromJson({
+            'id': 'g-null-slot',
+            'name': 'House',
+            'first_message': 'Come in.',
+            'alternate_greetings': [null, 'Get out.'],
+            'greeting_seeds': [
+              null,
+              {'character_emotion': 'furious'},
+            ],
+          });
+          expect(g.alternateGreetings, ['Get out.']);
+          expect(g.greetingSeeds.single!.characterEmotion, 'furious');
+        },
+      );
+
+      test('GroupChat.toJson/fromJson round-trips greeting_seeds', () {
+        final original = GroupChat(
+          id: 'g-persist-seeds',
+          name: 'House',
+          firstMessage: 'Come in.',
+          alternateGreetings: ['Get out.'],
+          greetingSeeds: [
+            GreetingRealismSeed(characterEmotion: 'furious'),
+          ],
+        );
+        final json = original.toJson();
+        expect(
+          json.containsKey('greeting_seeds'),
+          isTrue,
+          reason: 'toJson used to omit greeting_seeds and lose them on reload',
+        );
+        final back = GroupChat.fromJson(json);
+        expect(back.alternateGreetings, ['Get out.']);
+        expect(back.greetingSeeds.single!.characterEmotion, 'furious');
+      });
+
+      test(
         'blank greet row does not steal furious off Get out on the blob',
         () {
           final furious = GreetingRealismSeed(characterEmotion: 'furious');

--- a/web_ui/src/components/GreetingSeedForm.test.tsx
+++ b/web_ui/src/components/GreetingSeedForm.test.tsx
@@ -122,4 +122,66 @@ describe('GreetingSeedForm Story begins and inherit', () => {
     expect(container.querySelector('input[type="date"]')).toBeTruthy();
     expect(container.querySelector('input[type="time"]')).toBeTruthy();
   });
+
+  it('bond/trust/needs sliders authored then inherit persist undefined, not 0', () => {
+    const emitted: Array<GreetingSeed | null> = [];
+    render({}, (next) => {
+      emitted.push(next);
+    });
+
+    function sliderRow(label: string): HTMLElement {
+      const rows = Array.from(container.querySelectorAll('.realism-slider')) as HTMLElement[];
+      const row = rows.find((el) => {
+        const first = el.querySelector('.realism-slider-head > span');
+        return first?.textContent === label;
+      });
+      expect(row, `slider row ${label}`).toBeTruthy();
+      return row!;
+    }
+
+    function setRange(label: string, value: number) {
+      const range = sliderRow(label).querySelector('input[type="range"]') as HTMLInputElement;
+      const desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!;
+      act(() => {
+        desc.set!.call(range, String(value));
+        range.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+
+    function clickInherit(label: string) {
+      const btn = sliderRow(label).querySelector('button.realism-badge.muted') as HTMLButtonElement;
+      expect(btn, `inherit button for ${label}`).toBeTruthy();
+      expect(btn.textContent).toBe('inherit');
+      act(() => {
+        btn.click();
+      });
+    }
+
+    setRange('Short-term bond', 20);
+    expect(emitted.at(-1)?.shortTermBond).toBe(20);
+    setRange('Trust', 10);
+    expect(emitted.at(-1)?.trustLevel).toBe(10);
+    setRange('Hunger', 25);
+    expect(emitted.at(-1)?.needsBaselineHunger).toBe(25);
+
+    clickInherit('Short-term bond');
+    expect(emitted.at(-1)?.shortTermBond).toBeUndefined();
+    expect(emitted.at(-1)?.shortTermBond).not.toBe(0);
+
+    clickInherit('Trust');
+    expect(emitted.at(-1)?.trustLevel).toBeUndefined();
+    expect(emitted.at(-1)?.trustLevel).not.toBe(0);
+
+    clickInherit('Hunger');
+    const last = emitted.at(-1)!;
+    expect(last.shortTermBond).toBeUndefined();
+    expect(last.trustLevel).toBeUndefined();
+    expect(last.needsBaselineHunger).toBeUndefined();
+    expect(last.shortTermBond).not.toBe(0);
+    expect(last.trustLevel).not.toBe(0);
+    expect(last.needsBaselineHunger).not.toBe(0);
+    expect(last.shortTermBond).not.toBe(20);
+    expect(last.trustLevel).not.toBe(10);
+    expect(last.needsBaselineHunger).not.toBe(25);
+  });
 });

--- a/web_ui/src/components/GreetingSeedForm.test.tsx
+++ b/web_ui/src/components/GreetingSeedForm.test.tsx
@@ -12,6 +12,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { GreetingSeedForm } from './GreetingSeedForm';
 import type { GreetingSeed } from './realism/realismTypes';
 
+function lastOf<T>(items: T[]): T | undefined {
+  return items[items.length - 1];
+}
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -93,11 +97,11 @@ describe('GreetingSeedForm Story begins and inherit', () => {
     );
 
     clickToggle(false);
-    expect(emitted.at(-1)).toBeNull();
+    expect(lastOf(emitted)).toBeNull();
     expect(container.querySelector('input[type="date"]')).toBeNull();
 
     clickToggle(true);
-    const restored = emitted.at(-1);
+    const restored = lastOf(emitted);
     expect(restored).toEqual({
       characterEmotion: 'furious',
       storyStartDate: '1887-06-01',
@@ -158,22 +162,22 @@ describe('GreetingSeedForm Story begins and inherit', () => {
     }
 
     setRange('Short-term bond', 20);
-    expect(emitted.at(-1)?.shortTermBond).toBe(20);
+    expect(lastOf(emitted)?.shortTermBond).toBe(20);
     setRange('Trust', 10);
-    expect(emitted.at(-1)?.trustLevel).toBe(10);
+    expect(lastOf(emitted)?.trustLevel).toBe(10);
     setRange('Hunger', 25);
-    expect(emitted.at(-1)?.needsBaselineHunger).toBe(25);
+    expect(lastOf(emitted)?.needsBaselineHunger).toBe(25);
 
     clickInherit('Short-term bond');
-    expect(emitted.at(-1)?.shortTermBond).toBeUndefined();
-    expect(emitted.at(-1)?.shortTermBond).not.toBe(0);
+    expect(lastOf(emitted)?.shortTermBond).toBeUndefined();
+    expect(lastOf(emitted)?.shortTermBond).not.toBe(0);
 
     clickInherit('Trust');
-    expect(emitted.at(-1)?.trustLevel).toBeUndefined();
-    expect(emitted.at(-1)?.trustLevel).not.toBe(0);
+    expect(lastOf(emitted)?.trustLevel).toBeUndefined();
+    expect(lastOf(emitted)?.trustLevel).not.toBe(0);
 
     clickInherit('Hunger');
-    const last = emitted.at(-1)!;
+    const last = lastOf(emitted)!;
     expect(last.shortTermBond).toBeUndefined();
     expect(last.trustLevel).toBeUndefined();
     expect(last.needsBaselineHunger).toBeUndefined();

--- a/web_ui/src/components/GreetingSeedForm.test.tsx
+++ b/web_ui/src/components/GreetingSeedForm.test.tsx
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Web GreetingSeedForm: Story begins is date+time, {} looks inherit (mild) /
+// sliders unset, toggle off/on stashes, fresh enable persists null not {}.
+
+import { act } from 'react-dom/test-utils';
+import { createRoot, type Root } from 'react-dom/client';
+import { createElement, useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { GreetingSeedForm } from './GreetingSeedForm';
+import type { GreetingSeed } from './realism/realismTypes';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Harness({
+  initial,
+  onEmit,
+}: {
+  initial: GreetingSeed | null;
+  onEmit?: (next: GreetingSeed | null) => void;
+}) {
+  const [seed, setSeed] = useState<GreetingSeed | null>(initial);
+  return createElement(GreetingSeedForm, {
+    seed,
+    onChange: (next) => {
+      onEmit?.(next);
+      setSeed(next);
+    },
+    showNeeds: true,
+  });
+}
+
+function render(initial: GreetingSeed | null, onEmit?: (next: GreetingSeed | null) => void) {
+  act(() => {
+    root.render(createElement(Harness, { initial, onEmit }));
+  });
+}
+
+function clickToggle(on: boolean) {
+  const toggle = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+  const desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'checked')!;
+  act(() => {
+    desc.set!.call(toggle, on);
+    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('GreetingSeedForm Story begins and inherit', () => {
+  it('empty overlay {} shows inherit (mild) and unset sliders, not moderate', () => {
+    render({});
+    expect(container.textContent).toContain('inherit (mild)');
+    expect(container.textContent).toContain('inherit (morning)');
+    const inheritBadges = container.querySelectorAll('.realism-badge.muted');
+    expect(inheritBadges.length).toBeGreaterThan(0);
+    for (const badge of inheritBadges) {
+      expect(badge.textContent).toBe('inherit');
+    }
+    const intensity = container.querySelector('select') as HTMLSelectElement;
+    expect(intensity.value).toBe('');
+  });
+
+  it('Story begins has date and time inputs', () => {
+    render({});
+    const date = container.querySelector('input[type="date"]') as HTMLInputElement;
+    const time = container.querySelector('input[type="time"]') as HTMLInputElement;
+    expect(date).toBeTruthy();
+    expect(time).toBeTruthy();
+    expect(container.textContent).toContain('Story begins');
+    expect(container.textContent).toContain('Opens at');
+  });
+
+  it('toggle off then on stashes the prior authored seed', () => {
+    const emitted: Array<GreetingSeed | null> = [];
+    render(
+      { characterEmotion: 'furious', storyStartDate: '1887-06-01', storyStartTime: '23:47' },
+      (next) => {
+        emitted.push(next);
+      },
+    );
+
+    clickToggle(false);
+    expect(emitted.at(-1)).toBeNull();
+    expect(container.querySelector('input[type="date"]')).toBeNull();
+
+    clickToggle(true);
+    const restored = emitted.at(-1);
+    expect(restored).toEqual({
+      characterEmotion: 'furious',
+      storyStartDate: '1887-06-01',
+      storyStartTime: '23:47',
+    });
+    const date = container.querySelector('input[type="date"]') as HTMLInputElement;
+    const time = container.querySelector('input[type="time"]') as HTMLInputElement;
+    expect(date.value).toBe('1887-06-01');
+    expect(time.value).toBe('23:47');
+  });
+
+  it('fresh enable persists null, not empty {}', () => {
+    const emitted: Array<GreetingSeed | null> = [];
+    render(null, (next) => {
+      emitted.push(next);
+    });
+    expect(container.querySelector('input[type="date"]')).toBeNull();
+
+    clickToggle(true);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toBeNull();
+    expect(container.querySelector('input[type="date"]')).toBeTruthy();
+    expect(container.querySelector('input[type="time"]')).toBeTruthy();
+  });
+});

--- a/web_ui/src/components/GreetingSeedForm.test.tsx
+++ b/web_ui/src/components/GreetingSeedForm.test.tsx
@@ -45,10 +45,14 @@ function render(initial: GreetingSeed | null, onEmit?: (next: GreetingSeed | nul
 
 function clickToggle(on: boolean) {
   const toggle = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
-  const desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'checked')!;
+  if (!toggle) {
+    throw new Error('Custom opening state toggle not found');
+  }
+  if (toggle.checked === on) return;
+  // React 18 wires checkbox onChange to the click path. Setting checked +
+  // dispatching a synthetic change does not emit (lastOf was undefined).
   act(() => {
-    desc.set!.call(toggle, on);
-    toggle.dispatchEvent(new Event('change', { bubbles: true }));
+    toggle.click();
   });
 }
 

--- a/web_ui/src/components/GreetingSeedForm.tsx
+++ b/web_ui/src/components/GreetingSeedForm.tsx
@@ -3,7 +3,10 @@
 //
 // Compact opening-state editor for one alternate greeting. Off (null) =
 // reading-the-room; on = authored seed (blank fields inherit card defaults).
+// Toggle-on with no fields persists null, not {}. Toggle off/on restores the
+// last authored seed (including a desktop calendar) instead of wiping to {}.
 
+import { useEffect, useRef, useState } from 'react';
 import { Slider, SelectRow, ToggleRow } from './realism/controls';
 import { ChipList } from './realism/ChipList';
 import {
@@ -26,7 +29,16 @@ export function GreetingSeedForm({
   showNeeds?: boolean;
   showInventory?: boolean;
 }) {
-  const enabled = seed != null;
+  const stash = useRef<GreetingSeed | null>(seed);
+  const [uiOn, setUiOn] = useState(seed != null);
+  useEffect(() => {
+    if (seed != null) {
+      stash.current = seed;
+      setUiOn(true);
+    }
+  }, [seed]);
+
+  const enabled = uiOn || seed != null;
   const s = seed ?? {};
   const patch = (p: Partial<GreetingSeed>) => onChange({ ...s, ...p });
   const wardrobe = inventoryToChips(s.inventory ?? {});
@@ -36,11 +48,22 @@ export function GreetingSeedForm({
         label="Custom opening state"
         hint={
           enabled
-            ? 'Blank fields inherit the card. This alt will not read the room.'
+            ? 'Blank fields inherit the card. This alt will not read the room once a seed is authored.'
             : 'No seed — the engine reads the room from this greeting.'
         }
         value={enabled}
-        onChange={(on) => onChange(on ? {} : null)}
+        onChange={(on) => {
+          if (on) {
+            setUiOn(true);
+            // Restore last authored seed (calendar / {}). Fresh enable stays
+            // null — not {} — until a field is set.
+            onChange(stash.current);
+          } else {
+            stash.current = seed;
+            setUiOn(false);
+            onChange(null);
+          }
+        }}
       />
       {enabled && (
         <>
@@ -56,15 +79,17 @@ export function GreetingSeedForm({
           </label>
           <SelectRow
             label="Intensity"
-            value={s.emotionIntensity ?? 'moderate'}
+            value={s.emotionIntensity ?? ''}
+            placeholder="inherit (mild)"
             options={INTENSITY_OPTIONS.map((i) => ({ value: i, label: titleCase(i) }))}
-            onChange={(v) => patch({ emotionIntensity: v })}
+            onChange={(v) => patch({ emotionIntensity: v || undefined })}
           />
           <Slider
             label="Short-term bond"
             min={-300}
             max={300}
             value={s.shortTermBond ?? 0}
+            unset={s.shortTermBond === undefined}
             onChange={(n) => patch({ shortTermBond: n })}
           />
           <Slider
@@ -72,6 +97,7 @@ export function GreetingSeedForm({
             min={-300}
             max={300}
             value={s.longTermBond ?? 0}
+            unset={s.longTermBond === undefined}
             onChange={(n) => patch({ longTermBond: n })}
           />
           <Slider
@@ -79,22 +105,46 @@ export function GreetingSeedForm({
             min={-100}
             max={100}
             value={s.trustLevel ?? 0}
+            unset={s.trustLevel === undefined}
             onChange={(n) => patch({ trustLevel: n })}
           />
           <SelectRow
             label="Time of day"
-            value={s.timeOfDay ?? 'morning'}
+            value={s.timeOfDay ?? ''}
+            placeholder="inherit (morning)"
             options={TIME_OPTIONS.map((t) => ({ value: t, label: titleCase(t) }))}
-            onChange={(v) => patch({ timeOfDay: v })}
+            onChange={(v) => patch({ timeOfDay: v || undefined })}
           />
           <label>
             Day number
             <input
               type="number"
               min={1}
-              value={s.dayCount ?? 1}
+              value={s.dayCount ?? ''}
+              placeholder="inherit (day 1)"
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10);
+                patch({ dayCount: Number.isFinite(n) && n >= 1 ? n : undefined });
+              }}
+            />
+          </label>
+          <label>
+            Story begins
+            <input
+              type="date"
+              value={s.storyStartDate ?? ''}
               onChange={(e) =>
-                patch({ dayCount: Math.max(1, parseInt(e.target.value, 10) || 1) })
+                patch({ storyStartDate: e.target.value || undefined })
+              }
+            />
+          </label>
+          <label>
+            Opens at
+            <input
+              type="time"
+              value={s.storyStartTime ?? ''}
+              onChange={(e) =>
+                patch({ storyStartTime: e.target.value || undefined })
               }
             />
           </label>
@@ -110,7 +160,7 @@ export function GreetingSeedForm({
           </label>
           {showNeeds && (
             <>
-              <p className="muted small">Needs baselines (0–100). Default 80 inherits the card slider rest.</p>
+              <p className="muted small">Needs baselines (0–100). Blank inherits the card.</p>
               {NEEDS.map(([key, label]) => (
                 <Slider
                   key={key}
@@ -118,6 +168,7 @@ export function GreetingSeedForm({
                   min={0}
                   max={100}
                   value={(s[key] as number | undefined) ?? 80}
+                  unset={(s[key] as number | undefined) === undefined}
                   onChange={(n) => patch({ [key]: n })}
                 />
               ))}

--- a/web_ui/src/components/GreetingSeedForm.tsx
+++ b/web_ui/src/components/GreetingSeedForm.tsx
@@ -91,6 +91,7 @@ export function GreetingSeedForm({
             value={s.shortTermBond ?? 0}
             unset={s.shortTermBond === undefined}
             onChange={(n) => patch({ shortTermBond: n })}
+            onClear={() => patch({ shortTermBond: undefined })}
           />
           <Slider
             label="Long-term bond"
@@ -99,6 +100,7 @@ export function GreetingSeedForm({
             value={s.longTermBond ?? 0}
             unset={s.longTermBond === undefined}
             onChange={(n) => patch({ longTermBond: n })}
+            onClear={() => patch({ longTermBond: undefined })}
           />
           <Slider
             label="Trust"
@@ -107,6 +109,7 @@ export function GreetingSeedForm({
             value={s.trustLevel ?? 0}
             unset={s.trustLevel === undefined}
             onChange={(n) => patch({ trustLevel: n })}
+            onClear={() => patch({ trustLevel: undefined })}
           />
           <SelectRow
             label="Time of day"
@@ -170,6 +173,7 @@ export function GreetingSeedForm({
                   value={(s[key] as number | undefined) ?? 80}
                   unset={(s[key] as number | undefined) === undefined}
                   onChange={(n) => patch({ [key]: n })}
+                  onClear={() => patch({ [key]: undefined })}
                 />
               ))}
             </>

--- a/web_ui/src/components/GroupSettings.tsx
+++ b/web_ui/src/components/GroupSettings.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api/client';
 import { AltGreetingsEditor } from './AltGreetingsEditor';
-import { type GreetingSeed } from './realism/realismTypes';
+import { type GreetingSeed, compactGreetingPairs } from './realism/realismTypes';
 
 export interface GroupBlock {
   name: string;
@@ -100,13 +100,15 @@ export function GroupSettings({
           greetings={alts}
           onChange={(g) => {
             setAlts(g);
-            save({ alternateGreetings: g.filter((x) => x.trim()) });
+            const paired = compactGreetingPairs(g, seeds);
+            save({ alternateGreetings: paired.greetings, greetingSeeds: paired.seeds });
           }}
           seeds={seeds}
           showNeeds
           onSeedsChange={(s) => {
             setSeeds(s);
-            save({ greetingSeeds: s });
+            const paired = compactGreetingPairs(alts, s);
+            save({ alternateGreetings: paired.greetings, greetingSeeds: paired.seeds });
           }}
         />
         <h4 className="section-label">Per-member prompt overrides</h4>

--- a/web_ui/src/components/realism/controls.tsx
+++ b/web_ui/src/components/realism/controls.tsx
@@ -15,6 +15,7 @@ export function Slider({
   badge,
   step = 1,
   unset = false,
+  onClear,
 }: {
   label: string;
   min: number;
@@ -24,6 +25,7 @@ export function Slider({
   badge?: string;
   step?: number;
   unset?: boolean;
+  onClear?: () => void;
 }) {
   return (
     <div className="realism-slider">
@@ -31,6 +33,10 @@ export function Slider({
         <span>{label}</span>
         {unset ? (
           <span className="realism-badge muted">inherit</span>
+        ) : onClear ? (
+          <button type="button" className="realism-badge muted" onClick={onClear}>
+            inherit
+          </button>
         ) : (
           badge !== undefined && <span className="realism-badge">{badge}</span>
         )}

--- a/web_ui/src/components/realism/controls.tsx
+++ b/web_ui/src/components/realism/controls.tsx
@@ -14,6 +14,7 @@ export function Slider({
   onChange,
   badge,
   step = 1,
+  unset = false,
 }: {
   label: string;
   min: number;
@@ -22,19 +23,24 @@ export function Slider({
   onChange: (v: number) => void;
   badge?: string;
   step?: number;
+  unset?: boolean;
 }) {
   return (
     <div className="realism-slider">
       <div className="realism-slider-head">
         <span>{label}</span>
-        {badge !== undefined && <span className="realism-badge">{badge}</span>}
+        {unset ? (
+          <span className="realism-badge muted">inherit</span>
+        ) : (
+          badge !== undefined && <span className="realism-badge">{badge}</span>
+        )}
       </div>
       <input
         type="range"
         min={min}
         max={max}
         step={step}
-        value={value}
+        value={unset ? min : value}
         onChange={(e) => onChange(parseInt(e.target.value, 10))}
       />
     </div>
@@ -70,16 +76,21 @@ export function SelectRow({
   value,
   options,
   onChange,
+  placeholder,
 }: {
   label: string;
   value: string;
   options: { value: string; label: string }[];
   onChange: (v: string) => void;
+  placeholder?: string;
 }) {
   return (
     <label className="realism-field">
       <span>{label}</span>
       <select value={value} onChange={(e) => onChange(e.target.value)}>
+        {placeholder !== undefined && (
+          <option value="">{placeholder}</option>
+        )}
         {options.map((o) => (
           <option key={o.value} value={o.value}>
             {o.label}

--- a/web_ui/src/components/realism/realismTypes.test.ts
+++ b/web_ui/src/components/realism/realismTypes.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 import {
   REALISM_DEFAULTS,
   chipsToInventory,
+  compactGreetingPairs,
   inventoryToChips,
   realismFromDetail,
 } from './realismTypes';
@@ -182,5 +183,13 @@ describe('wardrobe chip text mirrors the Dart implementation', () => {
     expect(chipsToInventory(reopened.worn, reopened.carrying)).toEqual(first);
     expect(reopened.worn).toEqual(worn);
     expect(reopened.carrying).toEqual(carrying);
+  });
+});
+
+describe('compactGreetingPairs keeps seed on the surviving greet', () => {
+  it('drops the blank row and keeps furious on Get out.', () => {
+    const paired = compactGreetingPairs(['', 'Get out.'], [null, { characterEmotion: 'furious' }]);
+    expect(paired.greetings).toEqual(['Get out.']);
+    expect(paired.seeds).toEqual([{ characterEmotion: 'furious' }]);
   });
 });

--- a/web_ui/src/components/realism/realismTypes.test.ts
+++ b/web_ui/src/components/realism/realismTypes.test.ts
@@ -192,4 +192,13 @@ describe('compactGreetingPairs keeps seed on the surviving greet', () => {
     expect(paired.greetings).toEqual(['Get out.']);
     expect(paired.seeds).toEqual([{ characterEmotion: 'furious' }]);
   });
+
+  it('a blank middle row does not steal furious off Get out.', () => {
+    const paired = compactGreetingPairs(
+      ['Come in.', '', 'Get out.'],
+      [null, { characterEmotion: 'stolen' }, { characterEmotion: 'furious' }],
+    );
+    expect(paired.greetings).toEqual(['Come in.', 'Get out.']);
+    expect(paired.seeds).toEqual([null, { characterEmotion: 'furious' }]);
+  });
 });

--- a/web_ui/src/components/realism/realismTypes.ts
+++ b/web_ui/src/components/realism/realismTypes.ts
@@ -330,3 +330,27 @@ export function decayDescription(v: number): string {
   if (v <= 12) return `Fast (${v})`;
   return `Very Fast (${v})`;
 }
+
+
+/** Drop empty greet rows and their paired seed slots together. */
+export function compactGreetingPairs(
+  greetings: string[],
+  seeds: (GreetingSeed | null)[],
+): { greetings: string[]; seeds: (GreetingSeed | null)[] } {
+  const n = greetings.length;
+  const aligned =
+    seeds.length === n
+      ? seeds
+      : seeds.length > n
+        ? seeds.slice(0, n)
+        : [...seeds, ...Array<GreetingSeed | null>(n - seeds.length).fill(null)];
+  const outG: string[] = [];
+  const outS: (GreetingSeed | null)[] = [];
+  for (let i = 0; i < n; i++) {
+    if (!greetings[i].trim()) continue;
+    outG.push(greetings[i]);
+    outS.push(aligned[i] ?? null);
+  }
+  while (outS.length && outS[outS.length - 1] == null) outS.pop();
+  return { greetings: outG, seeds: outS };
+}

--- a/web_ui/src/pages/CharacterEditPage.tsx
+++ b/web_ui/src/pages/CharacterEditPage.tsx
@@ -18,7 +18,7 @@ import { RealismFormSection } from '../components/realism/RealismFormSection';
 import { useAdultThemes } from '../components/realism/useAdultThemes';
 import { NeedsFormSection } from '../components/realism/NeedsFormSection';
 import { TokenBadge } from '../components/realism/controls';
-import { type RealismValues, realismFromDetail } from '../components/realism/realismTypes';
+import { type RealismValues, compactGreetingPairs, realismFromDetail } from '../components/realism/realismTypes';
 
 interface RawLore {
   name?: string;
@@ -145,11 +145,17 @@ export function CharacterEditPage() {
         systemPrompt: c.systemPrompt,
         postHistoryInstructions: c.postHistoryInstructions,
         tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
-        alternateGreetings: greetings.filter((g) => g.trim()),
-        worldNames,
-        ttsVoice,
-        lorebook: lore.filter((e) => e.key.trim() || e.content.trim()),
-        ...rv,
+        ...(() => {
+          const paired = compactGreetingPairs(greetings, rv.greetingSeeds);
+          return {
+            alternateGreetings: paired.greetings,
+            worldNames,
+            ttsVoice,
+            lorebook: lore.filter((e) => e.key.trim() || e.content.trim()),
+            ...rv,
+            greetingSeeds: paired.seeds,
+          };
+        })(),
       });
       navigate(-1);
     } catch (e) {

--- a/web_ui/src/pages/CreateCharacterPage.tsx
+++ b/web_ui/src/pages/CreateCharacterPage.tsx
@@ -17,7 +17,7 @@ import { AltGreetingsEditor } from '../components/AltGreetingsEditor';
 import { RealismFormSection } from '../components/realism/RealismFormSection';
 import { useAdultThemes } from '../components/realism/useAdultThemes';
 import { NeedsFormSection } from '../components/realism/NeedsFormSection';
-import { type RealismValues, REALISM_DEFAULTS, inventoryToChips } from '../components/realism/realismTypes';
+import { type RealismValues, REALISM_DEFAULTS, compactGreetingPairs, inventoryToChips } from '../components/realism/realismTypes';
 
 interface Draft extends RealismValues {
   name: string;
@@ -66,10 +66,12 @@ export function CreateCharacterPage() {
     setSaving(true);
     setError('');
     try {
+      const paired = compactGreetingPairs(d.alternateGreetings, d.greetingSeeds);
       const res = await api.post<{ id: string; name: string }>('/api/characters/create', {
         ...d,
         tags: d.tags.split(',').map((t) => t.trim()).filter(Boolean),
-        alternateGreetings: d.alternateGreetings.filter((g) => g.trim()),
+        alternateGreetings: paired.greetings,
+        greetingSeeds: paired.seeds,
       });
       // Open the new character so creation is verifiable end-to-end.
       try {


### PR DESCRIPTION
## Summary
Follow-up to `0919d2d9` (per-greeting Realism/Needs seeds). Team review HOLDs, then pairing leftovers.

- Groups match 1:1: unauthored alt Reads the Room; authored seed skips it; swipe 0 restores the member baseline.
- Greeting text and seeds stay paired on compact, parse, import, facades, Enhance/chargen, and live group write. Empty rows and omitted `greetingSeeds` do not slide leftover fury onto the next greet.
- Stale greeting eval cannot stomp swipe 0. Reload keeps an authored overlay.
- Desktop inherit-clear (intensity/time/day/bond/trust/needs). Web Story begins date+time. `GroupChat.toJson` persists `greeting_seeds`.
- Docs: first_mes keeps the card seed; RtR is unauthored alts only.
- Web GroupSettings is one save with both keys (two-POST leftover gone).

Known non-HOLD: unauthored alt re-Reads the Room on reload.

God file `chat_service.dart` stays 998. Untouched: identity/hoursMatch/derivePresence/TimeStrip.

## Test plan
- [x] Local TestChampion + Bug Hunter PASS at `47a0f51d` (product `dd9240db`)
- [x] Bug Hunter PASS on published PR #209
- [ ] CI green

HEAD `47a0f51d`. Squash when merging.
