### PR TITLE
fix(realism): fall back when OpenRouter ignores forced tools

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -17891,10 +17891,31 @@ JSON fallback, leaving bond/trust unchanged and allowing Needs to show only
 ambient decay.
 
 Call-less text is now accepted only when it is valid JSON with the selected
-eval schema's required fields; prose and partial objects mark that tools route
-unreliable and immediately retry through text. OpenRouter metadata requires
-both `tools` and `tool_choice`, OpenRouter tool requests set
-`provider.require_parameters`, and eval identities include the normalized API
+eval schema's required fields; prose and partial objects immediately retry
+through text while the metadata/live probe keeps ownership of the durable
+capability verdict. OpenRouter metadata requires both `tools` and
+`tool_choice`, OpenRouter tool requests set
+`provider.require_parameters`, and eval identities include the configured API
 endpoint so Nano-GPT and OpenRouter cannot share probe or one-shot state for
 the same model slug. Nano-GPT and generic OpenAI-compatible requests remain
 unchanged.
+
+The three focused files pass 51 tests and the wider eval-transport set passes
+144. Both full non-golden runs passed 5,335 tests (13 skipped); the Linux host
+golden run passed 118. Full analysis reports only 12 pre-existing infos in
+untouched files, and `dart fix --dry-run` proposes only 8 pre-existing fixes.
+Two mutation passes proved all new guards red: restoring unconditional prose
+salvage, dropping the endpoint key, trusting tools-only metadata, omitting the
+OpenRouter provider constraint, rejecting valid JSON salvage, making metadata
+case-sensitive, bypassing the ChatService call site, and leaking the provider
+field to Nano/local requests each failed its intended assertion before the
+final green run.
+
+The first CI run's sole unit failure was an unrelated Drift teardown race in
+`session_picker_overlay_hold_test.dart` (no failed assertion); that file passes
+in isolation and both complete local runs passed. All 15 CI E2E shards, CI
+goldens, and changed-file analysis were green. The protected-test gate still
+requires the maintainer's `approved-test-change` label because the obsolete
+prose-salvage assertion was intentionally corrected.
+
+Commit: a42293ab (implementation); validation refinement in this commit

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -17879,7 +17879,8 @@ Commit: aadb6176 (implementation); verification/bundle in this commit
 Files: `lib/services/chat/pass_support.dart`,
 `lib/services/chat/chat_service_wiring_evals.dart`,
 `lib/services/capability/model_capabilities.dart`,
-`lib/services/open_router_service.dart`, `lib/services/system_role_probe.dart`,
+`lib/services/open_router_service.dart`, `lib/services/llm_provider.dart`,
+`lib/services/llm_service.dart`, `lib/services/system_role_probe.dart`,
 `test/services/chat/pass_support_test.dart`,
 `test/services/capability/model_capabilities_test.dart`,
 `test/services/open_router_tools_test.dart`, and `docs/Rawhide.md`.
@@ -17900,6 +17901,17 @@ endpoint so Nano-GPT and OpenRouter cannot share probe or one-shot state for
 the same model slug. Nano-GPT and generic OpenAI-compatible requests remain
 unchanged.
 
+Hostile review tightened those boundaries before completion. Call-less JSON
+now validates enums and nested required fields against the actual selected
+tool schema; unknown-only and descriptor-only cast objects fall through
+instead of becoming a false "no character" result. Opaque nested objects (the
+fused Pockets schema) conservatively fall through when their usability cannot
+be proven. OpenRouter strict tool requests omit optional `min_p`, `top_k`, and
+`repetition_penalty` so `require_parameters` does not exclude Grok/Gemini
+routes merely because they lack unrelated samplers; Nano and generic hosts
+retain all three. Eval identity reads the active service URL, including oMLX's
+localhost endpoint, rather than the stored Remote API URL.
+
 The three focused files pass 51 tests and the wider eval-transport set passes
 144. Both full non-golden runs passed 5,335 tests (13 skipped); the Linux host
 golden run passed 118. Full analysis reports only 12 pre-existing infos in
@@ -17911,6 +17923,12 @@ case-sensitive, bypassing the ChatService call site, and leaking the provider
 field to Nano/local requests each failed its intended assertion before the
 final green run.
 
+The hostile-review guards were also red-proven before implementation: invalid
+expression enums, incomplete nested Pockets ops, ambiguous cast JSON, the
+stored-vs-active endpoint call site, and strict OpenRouter sampler leakage all
+failed. A named-tool 400→retry test confirms the provider constraint survives
+both request attempts and still returns the successful call.
+
 The first CI run's sole unit failure was an unrelated Drift teardown race in
 `session_picker_overlay_hold_test.dart` (no failed assertion); that file passes
 in isolation and both complete local runs passed. All 15 CI E2E shards, CI
@@ -17918,4 +17936,5 @@ goldens, and changed-file analysis were green. The protected-test gate still
 requires the maintainer's `approved-test-change` label because the obsolete
 prose-salvage assertion was intentionally corrected.
 
-Commit: a42293ab (implementation); validation refinement in this commit
+Commits: a42293ab (implementation), a20a7bc8 (validation refinement);
+hostile-review hardening in this commit

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -17929,6 +17929,13 @@ stored-vs-active endpoint call site, and strict OpenRouter sampler leakage all
 failed. A named-tool 400→retry test confirms the provider constraint survives
 both request attempts and still returns the successful call.
 
+The first post-review full run caught a compatibility miss: adding the
+endpoint getter directly to `LLMProvider` made legacy noSuchMethod test fakes
+throw. Endpoint identity now uses an opt-in `LlmApiEndpoint` interface
+implemented only by `OpenRouterService`; existing local/fake services remain
+untouched, while oMLX still exposes its live localhost URL. Both failing
+fake-backed paths passed after this correction.
+
 The first CI run's sole unit failure was an unrelated Drift teardown race in
 `session_picker_overlay_hold_test.dart` (no failed assertion); that file passes
 in isolation and both complete local runs passed. All 15 CI E2E shards, CI
@@ -17936,5 +17943,5 @@ goldens, and changed-file analysis were green. The protected-test gate still
 requires the maintainer's `approved-test-change` label because the obsolete
 prose-salvage assertion was intentionally corrected.
 
-Commits: a42293ab (implementation), a20a7bc8 (validation refinement);
-hostile-review hardening in this commit
+Commits: a42293ab (implementation), a20a7bc8 (validation refinement),
+294b873f (hostile-review hardening); endpoint compatibility in this commit

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -17873,3 +17873,28 @@ Linux container goldens were unavailable because this environment has no
 Docker.
 
 Commit: aadb6176 (implementation); verification/bundle in this commit
+
+## 2026-09-06 — OpenRouter structured evals fall back when forced tools fail
+
+Files: `lib/services/chat/pass_support.dart`,
+`lib/services/chat/chat_service_wiring_evals.dart`,
+`lib/services/capability/model_capabilities.dart`,
+`lib/services/open_router_service.dart`, `lib/services/system_role_probe.dart`,
+`test/services/chat/pass_support_test.dart`,
+`test/services/capability/model_capabilities_test.dart`,
+`test/services/open_router_tools_test.dart`, and `docs/Rawhide.md`.
+
+OpenRouter can advertise tool schemas while a routed provider ignores forced
+`tool_choice`, returning prose or partial JSON instead of a call. The shared
+structured-eval door used to accept any non-empty text and skip its streaming
+JSON fallback, leaving bond/trust unchanged and allowing Needs to show only
+ambient decay.
+
+Call-less text is now accepted only when it is valid JSON with the selected
+eval schema's required fields; prose and partial objects mark that tools route
+unreliable and immediately retry through text. OpenRouter metadata requires
+both `tools` and `tool_choice`, OpenRouter tool requests set
+`provider.require_parameters`, and eval identities include the normalized API
+endpoint so Nano-GPT and OpenRouter cannot share probe or one-shot state for
+the same model slug. Nano-GPT and generic OpenAI-compatible requests remain
+unchanged.

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -5,6 +5,8 @@ These notes feed the in-app "Update Available" dialog for Rawhide / cutting-edge
 
 ## Recent improvements (unreleased — ships in the next build)
 
+- 🎭 **OpenRouter models move relationships, Needs, and scene time again** — providers that ignore forced tool calls now retry through the reliable JSON path instead of treating prose as an answer. Bonds no longer freeze while Needs only decay on Grok, Gemini, and similar routed models. Same on the phone.
+
 - 💬 **Stoop messages, typing, and live card counts keep working after the hub's security upgrade** — desktop and phone now authenticate live connections without putting your sign-in token in the connection address.
 
 - 🔎 **They can look unknown terms up — safely and only when you ask** — turn on Web Search in Porch Life and the first reply to a message you send can quietly look up an unknown word (lore, a show, weather, whatever), then react as themselves. Continue, Regenerate, guests, group follow-ups, cast entrances, and AFK / Dynamic Responses stay offline. Search results are treated as untrusted notes, redirects are refused, and Tavily keys now move out of preferences into your system's secure credential store. One switch for every chat, including ones already open; no key still uses Wikipedia. A small chip shows when a lookup happened. Off by default. Same on the phone.

--- a/lib/services/capability/model_capabilities.dart
+++ b/lib/services/capability/model_capabilities.dart
@@ -113,10 +113,8 @@ class VisionSupport {
 
 /// Capabilities distilled from a provider `/models` entry.
 ///
-/// Only [vision] is consumed today. [toolCalling] is parsed from the very same
-/// metadata (OpenRouter's `supported_parameters`, Nano-GPT's
-/// `capabilities.tool_calling`) so a later phase can adopt native tool calling
-/// without another round-trip — the seam is intentionally left obvious here.
+/// [vision] gates image input; [toolCalling] seeds the shared eval transport
+/// probe from the same provider metadata without another round-trip.
 class ModelApiCapabilities {
   final bool vision;
   final bool toolCalling;
@@ -126,7 +124,9 @@ class ModelApiCapabilities {
   /// Parse an OpenRouter `/models` entry.
   ///
   /// Vision: `architecture.input_modalities` contains `"image"`.
-  /// Tools:  `supported_parameters` contains `"tools"`.
+  /// Tools:  `supported_parameters` contains both `"tools"` and
+  /// `"tool_choice"`. Advertising schemas without the ability to force the
+  /// selected function is not reliable enough for state-changing evals.
   factory ModelApiCapabilities.fromOpenRouterEntry(
     Map<dynamic, dynamic> entry,
   ) {
@@ -144,7 +144,8 @@ class ModelApiCapabilities {
     bool tools = false;
     final params = entry['supported_parameters'];
     if (params is List) {
-      tools = params.map((e) => e.toString().toLowerCase()).contains('tools');
+      final supported = params.map((e) => e.toString().toLowerCase()).toSet();
+      tools = supported.contains('tools') && supported.contains('tool_choice');
     }
 
     return ModelApiCapabilities(vision: vision, toolCalling: tools);

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -610,9 +610,11 @@ extension ChatServiceWiringEvals on ChatService {
   String get _evalBackendIdentity {
     final service =
         testLlmServiceOverride ?? _llmProvider?.activeService ?? _koboldService;
-    final remoteApiUrl = testLlmServiceOverride == null
-        ? _llmProvider?.activeApiUrl ?? ''
-        : (testIsLocalOverride ? '' : _storageService.remoteApiUrl);
+    final remoteApiUrl = service is LlmApiEndpoint
+        ? (service as LlmApiEndpoint).apiUrl
+        : (testLlmServiceOverride != null && !testIsLocalOverride
+              ? _storageService.remoteApiUrl
+              : '');
     return evalBackendIdentityFor(
       backendName: service.backendName,
       remoteApiUrl: remoteApiUrl,

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -33,13 +33,7 @@ extension ChatServiceWiringEvals on ChatService {
   // (onNotify/onSaveChat removed in step 10 fix round 1 + step11: oneShot populates pending snapshot;
   // god owns the post-eval _saveChat/notify in pre-turn + baseline paths to avoid double + races;
   // on* dead post step11 objective move, cleaned).
-  // 0 @Deprecated shims. 0 new god private _ methods beyond the required thin delegates (_fireLLMEval, _stripThinkBlocks, _extractJson*, evaluateNeedsImpactCall; the 5 _evaluate*Call thins now point to realism_evals; generate/check thins now to objective_proposal; the void _ count grep stayed 15; +1 late final only; thins/calls/late final only per plan). (cross-ref setActiveCharacter:1572 etc)
-  // Stateless/prompt-only: no reset calls needed. Reset hygiene comments list full set + llm_eval_engine (stateless or prompt-only;
-  // no reset calls needed; incomplete zeroing... now complete (see CLAUDE.md)) + realism_evals (stateless or prompt-only; no reset calls needed) + objective_proposal (stateless or prompt-only; no reset calls needed) + journal_maintenance (stateless or prompt-only; no reset calls needed) + cross-refs (e.g. setActiveCharacter:1572). Both startNew branches explicit.
   // 1:1 vs group + oneShot vs normal dispatch/parity preserved exactly (cbs + impersonation temp re-load; qualified).
-  // aug exercising only passive/qualified (no llm-eval-specific aug file edits; resets/loads/greetings/post hit by pre-existing
-  // startNew/setActive/_loadLast/group in key suites; full eval/JSON/strip + needs impact only in dedicated + manual;
-  // objective proposal/gen/check exercised via god thins generate/check ; qualified notes only in dedicated header + god + MD per precedent).
   LlmEvalEngine _buildLlmEvalEngine() {
     return LlmEvalEngine(
       getActiveCharacter: () => _activeCharacter,
@@ -616,9 +610,12 @@ extension ChatServiceWiringEvals on ChatService {
   String get _evalBackendIdentity {
     final service =
         testLlmServiceOverride ?? _llmProvider?.activeService ?? _koboldService;
+    final remoteApiUrl = testLlmServiceOverride == null
+        ? _llmProvider?.activeApiUrl ?? ''
+        : (testIsLocalOverride ? '' : _storageService.remoteApiUrl);
     return evalBackendIdentityFor(
       backendName: service.backendName,
-      remoteApiUrl: _storageService.remoteApiUrl,
+      remoteApiUrl: remoteApiUrl,
       remoteModelName: _storageService.remoteModelName,
       modelPath: _storageService.lastUsedModelPath,
     );

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -18,12 +18,8 @@
 
 part of '../chat_service.dart';
 
-/// Builders for the Realism/Needs eval pipeline (the LLM eval engine, the
-/// realism verifier, the needs-impact evaluator, the 5 realism evals, and
-/// objective proposal handling) plus the shared tools-transport surface
-/// (`_fireToolEval` / `_evalBackendIdentity` / the tool-support tester
-/// builder). Extracted verbatim from `chat_service.dart` — zero behaviour
-/// change; every callback closure is byte-identical to its old inline form.
+/// Builders for the Realism/Needs eval pipeline plus its shared tools
+/// transport (`_fireToolEval`, `_evalBackendIdentity`, and the support tester).
 extension ChatServiceWiringEvals on ChatService {
   // ── LLM Eval Engine (step 9: _fireLLMEval + strip + extract + needs impact cb) ──
   // Plain class (not ChangeNotifier). Owns the central eval firing (streaming/retry/cancel, 4000/0.1/no-reasoning),
@@ -616,14 +612,16 @@ extension ChatServiceWiringEvals on ChatService {
     }
   }
 
-  /// Backend+model identity key for the tools probe. Remote model name AND
-  /// local model path both ride the key, so switching either re-probes tool
-  /// support (capability is per model).
+  /// Endpoint+model identity key for the shared tools/one-shot probes.
   String get _evalBackendIdentity {
     final service =
         testLlmServiceOverride ?? _llmProvider?.activeService ?? _koboldService;
-    return '${service.backendName}|${_storageService.remoteModelName}'
-        '|${_storageService.lastUsedModelPath ?? ''}';
+    return evalBackendIdentityFor(
+      backendName: service.backendName,
+      remoteApiUrl: _storageService.remoteApiUrl,
+      remoteModelName: _storageService.remoteModelName,
+      modelPath: _storageService.lastUsedModelPath,
+    );
   }
 
   /// Active tool-support prober behind the sidebar's tool-calling pill:

--- a/lib/services/chat/pass_support.dart
+++ b/lib/services/chat/pass_support.dart
@@ -84,31 +84,13 @@ enum ToolCallSupport { untested, supported, unsupported }
 ///
 /// The endpoint component keeps two OpenAI-compatible providers with the same
 /// model slug (for example Nano-GPT and OpenRouter) from sharing tool-probe,
-/// tool-choice-style, or automatic one-shot state. Query and fragment data are
-/// deliberately omitted: capability belongs to the API endpoint, and secrets
-/// sometimes ride URL query parameters.
+/// tool-choice-style, or automatic one-shot state.
 String evalBackendIdentityFor({
   required String backendName,
   required String remoteApiUrl,
   required String remoteModelName,
   required String? modelPath,
-}) {
-  var endpoint = remoteApiUrl.trim();
-  final uri = Uri.tryParse(endpoint);
-  if (uri != null && uri.hasScheme && uri.host.isNotEmpty) {
-    var path = uri.path;
-    while (path.endsWith('/')) {
-      path = path.substring(0, path.length - 1);
-    }
-    endpoint = Uri(
-      scheme: uri.scheme.toLowerCase(),
-      host: uri.host.toLowerCase(),
-      port: uri.hasPort ? uri.port : null,
-      path: path,
-    ).toString();
-  }
-  return '$backendName|$endpoint|$remoteModelName|${modelPath ?? ''}';
-}
+}) => '$backendName|${remoteApiUrl.trim()}|$remoteModelName|${modelPath ?? ''}';
 
 /// Resolve the effective one-shot decision for a turn — pure, so the whole
 /// policy is testable as a truth table (eval review Tier-1 §3.4).
@@ -269,12 +251,11 @@ class ToolTransportProbe extends ChangeNotifier {
 /// tools-mode prompt; a matching call is converted by [callToText] into the
 /// canonical text the downstream parser expects. A tool-less reply is
 /// salvaged only when its text is valid JSON containing the selected tool's
-/// required fields. Prose or partial JSON is real evidence that the forced
-/// call was ignored, so it marks this identity text-only and falls through to
-/// [fireTextEval]. Transport failures, cancellations ([isCancelled]), and
-/// EMPTY answers (null resp, or no call + no text — the shape a server-side
-/// abort produces as a clean 200) remain inconclusive: they fall back for the
-/// round and leave the probe untested to retry next pass.
+/// required fields. Prose or partial JSON falls through to [fireTextEval].
+/// Call-less replies, transport failures, cancellations ([isCancelled]), and
+/// EMPTY answers (the shape a server-side abort produces as a clean 200) stay
+/// inconclusive here; provider metadata and ToolSupportTester own the durable
+/// capability verdict.
 String? _usableEvalJsonText(
   String text, {
   required List<Map<String, dynamic>> tools,
@@ -307,6 +288,12 @@ String? _usableEvalJsonText(
     }
   }
   if (selectedName == null || parameters == null) return null;
+  final requiredRaw = parameters['required'];
+  final required = requiredRaw is List
+      ? requiredRaw.map((field) => field.toString())
+      : const <String>[];
+  if (required.isEmpty && decoded.isEmpty) return trimmed;
+
   final normalized = callToText(
     LlmToolResponse(
       calls: [
@@ -326,10 +313,6 @@ String? _usableEvalJsonText(
     return null;
   }
   if (normalizedJson is! Map) return null;
-  final requiredRaw = parameters['required'];
-  final required = requiredRaw is List
-      ? requiredRaw.map((field) => field.toString())
-      : const <String>[];
   if (!required.every(normalizedJson.containsKey)) {
     return null;
   }
@@ -397,12 +380,9 @@ Future<String?> fireStructuredEval({
             '[Eval:Tools] $debugLabel returned prose or incomplete JSON — '
             'retrying with text transport',
           );
-        } else {
-          inconclusive = true;
         }
-      } else {
-        inconclusive = true;
       }
+      inconclusive = true;
       // Null resp, or a resp with no usable call AND no text: an EMPTY
       // answer is never a capability verdict. A KoboldCpp server-side abort
       // (/api/extra/abort — fired by stopGeneration, the eval-timeout
@@ -413,9 +393,8 @@ Future<String?> fireStructuredEval({
       // "not supported" after a Scene Guest join (the guest flow stacks a
       // long mint generation + a burst of concurrent evals + abort/idle
       // traffic on the single-slot backend). Models that genuinely can't
-      // speak tools answer with prose and are branded text-only above; an
-      // empty answer just falls back to text for THIS round and leaves the
-      // probe untested to retry next pass.
+      // speak tools answer with prose; the ToolSupportTester owns that durable
+      // verdict. This pass falls back for THIS round and retries next pass.
     } catch (e) {
       debugPrint('[Eval:Tools] $debugLabel attempt failed: $e');
       if (isCancelled?.call() ?? false) return null;

--- a/lib/services/chat/pass_support.dart
+++ b/lib/services/chat/pass_support.dart
@@ -16,14 +16,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
 
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 
 import 'package:front_porch_ai/models/models.dart';
 import 'package:front_porch_ai/services/chat/tool_eval_spec.dart';
-import 'package:front_porch_ai/services/llm_service.dart'
-    show LlmToolResponse, isToolTransportFailure;
-import 'package:front_porch_ai/services/storage/settings/realism_settings.dart'
-    show OneShotMode;
+import 'package:front_porch_ai/services/services.dart'
+    show LlmToolCall, LlmToolResponse, OneShotMode, isToolTransportFailure;
 
 /// Shared support for the two background maintenance passes (the Journal and
 /// Growth Rings) — extracted from JournalMaintenance so the growth pass
@@ -79,6 +79,36 @@ List<CharacterCard> resolvePassOwners({
 
 /// A backend identity's native tool-calling verdict, as observed this run.
 enum ToolCallSupport { untested, supported, unsupported }
+
+/// Stable identity for eval transport capability state.
+///
+/// The endpoint component keeps two OpenAI-compatible providers with the same
+/// model slug (for example Nano-GPT and OpenRouter) from sharing tool-probe,
+/// tool-choice-style, or automatic one-shot state. Query and fragment data are
+/// deliberately omitted: capability belongs to the API endpoint, and secrets
+/// sometimes ride URL query parameters.
+String evalBackendIdentityFor({
+  required String backendName,
+  required String remoteApiUrl,
+  required String remoteModelName,
+  required String? modelPath,
+}) {
+  var endpoint = remoteApiUrl.trim();
+  final uri = Uri.tryParse(endpoint);
+  if (uri != null && uri.hasScheme && uri.host.isNotEmpty) {
+    var path = uri.path;
+    while (path.endsWith('/')) {
+      path = path.substring(0, path.length - 1);
+    }
+    endpoint = Uri(
+      scheme: uri.scheme.toLowerCase(),
+      host: uri.host.toLowerCase(),
+      port: uri.hasPort ? uri.port : null,
+      path: path,
+    ).toString();
+  }
+  return '$backendName|$endpoint|$remoteModelName|${modelPath ?? ''}';
+}
 
 /// Resolve the effective one-shot decision for a turn — pure, so the whole
 /// policy is testable as a truth table (eval review Tier-1 §3.4).
@@ -237,15 +267,75 @@ class ToolTransportProbe extends ChangeNotifier {
 ///
 /// Flow: unless [probe] already marked the backend text-only, fire the
 /// tools-mode prompt; a matching call is converted by [callToText] into the
-/// canonical text the downstream parser expects; a tool-less reply with text
-/// is salvaged through the same parser. Verdict rule: only real evidence
-/// brands the backend — thrown non-transport rejections mark it text-only,
-/// while transport failures, cancellations ([isCancelled]), and EMPTY
-/// answers (null resp, or no call + no text — the shape a server-side abort
-/// produces as a clean 200) are inconclusive: fall back to text for the
-/// round and leave the probe untested to retry next pass. Capability
-/// branding of genuinely tool-less models is the ToolSupportTester ping's
-/// job.
+/// canonical text the downstream parser expects. A tool-less reply is
+/// salvaged only when its text is valid JSON containing the selected tool's
+/// required fields. Prose or partial JSON is real evidence that the forced
+/// call was ignored, so it marks this identity text-only and falls through to
+/// [fireTextEval]. Transport failures, cancellations ([isCancelled]), and
+/// EMPTY answers (null resp, or no call + no text — the shape a server-side
+/// abort produces as a clean 200) remain inconclusive: they fall back for the
+/// round and leave the probe untested to retry next pass.
+String? _usableEvalJsonText(
+  String text, {
+  required List<Map<String, dynamic>> tools,
+  required String? toolChoice,
+  required String? Function(LlmToolResponse resp) callToText,
+}) {
+  final trimmed = text.trim();
+  if (trimmed.isEmpty) return null;
+
+  final dynamic decoded;
+  try {
+    decoded = jsonDecode(trimmed);
+  } catch (_) {
+    return null;
+  }
+  if (decoded is! Map) return null;
+
+  String? selectedName;
+  Map<dynamic, dynamic>? parameters;
+  for (final tool in tools) {
+    final function = tool['function'];
+    if (function is! Map) continue;
+    final name = function['name']?.toString() ?? '';
+    if (name == toolChoice ||
+        ((toolChoice == null || toolChoice.isEmpty) && tools.length == 1)) {
+      selectedName = name;
+      final rawParameters = function['parameters'];
+      if (rawParameters is Map) parameters = rawParameters;
+      break;
+    }
+  }
+  if (selectedName == null || parameters == null) return null;
+  final normalized = callToText(
+    LlmToolResponse(
+      calls: [
+        LlmToolCall(
+          name: selectedName,
+          arguments: Map<String, dynamic>.from(decoded),
+        ),
+      ],
+      text: '',
+    ),
+  );
+  if (normalized == null) return null;
+  final dynamic normalizedJson;
+  try {
+    normalizedJson = jsonDecode(normalized);
+  } catch (_) {
+    return null;
+  }
+  if (normalizedJson is! Map) return null;
+  final requiredRaw = parameters['required'];
+  final required = requiredRaw is List
+      ? requiredRaw.map((field) => field.toString())
+      : const <String>[];
+  if (!required.every(normalizedJson.containsKey)) {
+    return null;
+  }
+  return normalized;
+}
+
 Future<String?> fireStructuredEval({
   required ToolTransportProbe probe,
   required String backendIdentity,
@@ -292,10 +382,26 @@ Future<String?> fireStructuredEval({
           onChunk?.call('$text\n');
           return text;
         }
-        if (resp.text.trim().isNotEmpty) {
-          onChunk?.call('${resp.text}\n');
-          return resp.text;
+        final salvaged = _usableEvalJsonText(
+          resp.text,
+          tools: tools,
+          toolChoice: toolChoice,
+          callToText: callToText,
+        );
+        if (salvaged != null) {
+          onChunk?.call('$salvaged\n');
+          return salvaged;
         }
+        if (resp.text.trim().isNotEmpty) {
+          debugPrint(
+            '[Eval:Tools] $debugLabel returned prose or incomplete JSON — '
+            'retrying with text transport',
+          );
+        } else {
+          inconclusive = true;
+        }
+      } else {
+        inconclusive = true;
       }
       // Null resp, or a resp with no usable call AND no text: an EMPTY
       // answer is never a capability verdict. A KoboldCpp server-side abort
@@ -307,10 +413,9 @@ Future<String?> fireStructuredEval({
       // "not supported" after a Scene Guest join (the guest flow stacks a
       // long mint generation + a burst of concurrent evals + abort/idle
       // traffic on the single-slot backend). Models that genuinely can't
-      // speak tools answer with PROSE (salvaged above) and are branded by
-      // the ToolSupportTester ping; an empty answer just falls back to text
-      // for THIS round and leaves the probe untested to retry next pass.
-      inconclusive = true;
+      // speak tools answer with prose and are branded text-only above; an
+      // empty answer just falls back to text for THIS round and leaves the
+      // probe untested to retry next pass.
     } catch (e) {
       debugPrint('[Eval:Tools] $debugLabel attempt failed: $e');
       if (isCancelled?.call() ?? false) return null;

--- a/lib/services/chat/pass_support.dart
+++ b/lib/services/chat/pass_support.dart
@@ -256,6 +256,59 @@ class ToolTransportProbe extends ChangeNotifier {
 /// EMPTY answers (the shape a server-side abort produces as a clean 200) stay
 /// inconclusive here; provider metadata and ToolSupportTester own the durable
 /// capability verdict.
+bool _matchesEvalSchema(
+  Object? value,
+  Map<dynamic, dynamic> schema, {
+  String? field,
+}) {
+  if (value == null) return false;
+  final allowed = schema['enum'];
+  if (allowed is List && !allowed.contains(value)) return false;
+
+  switch (schema['type']) {
+    case 'object':
+      if (value is! Map) return false;
+      final properties = schema['properties'];
+      if (properties is! Map) return false;
+      final required = schema['required'];
+      if (required is List &&
+          required.any((key) => !value.containsKey(key.toString()))) {
+        return false;
+      }
+      var recognized = value.isEmpty;
+      for (final entry in value.entries) {
+        final child = properties[entry.key];
+        if (child is! Map) continue;
+        recognized = true;
+        if (!_matchesEvalSchema(
+          entry.value,
+          child,
+          field: entry.key.toString(),
+        )) {
+          return false;
+        }
+      }
+      return recognized;
+    case 'array':
+      if (value is! List) return false;
+      final items = schema['items'];
+      return items is Map &&
+          value.every((item) => _matchesEvalSchema(item, items));
+    case 'integer':
+      return value is num || int.tryParse(value.toString().trim()) != null;
+    case 'boolean':
+      return value is bool ||
+          const {
+            'true',
+            'false',
+          }.contains(value.toString().trim().toLowerCase());
+    case 'string':
+      return value is String && (value.isNotEmpty || field == 'today_sentence');
+    default:
+      return false;
+  }
+}
+
 String? _usableEvalJsonText(
   String text, {
   required List<Map<String, dynamic>> tools,
@@ -288,6 +341,7 @@ String? _usableEvalJsonText(
     }
   }
   if (selectedName == null || parameters == null) return null;
+  if (!_matchesEvalSchema(decoded, parameters)) return null;
   final requiredRaw = parameters['required'];
   final required = requiredRaw is List
       ? requiredRaw.map((field) => field.toString())
@@ -314,6 +368,13 @@ String? _usableEvalJsonText(
   }
   if (normalizedJson is! Map) return null;
   if (!required.every(normalizedJson.containsKey)) {
+    return null;
+  }
+  if (required.isEmpty &&
+      decoded.isNotEmpty &&
+      !normalizedJson.values.any(
+        (value) => value != null && (value is! String || value.isNotEmpty),
+      )) {
     return null;
   }
   return normalized;

--- a/lib/services/llm_provider.dart
+++ b/lib/services/llm_provider.dart
@@ -134,6 +134,12 @@ class LLMProvider extends ChangeNotifier {
     }
   }
 
+  /// URL currently used by the active OpenAI-compatible service.
+  String? get activeApiUrl => switch (_activeBackend) {
+    BackendType.kobold => null,
+    BackendType.openRouter || BackendType.omlx => _openRouterService.apiUrl,
+  };
+
   /// Whether the active backend is the local KoboldCpp instance (native or
   /// launched from a .kcpps preset). Gates the local niceties — real
   /// tokenizer counts and prefill perf metrics — and sequential eval dispatch

--- a/lib/services/llm_provider.dart
+++ b/lib/services/llm_provider.dart
@@ -134,12 +134,6 @@ class LLMProvider extends ChangeNotifier {
     }
   }
 
-  /// URL currently used by the active OpenAI-compatible service.
-  String? get activeApiUrl => switch (_activeBackend) {
-    BackendType.kobold => null,
-    BackendType.openRouter || BackendType.omlx => _openRouterService.apiUrl,
-  };
-
   /// Whether the active backend is the local KoboldCpp instance (native or
   /// launched from a .kcpps preset). Gates the local niceties — real
   /// tokenizer counts and prefill perf metrics — and sequential eval dispatch

--- a/lib/services/llm_service.dart
+++ b/lib/services/llm_service.dart
@@ -96,7 +96,7 @@ class GenerationParams {
   /// prefer-text (the ping shares this door).
   final bool Function()? stillWantTools;
 
-  /// Probe identity (`backend|model|path`). Style retry and skip/pause
+  /// Probe identity (`backend|endpoint|model|path`). Style retry and skip/pause
   /// key on the same string [ChatService] uses.
   final String backendIdentity;
 

--- a/lib/services/llm_service.dart
+++ b/lib/services/llm_service.dart
@@ -176,6 +176,11 @@ class LlmToolResponse {
   });
 }
 
+/// Opt-in identity surface for OpenAI-compatible services with a live URL.
+abstract interface class LlmApiEndpoint {
+  String get apiUrl;
+}
+
 /// Abstract interface for all LLM backends (local KoboldCPP, OpenRouter, etc).
 abstract class LLMService extends ChangeNotifier {
   /// Stream tokens one at a time for real-time display.

--- a/lib/services/open_router_service.dart
+++ b/lib/services/open_router_service.dart
@@ -457,8 +457,7 @@ class OpenRouterService extends LLMService {
     'X-Title': 'Front Porch AI',
   };
 
-  /// Non-streaming OpenAI tools: null = unusable, throw = transport failure.
-  /// Named choice survives the mandatory-reasoning retry through [params].
+  /// OpenAI tools: null = unusable; throw = transport failure.
   @override
   Future<LlmToolResponse?> generateWithTools(
     GenerationParams params,
@@ -474,7 +473,11 @@ class OpenRouterService extends LLMService {
       final payload = _chatPayload(params, stream: false);
       final host = Uri.tryParse(_apiUrl)?.host.toLowerCase();
       if (host == 'openrouter.ai' || host?.endsWith('.openrouter.ai') == true) {
-        payload['provider'] = {'require_parameters': true};
+        payload
+          ..remove('repetition_penalty')
+          ..remove('min_p')
+          ..remove('top_k')
+          ..['provider'] = {'require_parameters': true};
       }
       final response = await attachToolsWithStyleRetry(
         identity: identity,
@@ -488,8 +491,7 @@ class OpenRouterService extends LLMService {
         ),
       );
       if (response.statusCode == 429 || response.statusCode >= 500) {
-        // Rate-limited / provider hiccup: transient, not a capability
-        // verdict — must not brand the model tool-less for the run.
+        // A provider hiccup is transient, not a capability verdict.
         throw LlmToolTransportException(
           'tool call HTTP ${response.statusCode} (server busy/unavailable)',
         );
@@ -519,9 +521,7 @@ class OpenRouterService extends LLMService {
       }
       return parseOpenAiToolResponse(response.body);
     } catch (e) {
-      // Rethrow instead of collapsing to null — a killed connection must not
-      // read as "model can't speak tools" (it branded the backend XML-only
-      // for the whole run). Callers filter via looksLikeBackendUnreachable.
+      // Let callers classify killed connections as transport failures.
       debugPrint('[RemoteAPI] Tool call transport failure: $e');
       rethrow;
     } finally {

--- a/lib/services/open_router_service.dart
+++ b/lib/services/open_router_service.dart
@@ -453,31 +453,34 @@ class OpenRouterService extends LLMService {
   Map<String, String> get _chatHeaders => {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer $_apiKey',
-    // Identify the app for providers that support it
     'HTTP-Referer': 'https://github.com/linux4life1/front-porch-AI',
     'X-Title': 'Front Porch AI',
   };
 
-  /// OpenAI-style tool calling (non-streaming). Null = answered unusable;
-  /// throw = transport failure. Named `tool_choice` rides [params.toolChoice]
-  /// so the mandatory-reasoning retry forwards it by passing the same params.
+  /// Non-streaming OpenAI tools: null = unusable, throw = transport failure.
+  /// Named choice survives the mandatory-reasoning retry through [params].
   @override
   Future<LlmToolResponse?> generateWithTools(
     GenerationParams params,
     List<Map<String, dynamic>> tools,
   ) async {
     if (!isReady) return null;
-    final client = http.Client();
+    final client = httpClientFactory?.call() ?? http.Client();
     _activeClients.add(client);
     try {
       final identity = params.backendIdentity.isEmpty
           ? '$backendName|$_modelName|'
           : params.backendIdentity;
+      final payload = _chatPayload(params, stream: false);
+      final host = Uri.tryParse(_apiUrl)?.host.toLowerCase();
+      if (host == 'openrouter.ai' || host?.endsWith('.openrouter.ai') == true) {
+        payload['provider'] = {'require_parameters': true};
+      }
       final response = await attachToolsWithStyleRetry(
         identity: identity,
         tools: tools,
         toolChoice: params.toolChoice,
-        basePayload: _chatPayload(params, stream: false),
+        basePayload: payload,
         post: (payload) => client.post(
           Uri.parse('$_apiUrl/chat/completions'),
           headers: _chatHeaders,
@@ -508,9 +511,6 @@ class OpenRouterService extends LLMService {
         );
         return null;
       }
-      // A tool call cut by max_tokens comes back as a clean 200 with no
-      // tool_calls and no content — downstream that reads as "inconclusive,
-      // fall back to text" with no trace. Name it in the log.
       if (RegExp(r'"finish_reason"\s*:\s*"length"').hasMatch(response.body)) {
         debugPrint(
           '[RemoteAPI] $modelName tool call hit max_tokens '

--- a/lib/services/open_router_service.dart
+++ b/lib/services/open_router_service.dart
@@ -70,18 +70,14 @@ String _remoteApiErrorMessage(String body, int statusCode) {
 }
 
 /// LLM backend for OpenAI-compatible APIs (OpenRouter, Nano-GPT, vLLM, …).
-class OpenRouterService extends LLMService {
+class OpenRouterService extends LLMService implements LlmApiEndpoint {
   String _apiUrl;
   String _apiKey;
   String _modelName;
   final RemoteApiHealth _health = RemoteApiHealth();
 
-  /// Every client with a call in flight, so [abortGeneration] can close all of
-  /// them. A SET rather than one slot because this is a single shared instance
-  /// and the app deliberately overlaps remote calls on it (the staggered
-  /// realism judges, post-gen needs + reply-facts): with one slot the first
-  /// call to finish cleared the field, and Cancel then closed nothing while
-  /// the rest kept streaming (and billing).
+  /// Every in-flight client; a set is required because staggered remote evals
+  /// overlap, and one slot let the first completion disarm Cancel for the rest.
   final Set<http.Client> _activeClients = {};
 
   /// Test seam: a MockClient so reachability tests never hit the network.
@@ -89,6 +85,7 @@ class OpenRouterService extends LLMService {
   set httpClientFactory(http.Client Function()? factory) =>
       _health.httpClientFactory = factory;
 
+  @override
   String get apiUrl => _apiUrl;
   String get apiKey => _apiKey;
   String get modelName => _modelName;

--- a/lib/services/system_role_probe.dart
+++ b/lib/services/system_role_probe.dart
@@ -436,10 +436,10 @@ class _ProbeRun {
   }
 }
 
-/// Backend+model identity key. Deliberately the same shape as the tools
-/// probe's `_evalBackendIdentity` — remote model name AND local model path
-/// both ride it — so switching either model or backend re-probes by
-/// construction, and both capability verdicts reset together.
+/// Backend+model identity key. It shares the model/path components used by the
+/// tools probe, while that remote-capability probe additionally keys by API
+/// endpoint. Switching either model or backend still re-probes by
+/// construction.
 ///
 /// Every component is a MUTABLE setting, so a caller must resolve this ONCE
 /// when the model comes up and hold the string — never recompute it per

--- a/test/services/capability/model_capabilities_test.dart
+++ b/test/services/capability/model_capabilities_test.dart
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:front_porch_ai/services/capability/model_capabilities.dart';
+import 'package:front_porch_ai/services/capability/capability.dart';
 import 'package:front_porch_ai/utils/gguf_vision.dart';
 
 void main() {
@@ -14,10 +14,18 @@ void main() {
           'input_modalities': ['text', 'image'],
           'output_modalities': ['text'],
         },
-        'supported_parameters': ['tools', 'temperature'],
+        'supported_parameters': ['TOOLS', 'Tool_Choice', 'temperature'],
       });
       expect(caps.vision, isTrue);
       expect(caps.toolCalling, isTrue);
+    });
+
+    test('tools without forced tool_choice are not reliable eval support', () {
+      final caps = ModelApiCapabilities.fromOpenRouterEntry({
+        'id': 'provider/model-that-ignores-forced-calls',
+        'supported_parameters': ['tools', 'temperature'],
+      });
+      expect(caps.toolCalling, isFalse);
     });
 
     test('text-only model has neither vision nor tools', () {
@@ -271,7 +279,6 @@ void main() {
       expect(s.supported, isTrue);
       expect(s.source, VisionSource.ggufWithMmproj);
     });
-
   });
 
   group('capability metadata host detection (shared helper)', () {

--- a/test/services/chat/pass_support_test.dart
+++ b/test/services/chat/pass_support_test.dart
@@ -39,6 +39,8 @@ void main() {
     Future<({String? result, ToolTransportProbe probe, int textCalls})> run({
       required Future<LlmToolResponse?> Function() toolAnswer,
       ToolTransportProbe? probe,
+      List<Map<String, dynamic>>? evalTools,
+      String toolChoice = kRelationshipTool,
     }) async {
       final p = probe ?? ToolTransportProbe();
       var textCalls = 0;
@@ -46,12 +48,11 @@ void main() {
         probe: p,
         backendIdentity: id,
         debugLabel: 'test',
-        tools: kRelationshipEvalTools,
-        toolChoice: kRelationshipTool,
+        tools: evalTools ?? kRelationshipEvalTools,
+        toolChoice: toolChoice,
         buildPrompt: ({required bool toolsMode}) =>
             toolsMode ? 'TOOLS' : 'TEXT',
-        callToText: (resp) =>
-            realismToolCallToJson(kRelationshipTool, resp.calls),
+        callToText: (resp) => realismToolCallToJson(toolChoice, resp.calls),
         fireToolEval: (_, _) => toolAnswer(),
         fireTextEval: (prompt, {onChunk}) async {
           textCalls++;
@@ -136,6 +137,50 @@ void main() {
       expect(r.textCalls, 1);
     });
 
+    test('invalid expression enum falls through to text', () async {
+      final r = await run(
+        evalTools: kExpressionEvalTools,
+        toolChoice: kExpressionTool,
+        toolAnswer: () async => const LlmToolResponse(
+          calls: [],
+          text: '{"label":"not-an-expression"}',
+        ),
+      );
+      expect(r.result, 'TEXT-RESULT');
+      expect(r.textCalls, 1);
+    });
+
+    test('unusable cast JSON falls through instead of meaning none', () async {
+      for (final text in const [
+        '{"error":"ignored tool"}',
+        '{"descriptor":"the host\'s sister"}',
+      ]) {
+        final r = await run(
+          evalTools: kCastDetectEvalTools,
+          toolChoice: kCastDetectTool,
+          toolAnswer: () async => LlmToolResponse(calls: const [], text: text),
+        );
+        expect(r.result, 'TEXT-RESULT', reason: text);
+        expect(r.textCalls, 1, reason: text);
+      }
+    });
+
+    test(
+      'nested required fields are validated before Pockets salvage',
+      () async {
+        final r = await run(
+          evalTools: PocketsEval.tools,
+          toolChoice: PocketsEval.kPocketsTool,
+          toolAnswer: () async => const LlmToolResponse(
+            calls: [],
+            text: '{"inventory_ops":[{"op":"pickup"}]}',
+          ),
+        );
+        expect(r.result, 'TEXT-RESULT');
+        expect(r.textCalls, 1);
+      },
+    );
+
     test('transport failure → text fallback, NO verdict', () async {
       final r = await run(
         toolAnswer: () async =>
@@ -191,8 +236,11 @@ void main() {
       expect(wiring, contains('return evalBackendIdentityFor('));
       expect(
         wiring,
-        contains('remoteApiUrl: _storageService.remoteApiUrl'),
-        reason: 'testing only the pure key helper would not guard its wiring',
+        allOf(
+          contains('_llmProvider?.activeApiUrl'),
+          contains('remoteApiUrl: remoteApiUrl'),
+        ),
+        reason: 'the key must use the active oMLX/OpenRouter service endpoint',
       );
     });
   });

--- a/test/services/chat/pass_support_test.dart
+++ b/test/services/chat/pass_support_test.dart
@@ -101,7 +101,7 @@ void main() {
     });
 
     test(
-      'prose answer falls through to text and brands tools unreliable',
+      'prose answer falls through to text without branding the model',
       () async {
         // OpenRouter can return ordinary prose while claiming the forced tool
         // parameter is supported. Returning it here used to skip the working
@@ -111,7 +111,7 @@ void main() {
               const LlmToolResponse(calls: [], text: 'bond_delta: 3'),
         );
         expect(r.result, 'TEXT-RESULT');
-        expect(r.probe.supportFor(id), ToolCallSupport.unsupported);
+        expect(r.probe.supportFor(id), ToolCallSupport.untested);
         expect(r.textCalls, 1);
       },
     );
@@ -132,7 +132,7 @@ void main() {
             const LlmToolResponse(calls: [], text: '{"relationship_delta":3}'),
       );
       expect(r.result, 'TEXT-RESULT');
-      expect(r.probe.supportFor(id), ToolCallSupport.unsupported);
+      expect(r.probe.supportFor(id), ToolCallSupport.untested);
       expect(r.textCalls, 1);
     });
 
@@ -182,16 +182,6 @@ void main() {
         modelPath: null,
       );
       expect(nano, isNot(openRouter));
-      expect(
-        openRouter,
-        evalBackendIdentityFor(
-          backendName: 'Remote API',
-          remoteApiUrl: 'HTTPS://OPENROUTER.AI/api/v1/',
-          remoteModelName: 'shared/model',
-          modelPath: null,
-        ),
-        reason: 'cosmetic URL spelling must not discard a probe verdict',
-      );
     });
 
     test('ChatService includes the configured API URL at the call site', () {

--- a/test/services/chat/pass_support_test.dart
+++ b/test/services/chat/pass_support_test.dart
@@ -24,10 +24,12 @@
 // Guest joined (long mint generation + concurrent eval burst + abort/idle
 // traffic on the single-slot backend).
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:front_porch_ai/services/chat/pass_support.dart';
-import 'package:front_porch_ai/services/llm_service.dart'
+import 'package:front_porch_ai/services/chat/chat.dart';
+import 'package:front_porch_ai/services/services.dart'
     show LlmToolCall, LlmToolResponse, LlmToolTransportException;
 
 void main() {
@@ -44,15 +46,12 @@ void main() {
         probe: p,
         backendIdentity: id,
         debugLabel: 'test',
-        tools: const [
-          {
-            'type': 'function',
-            'function': {'name': 'report', 'parameters': {}},
-          },
-        ],
+        tools: kRelationshipEvalTools,
+        toolChoice: kRelationshipTool,
         buildPrompt: ({required bool toolsMode}) =>
             toolsMode ? 'TOOLS' : 'TEXT',
-        callToText: (resp) => resp.calls.isEmpty ? null : 'CONVERTED',
+        callToText: (resp) =>
+            realismToolCallToJson(kRelationshipTool, resp.calls),
         fireToolEval: (_, _) => toolAnswer(),
         fireTextEval: (prompt, {onChunk}) async {
           textCalls++;
@@ -65,28 +64,35 @@ void main() {
     test('a real tool call → supported, converted text returned', () async {
       final r = await run(
         toolAnswer: () async => const LlmToolResponse(
-          calls: [LlmToolCall(name: 'report', arguments: {})],
+          calls: [
+            LlmToolCall(
+              name: kRelationshipTool,
+              arguments: {'relationship_delta': 0, 'trust_delta': 0},
+            ),
+          ],
           text: '',
         ),
       );
-      expect(r.result, 'CONVERTED');
+      expect(r.result, '{"relationship_delta":0,"trust_delta":0}');
       expect(r.probe.supportFor(id), ToolCallSupport.supported);
       expect(r.textCalls, 0);
     });
 
-    test('EMPTY answer (server-side abort shape) → text fallback, NO verdict',
-        () async {
-      final r = await run(
-        toolAnswer: () async => const LlmToolResponse(calls: [], text: ''),
-      );
-      expect(r.result, 'TEXT-RESULT');
-      expect(r.textCalls, 1);
-      expect(
-        r.probe.supportFor(id),
-        ToolCallSupport.untested,
-        reason: 'an aborted call answers as a clean empty 200 — never brand',
-      );
-    });
+    test(
+      'EMPTY answer (server-side abort shape) → text fallback, NO verdict',
+      () async {
+        final r = await run(
+          toolAnswer: () async => const LlmToolResponse(calls: [], text: ''),
+        );
+        expect(r.result, 'TEXT-RESULT');
+        expect(r.textCalls, 1);
+        expect(
+          r.probe.supportFor(id),
+          ToolCallSupport.untested,
+          reason: 'an aborted call answers as a clean empty 200 — never brand',
+        );
+      },
+    );
 
     test('null answer → text fallback, NO verdict', () async {
       final r = await run(toolAnswer: () async => null);
@@ -94,15 +100,40 @@ void main() {
       expect(r.probe.supportFor(id), ToolCallSupport.untested);
     });
 
-    test('prose answer is salvaged without branding (tester is the oracle)',
-        () async {
+    test(
+      'prose answer falls through to text and brands tools unreliable',
+      () async {
+        // OpenRouter can return ordinary prose while claiming the forced tool
+        // parameter is supported. Returning it here used to skip the working
+        // streaming JSON fallback, freezing Realism and scene Needs.
+        final r = await run(
+          toolAnswer: () async =>
+              const LlmToolResponse(calls: [], text: 'bond_delta: 3'),
+        );
+        expect(r.result, 'TEXT-RESULT');
+        expect(r.probe.supportFor(id), ToolCallSupport.unsupported);
+        expect(r.textCalls, 1);
+      },
+    );
+
+    test('complete JSON text remains a usable salvage response', () async {
+      const json = '{"relationship_delta":3,"trust_delta":1}';
       final r = await run(
-        toolAnswer: () async =>
-            const LlmToolResponse(calls: [], text: 'bond_delta: 3'),
+        toolAnswer: () async => const LlmToolResponse(calls: [], text: json),
       );
-      expect(r.result, 'bond_delta: 3');
+      expect(r.result, json);
       expect(r.probe.supportFor(id), ToolCallSupport.untested);
       expect(r.textCalls, 0);
+    });
+
+    test('JSON missing a required eval field falls through to text', () async {
+      final r = await run(
+        toolAnswer: () async =>
+            const LlmToolResponse(calls: [], text: '{"relationship_delta":3}'),
+      );
+      expect(r.result, 'TEXT-RESULT');
+      expect(r.probe.supportFor(id), ToolCallSupport.unsupported);
+      expect(r.textCalls, 1);
     });
 
     test('transport failure → text fallback, NO verdict', () async {
@@ -133,6 +164,46 @@ void main() {
       );
       expect(r.result, 'TEXT-RESULT');
       expect(toolCalls, 0);
+    });
+  });
+
+  group('evalBackendIdentityFor', () {
+    test('same model slug on Nano-GPT and OpenRouter has distinct state', () {
+      final nano = evalBackendIdentityFor(
+        backendName: 'Remote API',
+        remoteApiUrl: 'https://nano-gpt.com/api/v1',
+        remoteModelName: 'shared/model',
+        modelPath: null,
+      );
+      final openRouter = evalBackendIdentityFor(
+        backendName: 'Remote API',
+        remoteApiUrl: 'https://openrouter.ai/api/v1',
+        remoteModelName: 'shared/model',
+        modelPath: null,
+      );
+      expect(nano, isNot(openRouter));
+      expect(
+        openRouter,
+        evalBackendIdentityFor(
+          backendName: 'Remote API',
+          remoteApiUrl: 'HTTPS://OPENROUTER.AI/api/v1/',
+          remoteModelName: 'shared/model',
+          modelPath: null,
+        ),
+        reason: 'cosmetic URL spelling must not discard a probe verdict',
+      );
+    });
+
+    test('ChatService includes the configured API URL at the call site', () {
+      final wiring = File(
+        'lib/services/chat/chat_service_wiring_evals.dart',
+      ).readAsStringSync();
+      expect(wiring, contains('return evalBackendIdentityFor('));
+      expect(
+        wiring,
+        contains('remoteApiUrl: _storageService.remoteApiUrl'),
+        reason: 'testing only the pure key helper would not guard its wiring',
+      );
     });
   });
 }

--- a/test/services/chat/pass_support_test.dart
+++ b/test/services/chat/pass_support_test.dart
@@ -237,7 +237,7 @@ void main() {
       expect(
         wiring,
         allOf(
-          contains('_llmProvider?.activeApiUrl'),
+          contains('service is LlmApiEndpoint'),
           contains('remoteApiUrl: remoteApiUrl'),
         ),
         reason: 'the key must use the active oMLX/OpenRouter service endpoint',

--- a/test/services/open_router_tools_test.dart
+++ b/test/services/open_router_tools_test.dart
@@ -16,11 +16,12 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
-import 'package:front_porch_ai/services/llm_service.dart';
 import 'package:front_porch_ai/services/llm_tool_parsing.dart';
-import 'package:front_porch_ai/services/open_router_service.dart';
 import 'package:front_porch_ai/services/openai_chat_stream.dart';
+import 'package:front_porch_ai/services/services.dart'
+    show GenerationParams, OpenRouterService, isToolTransportFailure;
 
 void main() {
   // The test binding stubs HttpClient (every request would 400 without a
@@ -132,37 +133,81 @@ void main() {
       },
     ];
 
-    test('sends a non-streaming request with tools and parses the calls',
-        () async {
-      responseBody = jsonEncode({
-        'choices': [
-          {
-            'message': {
-              'tool_calls': [
-                {
-                  'function': {
-                    'name': 'add_memory',
-                    'arguments': '{"content": "It rained all night."}',
+    test(
+      'sends a non-streaming request with tools and parses the calls',
+      () async {
+        responseBody = jsonEncode({
+          'choices': [
+            {
+              'message': {
+                'tool_calls': [
+                  {
+                    'function': {
+                      'name': 'add_memory',
+                      'arguments': '{"content": "It rained all night."}',
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
-      });
+          ],
+        });
 
-      final resp = await service().generateWithTools(params, tools);
+        final resp = await service().generateWithTools(params, tools);
 
-      expect(lastRequest!['stream'], false);
-      expect(lastRequest!['tools'], isNotEmpty);
-      expect(lastRequest!['tool_choice'], 'auto');
-      expect(lastRequest!['model'], 'test-model');
-      // Same reasoning posture as the streaming eval path: with reasoning
-      // off and no budget, the shared payload builder omits the key.
-      expect(lastRequest!.containsKey('reasoning'), isFalse);
-      expect(resp!.calls.single.name, 'add_memory');
-      expect(resp.calls.single.arguments['content'], 'It rained all night.');
-    });
+        expect(lastRequest!['stream'], false);
+        expect(lastRequest!['tools'], isNotEmpty);
+        expect(lastRequest!['tool_choice'], 'auto');
+        expect(lastRequest!['model'], 'test-model');
+        expect(lastRequest!.containsKey('provider'), isFalse);
+        // Same reasoning posture as the streaming eval path: with reasoning
+        // off and no budget, the shared payload builder omits the key.
+        expect(lastRequest!.containsKey('reasoning'), isFalse);
+        expect(resp!.calls.single.name, 'add_memory');
+        expect(resp.calls.single.arguments['content'], 'It rained all night.');
+      },
+    );
+
+    test(
+      'only OpenRouter requires providers to honor tool parameters',
+      () async {
+        Future<Map<String, dynamic>> payloadFor(String apiUrl) async {
+          Map<String, dynamic>? payload;
+          final remote = OpenRouterService(
+            apiUrl: apiUrl,
+            apiKey: 'test-key',
+            modelName: 'same-model',
+          );
+          remote.httpClientFactory = () => MockClient((request) async {
+            payload = jsonDecode(request.body) as Map<String, dynamic>;
+            return http.Response(
+              jsonEncode({
+                'choices': [
+                  {
+                    'message': {
+                      'tool_calls': [
+                        {
+                          'function': {'name': 'add_memory', 'arguments': '{}'},
+                        },
+                      ],
+                    },
+                  },
+                ],
+              }),
+              200,
+            );
+          });
+          await remote.generateWithTools(params, tools);
+          return payload!;
+        }
+
+        final openRouter = await payloadFor('https://openrouter.ai/api/v1');
+        expect(openRouter['provider'], {'require_parameters': true});
+
+        final nano = await payloadFor('https://nano-gpt.com/api/v1');
+        expect(nano.containsKey('provider'), isFalse);
+      },
+    );
 
     test('non-200 (provider without tool support) returns null', () async {
       statusCode = 404;
@@ -172,35 +217,37 @@ void main() {
       expect(await service().generateWithTools(params, tools), isNull);
     });
 
-    test('429/5xx throws a transport failure — never a capability null',
-        () async {
-      statusCode = 503;
-      responseBody = jsonEncode({
-        'error': {'message': 'Server is busy; please try again later.'},
-      });
-      Object? caught;
-      try {
-        await service().generateWithTools(params, tools);
-        fail('a busy server must throw, not return null');
-      } catch (e) {
-        caught = e;
-      }
-      expect(isToolTransportFailure(caught), isTrue);
+    test(
+      '429/5xx throws a transport failure — never a capability null',
+      () async {
+        statusCode = 503;
+        responseBody = jsonEncode({
+          'error': {'message': 'Server is busy; please try again later.'},
+        });
+        Object? caught;
+        try {
+          await service().generateWithTools(params, tools);
+          fail('a busy server must throw, not return null');
+        } catch (e) {
+          caught = e;
+        }
+        expect(isToolTransportFailure(caught), isTrue);
 
-      // Same contract on the shared local door.
-      statusCode = 429;
-      try {
-        await postOpenAiChatWithTools(
-          'http://127.0.0.1:${server.port}',
-          params,
-          tools,
-        );
-        fail('a rate-limited server must throw, not return null');
-      } catch (e) {
-        caught = e;
-      }
-      expect(isToolTransportFailure(caught), isTrue);
-    });
+        // Same contract on the shared local door.
+        statusCode = 429;
+        try {
+          await postOpenAiChatWithTools(
+            'http://127.0.0.1:${server.port}',
+            params,
+            tools,
+          );
+          fail('a rate-limited server must throw, not return null');
+        } catch (e) {
+          caught = e;
+        }
+        expect(isToolTransportFailure(caught), isTrue);
+      },
+    );
 
     test('unready service returns null without making a request', () async {
       final unready = OpenRouterService(
@@ -211,50 +258,52 @@ void main() {
       expect(lastRequest, isNull);
     });
 
-    test('local door (postOpenAiChatWithTools) — same shape, same contract',
-        () async {
-      // The shared function KoboldService delegates to,
-      // pointed at the KoboldCpp-style root (no /v1 — the helper appends).
-      responseBody = jsonEncode({
-        'choices': [
-          {
-            'message': {
-              'tool_calls': [
-                {
-                  'function': {
-                    'name': 'pin_memory',
-                    'arguments': '{"id": 2}',
+    test(
+      'local door (postOpenAiChatWithTools) — same shape, same contract',
+      () async {
+        // The shared function KoboldService delegates to,
+        // pointed at the KoboldCpp-style root (no /v1 — the helper appends).
+        responseBody = jsonEncode({
+          'choices': [
+            {
+              'message': {
+                'tool_calls': [
+                  {
+                    'function': {
+                      'name': 'pin_memory',
+                      'arguments': '{"id": 2}',
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
-      });
-      final resp = await postOpenAiChatWithTools(
-        'http://127.0.0.1:${server.port}',
-        params,
-        tools,
-      );
-      expect(lastRequest!['stream'], false);
-      expect(lastRequest!['tools'], isNotEmpty);
-      expect(lastRequest!['tool_choice'], 'auto');
-      expect(lastRequest!['model'], 'koboldcpp'); // Kobold ignores the name
-      expect(resp!.calls.single.name, 'pin_memory');
-      expect(resp.calls.single.arguments['id'], 2);
-
-      // An old KoboldCpp that rejects the tools field → null → XML fallback.
-      statusCode = 400;
-      responseBody = '';
-      expect(
-        await postOpenAiChatWithTools(
+          ],
+        });
+        final resp = await postOpenAiChatWithTools(
           'http://127.0.0.1:${server.port}',
           params,
           tools,
-        ),
-        isNull,
-      );
-    });
+        );
+        expect(lastRequest!['stream'], false);
+        expect(lastRequest!['tools'], isNotEmpty);
+        expect(lastRequest!['tool_choice'], 'auto');
+        expect(lastRequest!['model'], 'koboldcpp'); // Kobold ignores the name
+        expect(resp!.calls.single.name, 'pin_memory');
+        expect(resp.calls.single.arguments['id'], 2);
+
+        // An old KoboldCpp that rejects the tools field → null → XML fallback.
+        statusCode = 400;
+        responseBody = '';
+        expect(
+          await postOpenAiChatWithTools(
+            'http://127.0.0.1:${server.port}',
+            params,
+            tools,
+          ),
+          isNull,
+        );
+      },
+    );
 
     test('client torn down mid-call (abortGeneration) throws a transport '
         'failure', () async {

--- a/test/services/open_router_tools_test.dart
+++ b/test/services/open_router_tools_test.dart
@@ -171,7 +171,10 @@ void main() {
     test(
       'only OpenRouter requires providers to honor tool parameters',
       () async {
-        Future<Map<String, dynamic>> payloadFor(String apiUrl) async {
+        Future<Map<String, dynamic>> payloadFor(
+          String apiUrl, {
+          GenerationParams? requestParams,
+        }) async {
           Map<String, dynamic>? payload;
           final remote = OpenRouterService(
             apiUrl: apiUrl,
@@ -197,17 +200,93 @@ void main() {
               200,
             );
           });
-          await remote.generateWithTools(params, tools);
+          await remote.generateWithTools(requestParams ?? params, tools);
           return payload!;
         }
 
-        final openRouter = await payloadFor('https://openrouter.ai/api/v1');
+        const strictParams = GenerationParams(
+          prompt: 'structured eval',
+          maxLength: 512,
+          repeatPenalty: 1.15,
+          minP: 0.05,
+          topK: 40,
+        );
+        final openRouter = await payloadFor(
+          'https://openrouter.ai/api/v1',
+          requestParams: strictParams,
+        );
         expect(openRouter['provider'], {'require_parameters': true});
+        expect(openRouter.containsKey('repetition_penalty'), isFalse);
+        expect(openRouter.containsKey('min_p'), isFalse);
+        expect(openRouter.containsKey('top_k'), isFalse);
 
-        final nano = await payloadFor('https://nano-gpt.com/api/v1');
+        final nano = await payloadFor(
+          'https://nano-gpt.com/api/v1',
+          requestParams: strictParams,
+        );
         expect(nano.containsKey('provider'), isFalse);
+        expect(nano['repetition_penalty'], 1.15);
+        expect(nano['min_p'], 0.05);
+        expect(nano['top_k'], 40);
       },
     );
+
+    test('OpenRouter constraint survives a tool-choice style retry', () async {
+      final payloads = <Map<String, dynamic>>[];
+      final remote = OpenRouterService(
+        apiUrl: 'https://openrouter.ai/api/v1',
+        apiKey: 'test-key',
+        modelName: 'retry-model',
+      );
+      remote.httpClientFactory = () => MockClient((request) async {
+        payloads.add(jsonDecode(request.body) as Map<String, dynamic>);
+        if (payloads.length == 1) {
+          return http.Response(
+            jsonEncode({
+              'error': {'message': 'unsupported tool_choice object'},
+            }),
+            400,
+          );
+        }
+        return http.Response(
+          jsonEncode({
+            'choices': [
+              {
+                'message': {
+                  'tool_calls': [
+                    {
+                      'function': {'name': 'add_memory', 'arguments': '{}'},
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          200,
+        );
+      });
+
+      final resp = await remote.generateWithTools(
+        const GenerationParams(
+          prompt: 'structured eval',
+          maxLength: 512,
+          toolChoice: 'add_memory',
+          backendIdentity: 'openrouter-require-params-retry',
+        ),
+        tools,
+      );
+
+      expect(payloads, hasLength(2));
+      expect(
+        payloads.every(
+          (payload) =>
+              (payload['provider'] as Map?)?['require_parameters'] == true,
+        ),
+        isTrue,
+      );
+      expect(payloads[1]['tool_choice'], 'required');
+      expect(resp!.calls.single.name, 'add_memory');
+    });
 
     test('non-200 (provider without tool support) returns null', () async {
       statusCode = 404;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Nano-GPT and OpenRouter share `OpenRouterService`, but their routed tool behavior differs. OpenRouter can advertise `tools` while the selected provider ignores forced `tool_choice` and returns prose or partial JSON. `fireStructuredEval` previously accepted any non-empty text as success, skipping the working streaming JSON fallback; bond/trust then stayed frozen while Needs still applied ambient decay.

This PR closes all four requested boundaries:

- validates call-less text against the selected tool schema (including enums and nested required fields), then through the same converter as real calls; prose, partial, unknown-only, or otherwise unusable JSON falls through, while successful `tool_calls -> callToText` remains unchanged;
- treats OpenRouter metadata as tool-capable only when both `tools` and `tool_choice` are advertised, case-insensitively; Nano-GPT metadata parsing is unchanged;
- sends OpenRouter's `provider: { require_parameters: true }` on tool requests. Strict OpenRouter tool payloads omit unrelated `min_p`, `top_k`, and `repetition_penalty` so Grok/Gemini routes are not excluded for optional samplers; Nano-GPT and generic hosts retain those fields;
- keys probe/one-shot state with the active service endpoint through an opt-in endpoint interface, so Nano, OpenRouter, and oMLX cannot share verdicts for an identical model slug. Existing local and fake services are unaffected.

A named-tool 400→style-retry test confirms the provider constraint survives every attempt and still returns the successful call.

The existing prose-salvage assertion and OpenRouter capability fixture were intentionally updated because they pinned the faulty behavior. This PR needs `approved-test-change` before the protected-path gate can pass.

The first CI unit run had one unrelated failure: `session_picker_overlay_hold_test.dart` saw its Drift isolate close while a fire-and-forget Porch Memory scan unwound. There was no failed assertion. That file passes alone and repeated complete local suites pass; all 15 CI E2E shards passed. A later local full run caught and fixed an actual endpoint-getter compatibility issue in legacy provider fakes before the final push.

## Target branch

- [x] This PR targets Rawhide

## Type of change

- [x] Bug fix

## How was this tested?

Tested on Linux. The transport logic is pure Dart/HTTP; the first CI run's Windows/macOS/Linux E2E shards all passed. No live OpenRouter account was available for a manual model call.

- [x] Focused + sibling transport set: 275 passed
- [x] Final full non-golden suite: 5,339 passed, 13 skipped
- [x] Linux host goldens: 118 passed; CI golden job also passed
- [x] `flutter analyze --no-fatal-warnings --no-fatal-infos` exits 0 (12 pre-existing infos, none in touched files)
- [x] `dart fix --dry-run` finds only 8 pre-existing fixes in untouched/protected files
- [x] Mutation checks proved prose, partial/nested/enum/cast JSON, endpoint identity, metadata case handling, OpenRouter-only routing, sampler stripping, and valid salvage guards red before green
- [ ] Live OpenRouter model exercised manually

## Parity

- [x] Realism/Needs behavior remains identical in 1:1 and group chats because both use the same transport chokepoint
- [x] Web/mobile needs no separate UI change; chats relay through the same Dart `ChatService`

## Dependencies and licensing

- [x] No dependencies changed

## Checklist

- [x] No new files
- [x] No UI or color changes
- [x] Formatting was limited to touched Dart paths
- [x] I did not edit the version in `pubspec.yaml`
- [x] Failed tool responses are logged and fall through rather than being swallowed
- [x] My contribution is licensed under AGPL-3.0-or-later and I have the right to submit it
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43fc32b1-26af-4bb6-abe8-eee6d11211e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43fc32b1-26af-4bb6-abe8-eee6d11211e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

