### PR TITLE
fix(stoop): allow lore-only world uploads

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -17811,3 +17811,34 @@ needing those servers — the doc carries the curl, the three possible outcomes
 and the work each implies.
 
 Commit: 6bc81de
+
+## 2026-09-06 — Lore-only WORLD cards clear Stoop upload completeness
+
+Files: `lib/services/backporch/stoop_card_completeness.dart`,
+`test/services/backporch/stoop_card_completeness_test.dart`,
+`docs/Rawhide.md`.
+
+Places with Climate switched off deliberately omit `biome` from their
+`.fpworld` envelope, but the Stoop completeness assessor still required biome
+content for every WORLD. The share wizard and final publish gate therefore
+rejected valid lore-only places before making an upload request.
+
+The assessor now reads the existing mixed-fleet `climate_enabled` /
+`climateEnabled` aliases. An explicit setting wins. Without either key, a
+present `biome` keeps old packages climate-on for safety; no biome means the
+package is lore-only. Biome remains critical only in climate mode, while
+lorebook content remains optional in both modes.
+
+Regression coverage now exercises explicit snake-case on/off, camel-case off,
+and both missing-flag fallbacks. Restoring the old unconditional biome rule
+made the three lore-only tests fail; restoring the fix returned all 9 focused
+tests to green. The full non-golden suite passed 5,327 tests (13 skipped), and
+the host Linux golden suite passed 118 tests. Changed-file analysis is clean.
+The full analyzer and `dart fix --dry-run` only report pre-existing findings in
+unmodified files.
+
+No `site/src/stoop/completeness.js` or other JavaScript completeness mirror
+exists in this repository. The independently maintained Stoop backend remains
+outside this repository.
+
+Commit: e5e5ed73

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -57,7 +57,7 @@ These notes feed the in-app "Update Available" dialog for Rawhide / cutting-edge
 
 - ⚡ **Empty evals on a remote model no longer wait five seconds to give up** — if the model returns nothing, the next check runs immediately instead of sitting on a local-thinking retry. Local models still pause and try once. Same on the phone.
 
-- 📚 **Lorebook-only worlds** — a place can be facts without weather. Flip off Climate, weather, and place traits and the world is description + lore only: no forecast, no sidebar chip, no atmosphere or gravity. Exports and Stoop listings no longer reveal leftover climate data. Existing worlds stay as they were. Same on the phone.
+- 📚 **Lorebook-only worlds** — a place can be facts without weather. Flip off Climate, weather, and place traits and the world is description + lore only: no forecast, no sidebar chip, no atmosphere or gravity. Exports, Stoop uploads, and listings no longer require or reveal leftover climate data. Existing worlds stay as they were. Same on the phone.
 
 - 🎂 **Birthdays** — set a year, month, and day on the character and on your persona (no February 29). The Journal keeps one card per person that heats up in the two weeks before, so they know how old everyone is without listing a wishlist. Both birthdays can fall on the same day. Objectives may freeze an outing from their likes. Same on the phone.
 

--- a/lib/services/backporch/stoop_card_completeness.dart
+++ b/lib/services/backporch/stoop_card_completeness.dart
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // Card completeness checklist for Stoop uploads. Mirrors
-// backporch-server/src/lib/card-completeness.ts and site/src/stoop/completeness.js
-// so the app, hub, and API reject the same incomplete shells (empty first
-// message / persona / scenario; worlds need climate; lorebook is optional).
+// the independently maintained hub/API rules so they reject the same incomplete
+// shells (empty first message / persona / scenario). WORLD climate is required
+// only when climate_enabled is on; climate-off lore-only worlds are allowed,
+// and lorebook content remains optional.
+
+import 'package:front_porch_ai/models/models.dart';
 
 /// One field on the completeness checklist.
 class StoopFieldStatus {
@@ -88,7 +91,11 @@ class StoopCardCompleteness {
           _present(d['description']) ||
           _present(d['personality']) ||
           _present(d['system_prompt'])) {
-        return {...cardJson, ...d, 'extensions': d['extensions'] ?? cardJson['extensions']};
+        return {
+          ...cardJson,
+          ...d,
+          'extensions': d['extensions'] ?? cardJson['extensions'],
+        };
       }
     }
     return cardJson;
@@ -163,15 +170,30 @@ class StoopCardCompleteness {
       _field('description', 'Description', card['description'], critical: true),
       _field('personality', 'Personality', card['personality'], critical: true),
       _field('scenario', 'Scenario', card['scenario'], critical: true),
-      _field('mes_example', 'Example messages', card['mes_example'], critical: false),
-      _field('system_prompt', 'System prompt', card['system_prompt'], critical: false),
+      _field(
+        'mes_example',
+        'Example messages',
+        card['mes_example'],
+        critical: false,
+      ),
+      _field(
+        'system_prompt',
+        'System prompt',
+        card['system_prompt'],
+        critical: false,
+      ),
       _field(
         'post_history_instructions',
         'Post-history instructions',
         card['post_history_instructions'],
         critical: false,
       ),
-      _field('creator_notes', 'Creator notes', card['creator_notes'], critical: false),
+      _field(
+        'creator_notes',
+        'Creator notes',
+        card['creator_notes'],
+        critical: false,
+      ),
       _field(
         'alternate_greetings',
         'Alternate greetings',
@@ -224,13 +246,18 @@ class StoopCardCompleteness {
     final members = (card['members'] is List)
         ? card['members'] as List
         : (card['raw_member_data'] is List)
-            ? card['raw_member_data'] as List
-            : const [];
+        ? card['raw_member_data'] as List
+        : const [];
     final first = card['first_mes'] ?? card['first_message'];
     final fields = <StoopFieldStatus>[
       _field('first_mes', 'Group first message', first, critical: true),
       _field('scenario', 'Group scenario', card['scenario'], critical: true),
-      _field('system_prompt', 'System prompt', card['system_prompt'], critical: false),
+      _field(
+        'system_prompt',
+        'System prompt',
+        card['system_prompt'],
+        critical: false,
+      ),
     ];
     final missingCritical = <String>[];
     if (!_present(first)) missingCritical.add('Group first message');
@@ -246,7 +273,9 @@ class StoopCardCompleteness {
           ? 'Member ${i + 1}'
           : _str(m['name']).trim();
       final idOk = _present(m['description']) || _present(m['personality']);
-      fields.add(_field('member_${i}_name', '$label · name', m['name'], critical: true));
+      fields.add(
+        _field('member_${i}_name', '$label · name', m['name'], critical: true),
+      );
       fields.add(
         _field(
           'member_${i}_identity',
@@ -269,7 +298,9 @@ class StoopCardCompleteness {
           .map((f) => f.label)
           .toList(),
       fields: fields,
-      cardName: _str(card['name']).trim().isEmpty ? null : _str(card['name']).trim(),
+      cardName: _str(card['name']).trim().isEmpty
+          ? null
+          : _str(card['name']).trim(),
       notes: ['${members.length} member(s)'],
     );
   }
@@ -279,13 +310,21 @@ class StoopCardCompleteness {
     final biome = biomeRaw is Map
         ? Map<String, dynamic>.from(biomeRaw)
         : <String, dynamic>{};
+    final climateEnabled =
+        readWorldClimateEnabled(card) ?? card.containsKey('biome');
     final book = _lorebook(card['lorebook']);
-    final climatePresent = _present(biome['displayName']) ||
+    final climatePresent =
+        _present(biome['displayName']) ||
         _present(biome['description']) ||
         _present(biome['feel']);
     final fields = <StoopFieldStatus>[
-      _field('biome', 'Biome / climate', climatePresent ? 'ok' : '', critical: true),
-      // Lore is useful but optional — worlds can ship climate first.
+      _field(
+        'biome',
+        'Biome / climate',
+        climatePresent ? 'ok' : '',
+        critical: climateEnabled,
+      ),
+      // Lore content remains optional in both climate and lore-only modes.
       _field(
         'lorebook',
         'Lorebook content',
@@ -294,7 +333,9 @@ class StoopCardCompleteness {
       ),
     ];
     final missingCritical = <String>[];
-    if (!climatePresent) missingCritical.add('Biome / climate');
+    if (climateEnabled && !climatePresent) {
+      missingCritical.add('Biome / climate');
+    }
 
     return StoopCompleteness(
       incomplete: missingCritical.isNotEmpty,
@@ -304,11 +345,13 @@ class StoopCardCompleteness {
           .map((f) => f.label)
           .toList(),
       fields: fields,
-      cardName: _str(card['name']).trim().isEmpty ? null : _str(card['name']).trim(),
+      cardName: _str(card['name']).trim().isEmpty
+          ? null
+          : _str(card['name']).trim(),
       notes: [
         'Lorebook: ${book.filled}/${book.entries} filled'
-        '${book.placeholder > 0 ? ' · ${book.placeholder} empty/placeholder' : ''}'
-        '${book.entries == 0 ? ' (optional)' : ''}',
+            '${book.placeholder > 0 ? ' · ${book.placeholder} empty/placeholder' : ''}'
+            '${book.entries == 0 ? ' (optional)' : ''}',
       ],
     );
   }

--- a/test/services/backporch/stoop_card_completeness_test.dart
+++ b/test/services/backporch/stoop_card_completeness_test.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:front_porch_ai/services/backporch/stoop_card_completeness.dart';
+import 'package:front_porch_ai/services/backporch/backporch.dart';
 
 void main() {
   group('StoopCardCompleteness', () {
@@ -19,10 +19,7 @@ void main() {
       expect(r.missingCritical, contains('First message'));
       expect(r.missingCritical, contains('Description or personality'));
       expect(r.missingCritical, contains('Scenario'));
-      expect(
-        r.notes.any((n) => n.contains('template/shell')),
-        isTrue,
-      );
+      expect(r.notes.any((n) => n.contains('template/shell')), isTrue);
     });
 
     test('accepts solo with identity in description only', () {
@@ -47,9 +44,45 @@ void main() {
       expect(r.missingOptional, contains('Lorebook content'));
     });
 
-    test('world without climate is incomplete', () {
+    test('world without a climate flag or biome is lore-only', () {
+      final r = StoopCardCompleteness.assess({'name': 'Blank'}, 'WORLD');
+      expect(r.incomplete, isFalse);
+      expect(r.missingCritical, isNot(contains('Biome / climate')));
+    });
+
+    test('world with climate explicitly off does not need a biome', () {
       final r = StoopCardCompleteness.assess({
-        'name': 'Blank',
+        'name': 'Library',
+        'climate_enabled': false,
+      }, 'WORLD');
+      expect(r.incomplete, isFalse);
+      expect(r.missingCritical, isNot(contains('Biome / climate')));
+    });
+
+    test('world with climate explicitly on still needs a biome', () {
+      final r = StoopCardCompleteness.assess({
+        'name': 'Blank climate',
+        'climate_enabled': true,
+        'biome': <String, dynamic>{},
+      }, 'WORLD');
+      expect(r.incomplete, isTrue);
+      expect(r.missingCritical, contains('Biome / climate'));
+    });
+
+    test('camel-case climate off accepts an empty biome', () {
+      final r = StoopCardCompleteness.assess({
+        'name': 'Lore shelf',
+        'climateEnabled': false,
+        'biome': <String, dynamic>{},
+      }, 'WORLD');
+      expect(r.incomplete, isFalse);
+      expect(r.missingCritical, isNot(contains('Biome / climate')));
+      expect(r.fields.singleWhere((f) => f.key == 'biome').critical, isFalse);
+    });
+
+    test('legacy world with an empty biome remains climate-on', () {
+      final r = StoopCardCompleteness.assess({
+        'name': 'Broken legacy climate',
         'biome': <String, dynamic>{},
       }, 'WORLD');
       expect(r.incomplete, isTrue);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Places may intentionally disable climate and export a lore-only `.fpworld` without a `biome` ([#226](https://github.com/linux4life1/front-porch-AI/issues/226)). The Stoop upload completeness gate still required biome content for every WORLD, so those valid cards were rejected before upload.

This change reads both `climate_enabled` and `climateEnabled`, keeps biome critical when climate is on, and makes it non-critical when climate is off. For mixed-fleet safety, an older card with a biome but no flag remains climate-on; a card with neither is treated as lore-only. Lorebook content remains optional.

No `site/src/stoop/completeness.js` or other JavaScript completeness mirror exists in this repository. The Stoop backend is maintained separately, so its matching rule is outside this PR.

## Target branch

- [x] Rawhide

## Type of change

- [x] Bug fix
- [x] Tests and release note

## How was this tested?

Tested on: Linux (Flutter 3.47.0)

- [x] Focused completeness suite: 9 passed
- [x] Negative proof: restoring the old unconditional biome rule made all 3 lore-only cases fail; restoring the fix returned 9/9 green
- [x] Full non-golden suite: 5,327 passed, 13 skipped
- [x] Linux host golden suite: 118 passed
- [x] Changed-file analyze: no issues
- [x] Full `flutter analyze --no-fatal-warnings --no-fatal-infos`: exit 0; 12 pre-existing infos in untouched files
- [x] `dart fix --dry-run`: 8 pre-existing proposals in untouched files; none applied
- [x] Linux desktop app built and launched; manually created a climate-off world successfully

`./scripts/ci-local.sh` could not run because this VM has no Docker executable. The equivalent host Linux golden command passed, and the PR's container golden job remains the authoritative gate.

The Stoop checklist itself could not be reached manually without signing into an external account. No upload was attempted. The focused tests directly cover the assessor used by both the live checklist and final publish gate.

## Test-change rationale

The existing “world without climate is incomplete” assertion became false when lore-only Places were allowed. It now verifies the missing-flag/no-biome lore-only fallback. New assertions preserve climate-on rejection, explicit climate-off acceptance, camel-case compatibility, and the legacy biome-present fallback. Because this intentionally edits a protected existing test, the test-integrity check requires the maintainer's `approved-test-change` label.

## Parity

- [x] No web/mobile upload completeness implementation or JS mirror exists in this repository
- [x] Realism/Needs and path-complete chat matrices: not applicable
- [x] Pure map inspection only; no platform-specific behavior

## Dependencies and licensing

- [x] No dependencies changed

## Checklist

- [x] No version, schema, network, or server changes
- [x] Edited Dart files use barrel imports and per-file formatter output
- [x] No new methods or duplicated completeness paths
- [x] Contribution is licensed under AGPL-3.0-or-later
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c402460-3a4c-4d5a-b771-850fdeeb8d53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c402460-3a4c-4d5a-b771-850fdeeb8d53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

