### PR TITLE
chore(ui): drop unused objectivesInTree; one relationship header key

### DIFF
--- a/lib/ui/chat_components/sidebar/sidebar_body.dart
+++ b/lib/ui/chat_components/sidebar/sidebar_body.dart
@@ -127,10 +127,6 @@ class _SidebarBodyState extends State<SidebarBody> {
       section: section,
       isGroup: isGroup,
       isLite: isLite,
-      objectivesInTree:
-          !isGroup &&
-          !isLite &&
-          (chat.objectivesActive || section == OpenSectionEnv.objectives),
       collapseCharacterState: () => _characterStateKey.currentState?.collapse(),
       collapseJournal: () => _journalAccordionKey.currentState?.collapse(),
       expandCharacterState: () => _characterStateKey.currentState?.expand(),

--- a/lib/ui/pages/home/open_section_env.dart
+++ b/lib/ui/pages/home/open_section_env.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:flutter/widgets.dart';
+import 'package:front_porch_ai/ui/widgets/realism_form_section.dart';
 
 /// Compile-time launch hook (`--dart-define=OPEN_SECTION=timestrip`).
 ///
@@ -34,15 +35,10 @@ class OpenSectionEnv {
   }
 
   /// Apply [section]. Empty is a no-op. Unknown tokens debugPrint and return.
-  ///
-  /// [objectivesInTree] stays on the signature for call-site stability.
-  /// Apply does not early-return on it: the accordion is still built for
-  /// OPEN_SECTION=objectives when the feature flag is off.
   static void apply({
     required String section,
     required bool isGroup,
     required bool isLite,
-    required bool objectivesInTree,
     VoidCallback? collapseCharacterState,
     VoidCallback? collapseJournal,
     VoidCallback? expandCharacterState,
@@ -66,6 +62,8 @@ class OpenSectionEnv {
         afterExpanded(() => ensureKeyVisible(journalKey));
         return;
       case objectives:
+        // Apply does not early-return when the feature flag is off: the
+        // accordion is still built for OPEN_SECTION=objectives.
         if (isGroup || isLite) return;
         collapseCharacterState?.call();
         collapseJournal?.call();
@@ -100,16 +98,12 @@ class OpenSectionEnv {
     Scrollable.ensureVisible(ctx, alignment: 0.0, duration: Duration.zero);
   }
 
-  /// Key on the Relationship gap+header block in [RealismFormSection].
-  static const Key relationshipHeaderBlockKey = Key(
-    'relationship-header-block',
-  );
-
-  /// Scroll [relationshipHeaderBlockKey] into view via the overlay (the
-  /// Edit Character dialog), not a ChatPage-only walk. Alignment 0.0 parks
-  /// the 20px gap at the top of the Details body, below the TabBar.
+  /// Scroll [RealismFormSection.relationshipHeaderBlockKey] into view via
+  /// the overlay (the Edit Character dialog), not a ChatPage-only walk.
+  /// Alignment 0.0 parks the 20px gap at the top of the Details body,
+  /// below the TabBar.
   static void ensureRelationshipHeaderVisible(BuildContext context) {
-    ensureKeyedVisible(context, relationshipHeaderBlockKey);
+    ensureKeyedVisible(context, RealismFormSection.relationshipHeaderBlockKey);
   }
 
   static void ensureKeyedVisible(BuildContext context, Key key) {

--- a/test/ui/chat_components/open_section_apply_test.dart
+++ b/test/ui/chat_components/open_section_apply_test.dart
@@ -22,7 +22,6 @@ void main() {
       section: OpenSectionEnv.journal,
       isGroup: false,
       isLite: false,
-      objectivesInTree: true,
       collapseCharacterState: () => keys.cs.currentState?.collapse(),
       expandJournal: () => keys.journal.currentState?.expand(),
       journalKey: keys.journal,
@@ -45,7 +44,6 @@ void main() {
         section: OpenSectionEnv.objectives,
         isGroup: false,
         isLite: false,
-        objectivesInTree: true,
         collapseCharacterState: () => keys.cs.currentState?.collapse(),
         collapseJournal: () => keys.journal.currentState?.collapse(),
         expandObjectives: () => expanded++,
@@ -72,7 +70,6 @@ void main() {
       section: OpenSectionEnv.objectives,
       isGroup: false,
       isLite: false,
-      objectivesInTree: false,
       collapseCharacterState: () => keys.cs.currentState?.collapse(),
       collapseJournal: () => keys.journal.currentState?.collapse(),
       expandObjectives: () => expanded++,
@@ -97,7 +94,6 @@ void main() {
         section: OpenSectionEnv.objectives,
         isGroup: true,
         isLite: false,
-        objectivesInTree: true,
         collapseCharacterState: () => keys.cs.currentState?.collapse(),
         expandObjectives: () => expanded++,
       );
@@ -105,7 +101,6 @@ void main() {
         section: OpenSectionEnv.objectives,
         isGroup: false,
         isLite: true,
-        objectivesInTree: true,
         collapseCharacterState: () => keys.cs.currentState?.collapse(),
         expandObjectives: () => expanded++,
       );
@@ -119,7 +114,6 @@ void main() {
         section: OpenSectionEnv.objectives,
         isGroup: false,
         isLite: false,
-        objectivesInTree: true,
         collapseCharacterState: () => keys.cs.currentState?.collapse(),
         collapseJournal: () => keys.journal.currentState?.collapse(),
         expandObjectives: () => expanded++,
@@ -153,7 +147,6 @@ void main() {
         section: OpenSectionEnv.objectives,
         isGroup: false,
         isLite: false,
-        objectivesInTree: true,
         collapseCharacterState: () => keys.cs.currentState?.collapse(),
         collapseJournal: () => keys.journal.currentState?.collapse(),
         expandObjectives: () => expanded++,
@@ -194,7 +187,6 @@ void main() {
       section: OpenSectionEnv.timestrip,
       isGroup: false,
       isLite: false,
-      objectivesInTree: true,
       expandCharacterState: () => keys.cs.currentState?.expand(),
       timeStripKey: keys.timeStrip,
     );
@@ -214,7 +206,6 @@ void main() {
       section: OpenSectionEnv.timestrip,
       isGroup: false,
       isLite: true,
-      objectivesInTree: false,
       expandCharacterState: () => expanded++,
     );
     expect(expanded, 0);

--- a/test/ui/pages/home/open_section_env_test.dart
+++ b/test/ui/pages/home/open_section_env_test.dart
@@ -30,7 +30,6 @@ void main() {
       section: OpenSectionEnv.edit,
       isGroup: false,
       isLite: false,
-      objectivesInTree: true,
       onOpenEdit: () => opened++,
     );
     expect(opened, 1);
@@ -39,14 +38,12 @@ void main() {
       section: OpenSectionEnv.edit,
       isGroup: true,
       isLite: false,
-      objectivesInTree: true,
       onOpenEdit: () => opened++,
     );
     OpenSectionEnv.apply(
       section: OpenSectionEnv.edit,
       isGroup: false,
       isLite: true,
-      objectivesInTree: true,
       onOpenEdit: () => opened++,
     );
     expect(opened, 1);
@@ -58,7 +55,6 @@ void main() {
       section: '',
       isGroup: false,
       isLite: false,
-      objectivesInTree: true,
       expandJournal: () => touched++,
       onOpenEdit: () => touched++,
     );


### PR DESCRIPTION
Cleanup after #212 squash. No layout. No pixel chrome.

- Drop unused `objectivesInTree` from `OpenSectionEnv.apply` (it was never read).
- Keep one `relationship-header-block` key, defined on `RealismFormSection`.