### PR TITLE
docs(release): stamp v1.3.2 as Make a Wish

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-09-03 — docs(release): stamp v1.3.2 Make a Wish
+- **Why:** The promoted main branch still called Clock In the current stable
+  release and did not name the v1.3.2 codename.
+- **What:** Make a Wish is now the current stable release in the long-form
+  notes, in-app What's New heading, and README release callout.
+- **Files:** docs/release-notes.md, docs/main.md, README.md,
+  .claude/changelog.md
+
 ## 2026-08-26 — release: v1.3.1 Clock In promote notes
 - **Why:** In-app What's New and the GitHub README must name the patch
   before the tag. Release body is the first ## section of docs/main.md.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **A local-first AI companion for character chat & roleplay — Windows, macOS, and Linux.** Runs fully offline with local LLMs (KoboldCpp, oMLX, LM Studio, …), driven by a living **Realism Engine** (emotion, trust, needs, memory, pockets) with built-in **TTS and image generation** — and supports remote APIs like OpenRouter, Nano-GPT, and OpenAI with no lock-in when you want them. Open-source (**AGPL-3.0**). Built as a home for people who lost theirs when Backyard AI killed its desktop app.
 
-> ### 🎂 New in 1.3.2
+> ### 🎂 New in 1.3.2 — Make a Wish
 > - **Birthdays are real.** Characters and personas show their birthday on the card panel, on The Stoop, with gold/blue checks next to verified creators.
 > - **Worlds can skip the weather.** A lorebook-only world opts out of climate entirely — quiet places stay quiet.
 > - **Tool calls got faster.** Evals stop stalling on empty responses, and the judges share their prompt prefix.

--- a/docs/main.md
+++ b/docs/main.md
@@ -2,7 +2,7 @@
 
 These notes feed the in-app "Update Available" dialog for stable releases on `main`.
 
-## v1.3.2
+## v1.3.2 — Make a Wish
 
 - 🎂 **Calendar birthdays on character and persona cards** — your characters' birthdays
   are now visible on the card panel and on The Stoop. Gold/blue verified checks appear

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,7 @@
 
 Front Porch AI ships often: a stable release every few weeks, patch releases in between, and a nightly Rawhide build most days.
 
-**The current stable release is v1.3.1, "Clock In", released 2026-08-26.**
+**The current stable release is v1.3.2, "Make a Wish", released 2026-09-03.**
 
 This page is the long-form history — the headlines of every release, newest first. The [GitHub Releases page](https://github.com/linux4life1/front-porch-ai/releases) is always the complete and most up-to-date record, and it is also where the nightly builds live.
 
@@ -12,6 +12,7 @@ This page is the long-form history — the headlines of every release, newest fi
 
 ## Table of Contents
 
+- [v1.3.2 — Make a Wish](#v132--make-a-wish)
 - [v1.3.1 — Clock In](#v131--clock-in)
 - [v1.3 — Check Your Pockets](#v13--check-your-pockets)
 - [v1.2 — Occupy Mars](#v12--occupy-mars)
@@ -30,9 +31,21 @@ This page is the long-form history — the headlines of every release, newest fi
 
 ---
 
+## v1.3.2 — Make a Wish
+
+**Released:** 2026-09-03 (v1.3.2) — current stable
+
+- 🎂 **Make a wish** — birthdays now appear on character and persona cards and on The Stoop. Discussion authors also wear clear gold or blue verified checks.
+- 🌍 **Worlds can skip the weather** — lorebook-only worlds can turn climate off entirely. Quiet places no longer get sunshine and rain they never asked for.
+- ⚡ **Tool calls land faster** — structured evaluations recover from empty responses, retry more intelligently, and share one tools list across the prefix-sharing judges.
+
+Fixes and improvements in the same cut: replacing a portrait keeps Journal memories, Growth Rings, quests, and RAG intact; buried swipes no longer delete later entries; forks from one-to-one chats into groups carry live pockets; regeneration keeps Realism chips and Needs deltas; scoped Needs reprocessing touches only the selected needs; and AFK turns set the speaker and clock before post-reply evaluation. Sidebar controls wrap cleanly at more sizes, light-mode readability is better, Stoop asset tokens clear on logout, and broken model downloads are rejected immediately. Dependencies and CI actions were refreshed too.
+
+---
+
 ## v1.3.1 — Clock In
 
-**Released:** 2026-08-26 (v1.3.1) — current stable
+**Released:** 2026-08-26 (v1.3.1)
 
 - 🕘 **They clock in** — occupation, which weekdays, hours on the job. Skip a turn and the banner says they're at work. A night skip lets them rest.
 - 🕰️ **Time is said first, then they write** — the prompt tells them what time it is; after the reply the clock decides how much passed. Continue does not tick.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Stamp v1.3.2 “Make a Wish” across the stable-facing documentation. The long-form release history now identifies it as the current stable release, includes a full section based on the existing What's New notes, and leaves v1.3.1 “Clock In” as the previous release.

## Target branch

- [x] This documentation-only release PR targets `main`.

## Type of change

- [x] Documentation

## How was this tested?

Tested on: Linux (documentation inspection only)

- [x] `git diff --check`
- [x] Verified the v1.3.2 heading, release date, current-stable marker, and table-of-contents anchor
- [x] Verified v1.3.1 no longer carries the current-stable marker
- [ ] `flutter analyze` — not run; no executable code changed
- [ ] `flutter test` — not run; no executable code changed
- [ ] Ran the app — not applicable to documentation-only changes

## Parity

- [x] Not applicable; no product behavior or UI changed

## Dependencies and licensing

- [x] No dependencies or assets changed

## Checklist

- [x] No new files were added
- [x] I did not edit `pubspec.yaml`, `lib/app_version.dart`, workflows, or product Dart
- [x] I did not create a tag or GitHub release
- [x] My contribution is licensed under AGPL-3.0-or-later and I have the right to submit it

## Screenshots

Not applicable; documentation-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4196bd1e-bf66-41e8-a05f-437978fe6214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4196bd1e-bf66-41e8-a05f-437978fe6214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

