### PR TITLE
fix(realism): use OpenRouter json_schema for named evals

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -6,7 +6,7 @@
 - **What:** Probe persists only named/required. Auto is a one-shot for this
   request. `styleFor` treats leftover auto as unset. Stream door also retries
   mandatory-reasoning 400s the POST path already did.
-- **Commit:** (this tip)
+- **Commit:** c010620d
 
 ## 2026-09-08 — fix(realism): stream OpenRouter tools with the same force as POST
 - **Why:** Live judges pass overlay `onChunk`, so `generateWithTools` took the

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,3 +1,19 @@
+## 2026-09-08 — fix(realism): OpenRouter judges use json_schema, not forced tools
+- **Why:** #230 (e00fb2ba) salvaged call-less prose and added
+  `require_parameters` on forced `tool_choice`. Live OR still froze bond/trust
+  (Needs kept ambient decay). Forced tools are the wrong primitive: several
+  providers advertise `tools` then ignore `tool_choice`, thinking models burn
+  the 512-token judge budget, overlay `onChunk` streamed `tool_choice:auto`
+  (so #230's non-stream routing never ran), and `reasoning` +
+  `require_parameters` routed only to thinking endpoints.
+- **What:** Named evals on openrouter.ai send `response_format: json_schema`
+  (strict schema from the selected tool, no tools/reasoning/samplers,
+  `require_parameters` for structured outputs, 4000-token floor). 404/unusable
+  JSON falls back to the existing tools door. Nano-GPT / oMLX / LM Studio /
+  Journal stay on tools. Salvage JSON from `reasoning_content` and mixed
+  prose. Named judges stay on the buffered POST.
+- **Commit:** (this tip)
+
 ## 2026-09-07 — test(chat): harden picker-hold Drift isolate tearDown
 - **Why:** CI @ 767b3bc6 unit failed `session_picker_overlay_hold_test`
   (picker hold stays up when setActive loads another card's tail) with Drift

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,3 +1,13 @@
+## 2026-09-08 — fix(realism): do not persist tool_choice auto for named judges
+- **Why:** Style retry remembered `auto` after a `tool_choice` 400. The next
+  overlay `report_*` judge on that identity started at auto — #230's
+  streaming-auto bug after one bad provider 400. Tests hid it with
+  `resetForTest`.
+- **What:** Probe persists only named/required. Auto is a one-shot for this
+  request. `styleFor` treats leftover auto as unset. Stream door also retries
+  mandatory-reasoning 400s the POST path already did.
+- **Commit:** (this tip)
+
 ## 2026-09-08 — fix(realism): stream OpenRouter tools with the same force as POST
 - **Why:** Live judges pass overlay `onChunk`, so `generateWithTools` took the
   streaming branch. That door hardcoded `tool_choice:auto`, skipped

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -12,7 +12,7 @@
   `onChunk` is forwarded again. json_schema stays primary for named OR judges
   and can stream when the overlay is live. Nano / oMLX / LM Studio unchanged
   aside from now forcing the named tool on the stream path too.
-- **Commit:** (this tip)
+- **Commit:** 2877dd72
 
 ## 2026-09-08 — fix(realism): OpenRouter judges use json_schema, not forced tools
 - **Why:** #230 (e00fb2ba) salvaged call-less prose and added

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,3 +1,19 @@
+## 2026-09-08 — fix(realism): stream OpenRouter tools with the same force as POST
+- **Why:** Live judges pass overlay `onChunk`, so `generateWithTools` took the
+  streaming branch. That door hardcoded `tool_choice:auto`, skipped
+  `require_parameters` / sampler strip, and kept the 512-token scalar budget.
+  #230 only patched the buffered POST. Overlay-null was a workaround, not a
+  fix — fallback / Journal / Nano still streamed the broken payload.
+- **What:** Streaming and non-streaming OR tool requests share
+  `applyOpenRouterToolRouting` + `attachToolsWithStyleRetry` /
+  `streamOpenAiChatToolsWithStyleRetry` (named/required from the probe,
+  `provider.require_parameters` on openrouter.ai, no min_p/top_k/rep-pen).
+  Scalar OR tools floor at 4000 (+ think headroom when mandatory). Overlay
+  `onChunk` is forwarded again. json_schema stays primary for named OR judges
+  and can stream when the overlay is live. Nano / oMLX / LM Studio unchanged
+  aside from now forcing the named tool on the stream path too.
+- **Commit:** (this tip)
+
 ## 2026-09-08 — fix(realism): OpenRouter judges use json_schema, not forced tools
 - **Why:** #230 (e00fb2ba) salvaged call-less prose and added
   `require_parameters` on forced `tool_choice`. Live OR still froze bond/trust
@@ -11,8 +27,8 @@
   `require_parameters` for structured outputs, 4000-token floor). 404/unusable
   JSON falls back to the existing tools door. Nano-GPT / oMLX / LM Studio /
   Journal stay on tools. Salvage JSON from `reasoning_content` and mixed
-  prose. Named judges stay on the buffered POST.
-- **Commit:** (this tip)
+  prose.
+- **Commit:** 539d7a12 / a9f14724
 
 ## 2026-09-07 — test(chat): harden picker-hold Drift isolate tearDown
 - **Why:** CI @ 767b3bc6 unit failed `session_picker_overlay_hold_test`

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -9,7 +9,7 @@ Last shipped nightly: `rawhide.20260906.7059c91`. Everything below is unreleased
 
 - ♾️ **Waifu Coder is not capped at chat Max Output Tokens** — a turn can fill the rest of the context window so a tool call is not cut off mid-file. Chat still uses that slider. One reply bubble per send: reads/writes/bash stack as a quiet log above it, then she speaks. The old 20-step cutoff is a runaway fuse at 80.
 
-- 🎭 **OpenRouter models move relationships, Needs, and scene time again** — providers that ignore forced tool calls now retry through the reliable JSON path instead of treating prose as an answer. Bonds no longer freeze while Needs only decay on Grok, Gemini, and similar routed models. Same on the phone.
+- 🎭 **OpenRouter models move relationships, Needs, and scene time again** — those judges now ask OpenRouter for a JSON schema instead of a forced tool call (several providers advertise tools and then ignore `tool_choice`, or spend the 512-token budget thinking). Nano-GPT, local MLX, and LM Studio stay on tools. Same on the phone.
 
 - 🖼 **Drop a photo on the composer** — Finder/Explorer onto the chat bar or Waifu Coder, or the attach button. One photo per send. The picker is still there if you prefer it.
 

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -9,7 +9,7 @@ Last shipped nightly: `rawhide.20260906.7059c91`. Everything below is unreleased
 
 - ♾️ **Waifu Coder is not capped at chat Max Output Tokens** — a turn can fill the rest of the context window so a tool call is not cut off mid-file. Chat still uses that slider. One reply bubble per send: reads/writes/bash stack as a quiet log above it, then she speaks. The old 20-step cutoff is a runaway fuse at 80.
 
-- 🎭 **OpenRouter models move relationships, Needs, and scene time again** — those judges now ask OpenRouter for a JSON schema instead of a forced tool call (several providers advertise tools and then ignore `tool_choice`, or spend the 512-token budget thinking). Nano-GPT, local MLX, and LM Studio stay on tools. Same on the phone.
+- 🎭 **OpenRouter models move relationships, Needs, and scene time again** — those judges now ask OpenRouter for a JSON schema (and the live overlay path finally sends the same forced tool / `require_parameters` payload as the background POST, with room for thinking models). Nano-GPT, local MLX, and LM Studio stay on tools. Same on the phone.
 
 - 🖼 **Drop a photo on the composer** — Finder/Explorer onto the chat bar or Waifu Coder, or the attach button. One photo per send. The picker is still there if you prefer it.
 

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -590,10 +590,7 @@ extension ChatServiceWiringEvals on ChatService {
           salvageReasoning: true,
           stopSequences: const [],
           toolChoice: spec.toolChoice,
-          // Named evals stay on the buffered POST. Forwarding overlay
-          // onChunk made generateWithTools stream with tool_choice:auto,
-          // which is how #230's OpenRouter routing never ran live.
-          onChunk: named ? null : spec.onChunk,
+          onChunk: spec.onChunk,
           backendIdentity: _evalBackendIdentity,
           stillWantTools: () =>
               _toolProbe.shouldPostAfterIdle(_evalBackendIdentity),

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -555,12 +555,16 @@ extension ChatServiceWiringEvals on ChatService {
                 resp.calls.fold(0, (a, c) => a + c.arguments.length * 16),
       ms: trafficWatch.elapsedMilliseconds,
     );
-    final timeout = spec.maxLength <= kScalarToolMaxTokens
-        ? kEvalStreamChunkTimeout
-        : kEvalToolCallTimeout;
+    final named = spec.toolChoice != null && spec.toolChoice!.isNotEmpty;
+    // Named judges use the whole-call deadline: OpenRouter thinking
+    // endpoints regularly exceed the 180s between-chunk guard that 512-token
+    // scalar tools used to share.
+    final timeout = named || spec.maxLength > kScalarToolMaxTokens
+        ? kEvalToolCallTimeout
+        : kEvalStreamChunkTimeout;
     try {
       final resp = await service
-          .generateWithTools(
+          .generateStructuredJson(
             GenerationParams(
               prompt: spec.prompt,
               maxLength: spec.maxLength,
@@ -582,7 +586,10 @@ extension ChatServiceWiringEvals on ChatService {
               salvageReasoning: true,
               stopSequences: const [],
               toolChoice: spec.toolChoice,
-              onChunk: spec.onChunk,
+              // Named evals stay on the buffered POST. Forwarding overlay
+              // onChunk made generateWithTools stream with tool_choice:auto,
+              // which is how #230's OpenRouter routing never ran live.
+              onChunk: named ? null : spec.onChunk,
               backendIdentity: _evalBackendIdentity,
               stillWantTools: () =>
                   _toolProbe.shouldPostAfterIdle(_evalBackendIdentity),

--- a/lib/services/chat/chat_service_wiring_evals.dart
+++ b/lib/services/chat/chat_service_wiring_evals.dart
@@ -563,40 +563,43 @@ extension ChatServiceWiringEvals on ChatService {
         ? kEvalToolCallTimeout
         : kEvalStreamChunkTimeout;
     try {
-      final resp = await service
-          .generateStructuredJson(
-            GenerationParams(
-              prompt: spec.prompt,
-              maxLength: spec.maxLength,
-              temperature: 0.1,
-              repeatPenalty: spec.repeatPenalty,
-              topP: 0.5,
-              xtcProbability: 0.0,
-              reasoningEnabled: false,
-              // Explicit thinking-off: Nano-GPT/OpenRouter only receive the
-              // disable signal when the reasoning block is present, and it is
-              // only emitted when a reasoning field is set. Without this a
-              // ":thinking" model (e.g. Kimi K2.6) keeps reasoning during the
-              // journal tool call, which returns tool calls only intermittently
-              // (the "had to regen twice" symptom). 0 → {enabled:false,
-              // max_tokens:0, exclude:true}, the strongest disable signal.
-              reasoningMaxTokens: 0,
-              // Keep the think channel on mandatory models so a 400-then-
-              // exclude path cannot swallow the JSON / tool call (Kimi 2.6).
-              salvageReasoning: true,
-              stopSequences: const [],
-              toolChoice: spec.toolChoice,
-              // Named evals stay on the buffered POST. Forwarding overlay
-              // onChunk made generateWithTools stream with tool_choice:auto,
-              // which is how #230's OpenRouter routing never ran live.
-              onChunk: named ? null : spec.onChunk,
-              backendIdentity: _evalBackendIdentity,
-              stillWantTools: () =>
-                  _toolProbe.shouldPostAfterIdle(_evalBackendIdentity),
-            ),
-            spec.tools,
-          )
-          .timeout(timeout);
+      // OpenRouter named evals use json_schema; Kobold / fakes stay on tools.
+      // Kept off LLMService so implementers do not need a stub.
+      final evalCall = service is OpenRouterService
+          ? service.generateStructuredJson
+          : service.generateWithTools;
+      final resp = await evalCall(
+        GenerationParams(
+          prompt: spec.prompt,
+          maxLength: spec.maxLength,
+          temperature: 0.1,
+          repeatPenalty: spec.repeatPenalty,
+          topP: 0.5,
+          xtcProbability: 0.0,
+          reasoningEnabled: false,
+          // Explicit thinking-off: Nano-GPT/OpenRouter only receive the
+          // disable signal when the reasoning block is present, and it is
+          // only emitted when a reasoning field is set. Without this a
+          // ":thinking" model (e.g. Kimi K2.6) keeps reasoning during the
+          // journal tool call, which returns tool calls only intermittently
+          // (the "had to regen twice" symptom). 0 → {enabled:false,
+          // max_tokens:0, exclude:true}, the strongest disable signal.
+          reasoningMaxTokens: 0,
+          // Keep the think channel on mandatory models so a 400-then-
+          // exclude path cannot swallow the JSON / tool call (Kimi 2.6).
+          salvageReasoning: true,
+          stopSequences: const [],
+          toolChoice: spec.toolChoice,
+          // Named evals stay on the buffered POST. Forwarding overlay
+          // onChunk made generateWithTools stream with tool_choice:auto,
+          // which is how #230's OpenRouter routing never ran live.
+          onChunk: named ? null : spec.onChunk,
+          backendIdentity: _evalBackendIdentity,
+          stillWantTools: () =>
+              _toolProbe.shouldPostAfterIdle(_evalBackendIdentity),
+        ),
+        spec.tools,
+      ).timeout(timeout);
       recordTraffic(resp);
       return resp;
     } on TimeoutException {

--- a/lib/services/chat/pass_support.dart
+++ b/lib/services/chat/pass_support.dart
@@ -21,6 +21,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 
 import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/chat/eval_json_merge.dart';
 import 'package:front_porch_ai/services/chat/tool_eval_spec.dart';
 import 'package:front_porch_ai/services/services.dart'
     show LlmToolCall, LlmToolResponse, OneShotMode, isToolTransportFailure;
@@ -315,16 +316,8 @@ String? _usableEvalJsonText(
   required String? toolChoice,
   required String? Function(LlmToolResponse resp) callToText,
 }) {
-  final trimmed = text.trim();
-  if (trimmed.isEmpty) return null;
-
-  final dynamic decoded;
-  try {
-    decoded = jsonDecode(trimmed);
-  } catch (_) {
-    return null;
-  }
-  if (decoded is! Map) return null;
+  final decoded = parseEvalJsonObject(text);
+  if (decoded == null) return null;
 
   String? selectedName;
   Map<dynamic, dynamic>? parameters;
@@ -346,7 +339,7 @@ String? _usableEvalJsonText(
   final required = requiredRaw is List
       ? requiredRaw.map((field) => field.toString())
       : const <String>[];
-  if (required.isEmpty && decoded.isEmpty) return trimmed;
+  if (required.isEmpty && decoded.isEmpty) return text.trim();
 
   final normalized = callToText(
     LlmToolResponse(
@@ -426,17 +419,24 @@ Future<String?> fireStructuredEval({
           onChunk?.call('$text\n');
           return text;
         }
-        final salvaged = _usableEvalJsonText(
-          resp.text,
-          tools: tools,
-          toolChoice: toolChoice,
-          callToText: callToText,
-        );
+        final salvaged =
+            _usableEvalJsonText(
+              resp.text,
+              tools: tools,
+              toolChoice: toolChoice,
+              callToText: callToText,
+            ) ??
+            _usableEvalJsonText(
+              resp.reasoning,
+              tools: tools,
+              toolChoice: toolChoice,
+              callToText: callToText,
+            );
         if (salvaged != null) {
           onChunk?.call('$salvaged\n');
           return salvaged;
         }
-        if (resp.text.trim().isNotEmpty) {
+        if (resp.text.trim().isNotEmpty || resp.reasoning.trim().isNotEmpty) {
           debugPrint(
             '[Eval:Tools] $debugLabel returned prose or incomplete JSON — '
             'retrying with text transport',

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -29,13 +29,13 @@ import 'package:uuid/uuid.dart';
 import 'package:front_porch_ai/app_version.dart';
 import 'package:front_porch_ai/services/kobold_service.dart';
 import 'package:front_porch_ai/services/llm_service.dart';
+import 'package:front_porch_ai/services/open_router_service.dart';
 import 'package:front_porch_ai/services/reasoning_effort.dart';
 import 'package:front_porch_ai/services/capability/vision_support_resolver.dart';
 import 'package:front_porch_ai/services/caption/local_caption_service.dart';
 import 'package:front_porch_ai/services/vision_eval.dart';
 import 'package:front_porch_ai/services/llm_provider.dart';
 import 'package:front_porch_ai/services/user_persona_service.dart';
-
 import 'package:front_porch_ai/utils/utils.dart';
 import 'package:front_porch_ai/services/storage_service.dart';
 import 'package:front_porch_ai/services/tool_choice_style_probe.dart';
@@ -58,7 +58,6 @@ import 'package:front_porch_ai/services/mcp/mcp.dart';
 import 'package:front_porch_ai/services/macro_resolver.dart';
 import 'package:drift/drift.dart' as drift;
 
-// Parts share this library's imports and privates. Keep this file under 1000.
 part 'chat/chat_service_group_read.dart';
 part 'chat/chat_service_group_settings.dart';
 part 'chat/chat_service_growth.dart';
@@ -781,7 +780,8 @@ class ChatService extends ChangeNotifier with ChatServiceTodaySentence {
   // building/saving, and the TTS drain buffer. 1:1 vs group parity is
   // preserved for all of it via callbacks + the impersonation dance. See
   // docs/refactor-god-file-modularization.md for the full extraction history.
-  Completer<void>? _chanceTimeCompleter; // pauses sendMessage while wheel is active (UI coordination, stays in god)
+  Completer<void>?
+  _chanceTimeCompleter; // pauses sendMessage while wheel is active (UI coordination, stays in god)
 
   // ── Trust Repair ──
   // Armed on each severe trust drop (≥ -20 delta). Consumed on the very

--- a/lib/services/llm_service.dart
+++ b/lib/services/llm_service.dart
@@ -205,16 +205,6 @@ abstract class LLMService extends ChangeNotifier {
     List<Map<String, dynamic>> tools,
   ) async => null;
 
-  /// Named realism/needs-style evals that want a JSON object. Default is
-  /// [generateWithTools]. OpenRouter overrides this to send
-  /// `response_format: json_schema` (forced `tool_choice` is ignored by
-  /// several of its providers). Nano-GPT, oMLX, LM Studio, and Kobold stay
-  /// on tools via the default.
-  Future<LlmToolResponse?> generateStructuredJson(
-    GenerationParams params,
-    List<Map<String, dynamic>> tools,
-  ) => generateWithTools(params, tools);
-
   /// Abort the current in-flight generation request (closes the HTTP client).
   void abortGeneration() {}
 

--- a/lib/services/llm_service.dart
+++ b/lib/services/llm_service.dart
@@ -88,8 +88,8 @@ class GenerationParams {
   /// signature (existing test fakes must not be edited).
   final String? toolChoice;
 
-  /// Live token callback for streaming tool calls (Waifu Coder think
-  /// tokens). Evals leave this null and stay on the buffered POST.
+  /// Live token callback (Waifu Coder think tokens, realism overlay).
+  /// Null stays on the buffered POST.
   final void Function(String chunk)? onChunk;
 
   /// After Kobold FIFO `waitForIdle`: skip/pause/xml-only, never live

--- a/lib/services/llm_service.dart
+++ b/lib/services/llm_service.dart
@@ -205,6 +205,16 @@ abstract class LLMService extends ChangeNotifier {
     List<Map<String, dynamic>> tools,
   ) async => null;
 
+  /// Named realism/needs-style evals that want a JSON object. Default is
+  /// [generateWithTools]. OpenRouter overrides this to send
+  /// `response_format: json_schema` (forced `tool_choice` is ignored by
+  /// several of its providers). Nano-GPT, oMLX, LM Studio, and Kobold stay
+  /// on tools via the default.
+  Future<LlmToolResponse?> generateStructuredJson(
+    GenerationParams params,
+    List<Map<String, dynamic>> tools,
+  ) => generateWithTools(params, tools);
+
   /// Abort the current in-flight generation request (closes the HTTP client).
   void abortGeneration() {}
 

--- a/lib/services/open_router_service.dart
+++ b/lib/services/open_router_service.dart
@@ -580,7 +580,8 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
         );
       }
       if (streaming) {
-        return await streamOpenAiChatToolsWithStyleRetry(
+        String? streamErr;
+        final streamed = await streamOpenAiChatToolsWithStyleRetry(
           identity: identity,
           tools: tools,
           toolChoice: params.toolChoice,
@@ -591,7 +592,21 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
           wrapReasoning: params.reasoningEnabled,
           salvage: params.salvageReasoning,
           onChunk: params.onChunk,
+          onHttpError: (_, body) => streamErr = body,
         );
+        if (streamed != null) return streamed;
+        final rejected = streamErr;
+        if (rejected != null &&
+            !reasoningCannotDisable(modelName) &&
+            _isMandatoryReasoningRejection(rejected)) {
+          rememberMandatoryReasoning(modelName);
+          debugPrint(
+            '[RemoteAPI] $modelName cannot disable reasoning — retrying '
+            'streamed tool call with reasoning.exclude only',
+          );
+          return await generateWithTools(params, tools);
+        }
+        return null;
       }
       final response = await attachToolsWithStyleRetry(
         identity: identity,

--- a/lib/services/open_router_service.dart
+++ b/lib/services/open_router_service.dart
@@ -17,6 +17,7 @@
 // along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
 
 import 'dart:convert';
+
 import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
 import 'package:front_porch_ai/services/llm_service.dart';
@@ -24,6 +25,7 @@ import 'package:front_porch_ai/services/llm_tool_parsing.dart';
 import 'package:front_porch_ai/services/openai_completions_fallback.dart';
 import 'package:front_porch_ai/services/openai_tool_payload.dart';
 import 'package:front_porch_ai/services/openai_tool_stream.dart';
+import 'package:front_porch_ai/services/openrouter_structured_eval.dart';
 import 'package:front_porch_ai/services/reasoning_effort.dart';
 import 'package:front_porch_ai/services/tool_choice_style_probe.dart';
 import 'package:front_porch_ai/services/reasoning_stream_wrapper.dart';
@@ -398,11 +400,12 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
         // the user never agreed to. One rejection per model is the whole cost.
         if (reasoningCannotDisable(modelName)) {
           reasoning.remove('enabled');
-          // Evals need the think channel: Kimi 2.6:thinking puts the JSON
-          // there, and exclude:true leaves content as a newline after a
-          // long think (2026-08-15). Chat Continue still excludes.
-          if (params.salvageReasoning) reasoning.remove('exclude');
         }
+        // Evals need the think channel whenever the provider still thinks:
+        // exclude:true leaves content empty after a long think (Kimi 2.6,
+        // 2026-08-15; Grok/Gemini/DeepSeek on OpenRouter, 2026-09). Chat
+        // Continue still excludes.
+        if (params.salvageReasoning) reasoning.remove('exclude');
       }
       payload['reasoning'] = reasoning;
     }
@@ -456,6 +459,80 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
     'X-Title': 'Front Porch AI',
   };
 
+  /// OpenRouter named evals: `response_format` json_schema first, then tools.
+  @override
+  Future<LlmToolResponse?> generateStructuredJson(
+    GenerationParams params,
+    List<Map<String, dynamic>> tools,
+  ) async {
+    final toolName = params.toolChoice;
+    final schema = openRouterEvalJsonSchema(tools: tools, toolChoice: toolName);
+    if (!isOpenRouterApiUrl(_apiUrl) || schema == null || toolName == null) {
+      return generateWithTools(params, tools);
+    }
+    if (!isReady) return null;
+    final client = httpClientFactory?.call() ?? http.Client();
+    _activeClients.add(client);
+    try {
+      final payload = applyOpenRouterStructuredEvalRouting(
+        _chatPayload(
+          GenerationParams(
+            prompt: params.prompt,
+            maxLength: params.maxLength,
+            temperature: params.temperature,
+            topP: params.topP,
+            repeatPenalty: 1.0,
+            reasoningEnabled: false,
+            salvageReasoning: true,
+            stopSequences: params.stopSequences ?? const [],
+            toolChoice: toolName,
+            backendIdentity: params.backendIdentity,
+          ),
+          stream: false,
+        ),
+        jsonSchema: schema,
+        mandatoryReasoning: reasoningCannotDisable(modelName),
+      );
+      final response = await client.post(
+        Uri.parse('$_apiUrl/chat/completions'),
+        headers: _chatHeaders,
+        body: jsonEncode(payload),
+      );
+      if (response.statusCode == 429 || response.statusCode >= 500) {
+        throw LlmToolTransportException(
+          'structured eval HTTP ${response.statusCode} '
+          '(server busy/unavailable)',
+        );
+      }
+      if (response.statusCode != 200) {
+        debugPrint(
+          '[RemoteAPI] Structured eval rejected '
+          '(HTTP ${response.statusCode}) — falling back to tools',
+        );
+        return await generateWithTools(params, tools);
+      }
+      final parsed = parseOpenAiToolResponse(response.body);
+      if (parsed != null && parsed.calls.isNotEmpty) return parsed;
+      final fromSchema = toolResponseFromStructuredEvalContent(
+        content: parsed?.text,
+        reasoning: parsed?.reasoning,
+        toolName: toolName,
+      );
+      if (fromSchema != null) return fromSchema;
+      debugPrint(
+        '[RemoteAPI] Structured eval returned unusable JSON — '
+        'falling back to tools',
+      );
+      return await generateWithTools(params, tools);
+    } catch (e) {
+      debugPrint('[RemoteAPI] Structured eval transport failure: $e');
+      rethrow;
+    } finally {
+      _activeClients.remove(client);
+      client.close();
+    }
+  }
+
   /// OpenAI tools: null = unusable; throw = transport failure.
   @override
   Future<LlmToolResponse?> generateWithTools(
@@ -489,12 +566,14 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
           ? '$backendName|$_modelName|'
           : params.backendIdentity;
       final payload = _chatPayload(params, stream: false);
-      final host = Uri.tryParse(_apiUrl)?.host.toLowerCase();
-      if (host == 'openrouter.ai' || host?.endsWith('.openrouter.ai') == true) {
+      if (isOpenRouterApiUrl(_apiUrl)) {
         payload
           ..remove('repetition_penalty')
           ..remove('min_p')
           ..remove('top_k')
+          // `reasoning` + `require_parameters` only routes to thinking
+          // endpoints — the same class that ignores forced tool_choice.
+          ..remove('reasoning')
           ..['provider'] = {'require_parameters': true};
       }
       final response = await attachToolsWithStyleRetry(

--- a/lib/services/open_router_service.dart
+++ b/lib/services/open_router_service.dart
@@ -460,7 +460,6 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
   };
 
   /// OpenRouter named evals: `response_format` json_schema first, then tools.
-  @override
   Future<LlmToolResponse?> generateStructuredJson(
     GenerationParams params,
     List<Map<String, dynamic>> tools,

--- a/lib/services/open_router_service.dart
+++ b/lib/services/open_router_service.dart
@@ -27,7 +27,6 @@ import 'package:front_porch_ai/services/openai_tool_payload.dart';
 import 'package:front_porch_ai/services/openai_tool_stream.dart';
 import 'package:front_porch_ai/services/openrouter_structured_eval.dart';
 import 'package:front_porch_ai/services/reasoning_effort.dart';
-import 'package:front_porch_ai/services/tool_choice_style_probe.dart';
 import 'package:front_porch_ai/services/reasoning_stream_wrapper.dart';
 import 'package:front_porch_ai/services/remote_model_info.dart';
 import 'package:front_porch_ai/services/remote_reachability.dart';
@@ -473,6 +472,7 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
     final client = httpClientFactory?.call() ?? http.Client();
     _activeClients.add(client);
     try {
+      final streaming = params.onChunk != null;
       final payload = applyOpenRouterStructuredEvalRouting(
         _chatPayload(
           GenerationParams(
@@ -486,12 +486,38 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
             stopSequences: params.stopSequences ?? const [],
             toolChoice: toolName,
             backendIdentity: params.backendIdentity,
+            onChunk: params.onChunk,
           ),
-          stream: false,
+          stream: streaming,
         ),
         jsonSchema: schema,
         mandatoryReasoning: reasoningCannotDisable(modelName),
       );
+      if (streaming) {
+        final streamed = await streamOpenAiChatTools(
+          uri: Uri.parse('$_apiUrl/chat/completions'),
+          headers: _chatHeaders,
+          payload: payload,
+          client: client,
+          wrapReasoning: false,
+          salvage: true,
+          onChunk: params.onChunk,
+        );
+        if (streamed != null) {
+          if (streamed.calls.isNotEmpty) return streamed;
+          final fromSchema = toolResponseFromStructuredEvalContent(
+            content: streamed.text,
+            reasoning: streamed.reasoning,
+            toolName: toolName,
+          );
+          if (fromSchema != null) return fromSchema;
+        }
+        debugPrint(
+          '[RemoteAPI] Structured eval stream unusable — '
+          'falling back to tools',
+        );
+        return await generateWithTools(params, tools);
+      }
       final response = await client.post(
         Uri.parse('$_apiUrl/chat/completions'),
         headers: _chatHeaders,
@@ -542,38 +568,30 @@ class OpenRouterService extends LLMService implements LlmApiEndpoint {
     final client = httpClientFactory?.call() ?? http.Client();
     _activeClients.add(client);
     try {
-      if (params.onChunk != null) {
-        final payload = _chatPayload(params, stream: true);
-        attachTools(
+      final identity = params.backendIdentity.isEmpty
+          ? '$backendName|$_modelName|'
+          : params.backendIdentity;
+      final streaming = params.onChunk != null;
+      var payload = _chatPayload(params, stream: streaming);
+      if (isOpenRouterApiUrl(_apiUrl)) {
+        payload = applyOpenRouterToolRouting(
           payload,
+          mandatoryReasoning: reasoningCannotDisable(modelName),
+        );
+      }
+      if (streaming) {
+        return await streamOpenAiChatToolsWithStyleRetry(
+          identity: identity,
           tools: tools,
           toolChoice: params.toolChoice,
-          stream: true,
-          style: ToolChoiceStyle.auto,
-        );
-        return await streamOpenAiChatTools(
+          basePayload: payload,
           uri: Uri.parse('$_apiUrl/chat/completions'),
           headers: _chatHeaders,
-          payload: payload,
           client: client,
           wrapReasoning: params.reasoningEnabled,
           salvage: params.salvageReasoning,
           onChunk: params.onChunk,
         );
-      }
-      final identity = params.backendIdentity.isEmpty
-          ? '$backendName|$_modelName|'
-          : params.backendIdentity;
-      final payload = _chatPayload(params, stream: false);
-      if (isOpenRouterApiUrl(_apiUrl)) {
-        payload
-          ..remove('repetition_penalty')
-          ..remove('min_p')
-          ..remove('top_k')
-          // `reasoning` + `require_parameters` only routes to thinking
-          // endpoints — the same class that ignores forced tool_choice.
-          ..remove('reasoning')
-          ..['provider'] = {'require_parameters': true};
       }
       final response = await attachToolsWithStyleRetry(
         identity: identity,

--- a/lib/services/openai_tool_payload.dart
+++ b/lib/services/openai_tool_payload.dart
@@ -61,6 +61,10 @@ Map<String, dynamic> attachTools(
 
 final _toolChoiceBody = RegExp(r'tool[_ ]?choice', caseSensitive: false);
 
+/// A 400 whose body mentions `tool_choice` — step named → required → auto.
+bool isToolChoiceStyleRejection(int statusCode, String body) =>
+    statusCode == 400 && _toolChoiceBody.hasMatch(body);
+
 /// POST [basePayload] with tools attached, stepping named → required → auto
 /// on a 400 whose body mentions `tool_choice`. Returns the last
 /// [http.Response] — **never null**, even on an unrelated 400. The OpenRouter
@@ -96,14 +100,16 @@ Future<http.Response> attachToolsWithStyleRetry({
 
   var response = await once(style);
   if (toolChoice == null || toolChoice.isEmpty) return response;
-  if (response.statusCode != 400) return response;
-  if (!_toolChoiceBody.hasMatch(response.body)) return response;
+  if (!isToolChoiceStyleRejection(response.statusCode, response.body)) {
+    return response;
+  }
 
   if (style == ToolChoiceStyle.named) {
     styleProbe.remember(identity, ToolChoiceStyle.required);
     response = await once(ToolChoiceStyle.required);
-    if (response.statusCode != 400) return response;
-    if (!_toolChoiceBody.hasMatch(response.body)) return response;
+    if (!isToolChoiceStyleRejection(response.statusCode, response.body)) {
+      return response;
+    }
     style = ToolChoiceStyle.required;
   }
   if (style == ToolChoiceStyle.required) {

--- a/lib/services/openai_tool_payload.dart
+++ b/lib/services/openai_tool_payload.dart
@@ -80,11 +80,7 @@ Future<http.Response> attachToolsWithStyleRetry({
   bool stream = false,
 }) async {
   final styleProbe = probe ?? ToolChoiceStyleProbe.instance;
-  var style = styleProbe.styleFor(identity);
-  // Journal/Growth (`toolChoice` null) always send `'auto'` — do not step.
-  if (toolChoice == null || toolChoice.isEmpty) {
-    style = ToolChoiceStyle.auto;
-  }
+  var style = styleProbe.startingStyleFor(identity, toolChoice: toolChoice);
 
   Future<http.Response> once(ToolChoiceStyle s) {
     final payload = Map<String, dynamic>.from(basePayload);
@@ -113,7 +109,8 @@ Future<http.Response> attachToolsWithStyleRetry({
     style = ToolChoiceStyle.required;
   }
   if (style == ToolChoiceStyle.required) {
-    styleProbe.remember(identity, ToolChoiceStyle.auto);
+    // One-shot for this request. Do not persist auto — that disarms
+    // the next named overlay judge on this identity.
     return once(ToolChoiceStyle.auto);
   }
   return response;

--- a/lib/services/openai_tool_stream.dart
+++ b/lib/services/openai_tool_stream.dart
@@ -22,7 +22,9 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:front_porch_ai/services/llm_service.dart';
+import 'package:front_porch_ai/services/openai_tool_payload.dart';
 import 'package:front_porch_ai/services/reasoning_stream_wrapper.dart';
+import 'package:front_porch_ai/services/tool_choice_style_probe.dart';
 
 /// Incremental OpenAI `delta.tool_calls` + reasoning/content. Pure: tests
 /// feed maps, production feeds SSE.
@@ -210,4 +212,98 @@ Future<LlmToolResponse?> streamOpenAiChatTools({
     salvage: salvage,
     onChunk: onChunk,
   );
+}
+
+/// Streaming twin of [attachToolsWithStyleRetry]: same named → required →
+/// auto step on a `tool_choice` 400. Overlay evals use this door.
+Future<LlmToolResponse?> streamOpenAiChatToolsWithStyleRetry({
+  required String identity,
+  required List<Map<String, dynamic>> tools,
+  String? toolChoice,
+  required Map<String, dynamic> basePayload,
+  required Uri uri,
+  required Map<String, String> headers,
+  required http.Client client,
+  required bool wrapReasoning,
+  bool salvage = false,
+  void Function(String chunk)? onChunk,
+  ToolChoiceStyleProbe? probe,
+}) async {
+  final styleProbe = probe ?? ToolChoiceStyleProbe.instance;
+  var style = styleProbe.styleFor(identity);
+  if (toolChoice == null || toolChoice.isEmpty) {
+    style = ToolChoiceStyle.auto;
+  }
+
+  Future<http.StreamedResponse> once(ToolChoiceStyle s) {
+    final payload = Map<String, dynamic>.from(basePayload);
+    attachTools(
+      payload,
+      tools: tools,
+      toolChoice: toolChoice,
+      stream: true,
+      style: s,
+    );
+    final request = http.Request('POST', uri);
+    request.headers.addAll(headers);
+    request.body = jsonEncode(payload);
+    return client.send(request);
+  }
+
+  Future<LlmToolResponse?> finish(http.StreamedResponse response) async {
+    if (response.statusCode == 429 || response.statusCode >= 500) {
+      throw LlmToolTransportException(
+        'tool call HTTP ${response.statusCode} (server busy/unavailable)',
+      );
+    }
+    if (response.statusCode == 200) {
+      return consumeOpenAiToolSse(
+        response.stream,
+        wrap: wrapReasoning,
+        salvage: salvage,
+        onChunk: onChunk,
+      );
+    }
+    debugPrint(
+      '[OpenAiChat] Streamed tool call rejected '
+      '(HTTP ${response.statusCode}) — falling back to text transport',
+    );
+    return null;
+  }
+
+  var response = await once(style);
+  if (toolChoice == null || toolChoice.isEmpty) return finish(response);
+  if (response.statusCode == 200 ||
+      response.statusCode == 429 ||
+      response.statusCode >= 500) {
+    return finish(response);
+  }
+  final first = await http.Response.fromStream(response);
+  if (!isToolChoiceStyleRejection(first.statusCode, first.body)) {
+    debugPrint(
+      '[OpenAiChat] Streamed tool call rejected '
+      '(HTTP ${first.statusCode}) — falling back to text transport',
+    );
+    return null;
+  }
+
+  if (style == ToolChoiceStyle.named) {
+    styleProbe.remember(identity, ToolChoiceStyle.required);
+    response = await once(ToolChoiceStyle.required);
+    if (response.statusCode != 400) return finish(response);
+    final second = await http.Response.fromStream(response);
+    if (!isToolChoiceStyleRejection(second.statusCode, second.body)) {
+      debugPrint(
+        '[OpenAiChat] Streamed tool call rejected '
+        '(HTTP ${second.statusCode}) — falling back to text transport',
+      );
+      return null;
+    }
+    style = ToolChoiceStyle.required;
+  }
+  if (style == ToolChoiceStyle.required) {
+    styleProbe.remember(identity, ToolChoiceStyle.auto);
+    return finish(await once(ToolChoiceStyle.auto));
+  }
+  return null;
 }

--- a/lib/services/openai_tool_stream.dart
+++ b/lib/services/openai_tool_stream.dart
@@ -228,12 +228,10 @@ Future<LlmToolResponse?> streamOpenAiChatToolsWithStyleRetry({
   bool salvage = false,
   void Function(String chunk)? onChunk,
   ToolChoiceStyleProbe? probe,
+  void Function(int status, String body)? onHttpError,
 }) async {
   final styleProbe = probe ?? ToolChoiceStyleProbe.instance;
-  var style = styleProbe.styleFor(identity);
-  if (toolChoice == null || toolChoice.isEmpty) {
-    style = ToolChoiceStyle.auto;
-  }
+  var style = styleProbe.startingStyleFor(identity, toolChoice: toolChoice);
 
   Future<http.StreamedResponse> once(ToolChoiceStyle s) {
     final payload = Map<String, dynamic>.from(basePayload);
@@ -264,9 +262,11 @@ Future<LlmToolResponse?> streamOpenAiChatToolsWithStyleRetry({
         onChunk: onChunk,
       );
     }
+    final buffered = await http.Response.fromStream(response);
+    onHttpError?.call(buffered.statusCode, buffered.body);
     debugPrint(
       '[OpenAiChat] Streamed tool call rejected '
-      '(HTTP ${response.statusCode}) — falling back to text transport',
+      '(HTTP ${buffered.statusCode}) — falling back to text transport',
     );
     return null;
   }
@@ -280,6 +280,7 @@ Future<LlmToolResponse?> streamOpenAiChatToolsWithStyleRetry({
   }
   final first = await http.Response.fromStream(response);
   if (!isToolChoiceStyleRejection(first.statusCode, first.body)) {
+    onHttpError?.call(first.statusCode, first.body);
     debugPrint(
       '[OpenAiChat] Streamed tool call rejected '
       '(HTTP ${first.statusCode}) — falling back to text transport',
@@ -293,6 +294,7 @@ Future<LlmToolResponse?> streamOpenAiChatToolsWithStyleRetry({
     if (response.statusCode != 400) return finish(response);
     final second = await http.Response.fromStream(response);
     if (!isToolChoiceStyleRejection(second.statusCode, second.body)) {
+      onHttpError?.call(second.statusCode, second.body);
       debugPrint(
         '[OpenAiChat] Streamed tool call rejected '
         '(HTTP ${second.statusCode}) — falling back to text transport',
@@ -302,7 +304,7 @@ Future<LlmToolResponse?> streamOpenAiChatToolsWithStyleRetry({
     style = ToolChoiceStyle.required;
   }
   if (style == ToolChoiceStyle.required) {
-    styleProbe.remember(identity, ToolChoiceStyle.auto);
+    // One-shot for this request. Do not persist auto.
     return finish(await once(ToolChoiceStyle.auto));
   }
   return null;

--- a/lib/services/openrouter_structured_eval.dart
+++ b/lib/services/openrouter_structured_eval.dart
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This file is part of Front Porch AI.
+//
+// Front Porch AI is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Front Porch AI is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:front_porch_ai/services/chat/eval_json_merge.dart';
+import 'package:front_porch_ai/services/llm_service.dart';
+import 'package:front_porch_ai/services/reasoning_effort.dart';
+
+/// True when [apiUrl] is OpenRouter's public API, not Nano-GPT / oMLX /
+/// LM Studio / a LAN OpenAI-compatible host.
+bool isOpenRouterApiUrl(String apiUrl) {
+  final host = Uri.tryParse(apiUrl.trim())?.host.toLowerCase();
+  return host == 'openrouter.ai' || (host?.endsWith('.openrouter.ai') ?? false);
+}
+
+/// Floor for OpenRouter `response_format` evals. Forced-tool judges used
+/// 512 tokens; thinking endpoints that still honor the schema spend that
+/// budget on the think and return empty `content`.
+const int kOpenRouterStructuredEvalMinTokens = 4000;
+
+/// Build the OpenRouter `json_schema` object from the named eval tool.
+///
+/// Strict mode wants every property listed in `required` plus
+/// `additionalProperties: false`. Journal/Growth (`toolChoice` empty) return
+/// null so they stay on real `tools`.
+Map<String, dynamic>? openRouterEvalJsonSchema({
+  required List<Map<String, dynamic>> tools,
+  required String? toolChoice,
+}) {
+  if (toolChoice == null || toolChoice.isEmpty) return null;
+  for (final tool in tools) {
+    final function = tool['function'];
+    if (function is! Map) continue;
+    if (function['name']?.toString() != toolChoice) continue;
+    final parameters = function['parameters'];
+    if (parameters is! Map) return null;
+    final rawProps = parameters['properties'];
+    if (rawProps is! Map || rawProps.isEmpty) return null;
+    final properties = <String, dynamic>{
+      for (final entry in rawProps.entries) entry.key.toString(): entry.value,
+    };
+    return {
+      'name': toolChoice,
+      'strict': true,
+      'schema': {
+        'type': 'object',
+        'properties': properties,
+        'required': properties.keys.toList(),
+        'additionalProperties': false,
+      },
+    };
+  }
+  return null;
+}
+
+/// OpenRouter structured-output routing for a named eval.
+///
+/// Drops tools, sampler extras, and the `reasoning` object so
+/// `require_parameters` only has to match `response_format` — the #230 combo
+/// of tools + tool_choice + reasoning + require_parameters routed to thinking
+/// endpoints that ignore forced tools, or 404'd entirely.
+Map<String, dynamic> applyOpenRouterStructuredEvalRouting(
+  Map<String, dynamic> payload, {
+  required Map<String, dynamic> jsonSchema,
+  required bool mandatoryReasoning,
+}) {
+  final next = Map<String, dynamic>.from(payload)
+    ..remove('repetition_penalty')
+    ..remove('min_p')
+    ..remove('top_k')
+    ..remove('tools')
+    ..remove('tool_choice')
+    ..remove('reasoning')
+    ..['response_format'] = {'type': 'json_schema', 'json_schema': jsonSchema}
+    ..['provider'] = {'require_parameters': true};
+  var floor = kOpenRouterStructuredEvalMinTokens;
+  if (mandatoryReasoning) {
+    floor += kMandatoryReasoningThinkHeadroomTokens;
+  }
+  final current = next['max_tokens'];
+  if (current is! num || current < floor) next['max_tokens'] = floor;
+  return next;
+}
+
+/// Turn schema `content` / `reasoning` into the same [LlmToolResponse] a
+/// successful `tool_calls` reply would have produced.
+LlmToolResponse? toolResponseFromStructuredEvalContent({
+  required String? content,
+  required String? reasoning,
+  required String toolName,
+}) {
+  for (final raw in [content, reasoning]) {
+    if (raw == null || raw.trim().isEmpty) continue;
+    final decoded = parseEvalJsonObject(raw);
+    if (decoded == null || decoded.isEmpty) continue;
+    return LlmToolResponse(
+      calls: [LlmToolCall(name: toolName, arguments: decoded)],
+      text: raw,
+      reasoning: reasoning ?? '',
+    );
+  }
+  return null;
+}

--- a/lib/services/openrouter_structured_eval.dart
+++ b/lib/services/openrouter_structured_eval.dart
@@ -27,10 +27,40 @@ bool isOpenRouterApiUrl(String apiUrl) {
   return host == 'openrouter.ai' || (host?.endsWith('.openrouter.ai') ?? false);
 }
 
-/// Floor for OpenRouter `response_format` evals. Forced-tool judges used
-/// 512 tokens; thinking endpoints that still honor the schema spend that
-/// budget on the think and return empty `content`.
+/// Floor for OpenRouter structured / tool evals. Scalar judges used 512
+/// tokens; thinking endpoints spend that budget on the think and return
+/// empty `content` / `tool_calls` with `finish_reason=length`.
 const int kOpenRouterStructuredEvalMinTokens = 4000;
+
+/// Strip OR-hostile optional samplers, require the params on THIS request,
+/// and raise a 512-token judge budget so a think cannot starve the call.
+Map<String, dynamic> applyOpenRouterToolRouting(
+  Map<String, dynamic> payload, {
+  required bool mandatoryReasoning,
+}) {
+  final next = Map<String, dynamic>.from(payload)
+    ..remove('repetition_penalty')
+    ..remove('min_p')
+    ..remove('top_k')
+    // `reasoning` + `require_parameters` only routes to thinking
+    // endpoints — the same class that ignores forced tool_choice.
+    ..remove('reasoning')
+    ..['provider'] = {'require_parameters': true};
+  _floorOpenRouterEvalTokens(next, mandatoryReasoning: mandatoryReasoning);
+  return next;
+}
+
+void _floorOpenRouterEvalTokens(
+  Map<String, dynamic> payload, {
+  required bool mandatoryReasoning,
+}) {
+  var floor = kOpenRouterStructuredEvalMinTokens;
+  if (mandatoryReasoning) {
+    floor += kMandatoryReasoningThinkHeadroomTokens;
+  }
+  final current = payload['max_tokens'];
+  if (current is! num || current < floor) payload['max_tokens'] = floor;
+}
 
 /// Build the OpenRouter `json_schema` object from the named eval tool.
 ///
@@ -87,12 +117,7 @@ Map<String, dynamic> applyOpenRouterStructuredEvalRouting(
     ..remove('reasoning')
     ..['response_format'] = {'type': 'json_schema', 'json_schema': jsonSchema}
     ..['provider'] = {'require_parameters': true};
-  var floor = kOpenRouterStructuredEvalMinTokens;
-  if (mandatoryReasoning) {
-    floor += kMandatoryReasoningThinkHeadroomTokens;
-  }
-  final current = next['max_tokens'];
-  if (current is! num || current < floor) next['max_tokens'] = floor;
+  _floorOpenRouterEvalTokens(next, mandatoryReasoning: mandatoryReasoning);
   return next;
 }
 

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -59,6 +59,7 @@ export 'chat_service.dart';
 export 'mcp/mcp.dart';
 export 'backend_manager.dart';
 export 'open_router_service.dart';
+export 'openrouter_structured_eval.dart';
 export 'remote_reachability.dart';
 export 'reasoning_effort.dart';
 export 'reasoning_effort_probe.dart';

--- a/lib/services/tool_choice_style_probe.dart
+++ b/lib/services/tool_choice_style_probe.dart
@@ -23,7 +23,15 @@ import 'package:flutter/foundation.dart';
 /// Named function objects are the default (scalar evals always want exactly
 /// one function). Some older OpenAI-compatible hosts only accept
 /// `'auto' | 'none' | 'required'` and 400 a named object. The style probe
-/// remembers that 400 so the next call starts on the style that worked.
+/// remembers a named-object 400 as [ToolChoiceStyle.required] so the next
+/// call starts there.
+///
+/// [auto] is **never durable**. Persisting it after a `tool_choice` 400
+/// disarmed the next overlay `report_*` judge (the #230 streaming-auto bug
+/// coming back after one bad provider 400). A step to `auto` is one-shot
+/// for this request only. Journal/Growth pass an empty toolChoice and
+/// always send `auto` without reading or writing this map.
+///
 /// It is NEVER a capability verdict — a host that 400s named choice may
 /// still speak tools.
 enum ToolChoiceStyle { named, required, auto }
@@ -41,11 +49,33 @@ class ToolChoiceStyleProbe {
 
   final Map<String, ToolChoiceStyle> _style = {};
 
-  ToolChoiceStyle styleFor(String identity) =>
-      _style[identity] ?? ToolChoiceStyle.named;
+  /// Named evals start at [ToolChoiceStyle.named] or a remembered
+  /// [ToolChoiceStyle.required]. Leftover [ToolChoiceStyle.auto] in the
+  /// map is treated as unset so a prior one-shot cannot disarm later
+  /// `report_*` calls.
+  ToolChoiceStyle styleFor(String identity) {
+    final remembered = _style[identity];
+    if (remembered == null || remembered == ToolChoiceStyle.auto) {
+      return ToolChoiceStyle.named;
+    }
+    return remembered;
+  }
 
-  void remember(String identity, ToolChoiceStyle style) =>
-      _style[identity] = style;
+  /// Journal/Growth (`toolChoice` empty) always send auto. Named
+  /// functions use [styleFor] and never start at auto.
+  ToolChoiceStyle startingStyleFor(String identity, {String? toolChoice}) {
+    if (toolChoice == null || toolChoice.isEmpty) {
+      return ToolChoiceStyle.auto;
+    }
+    return styleFor(identity);
+  }
+
+  /// Persist named / required only. Auto is ignored so a one-shot
+  /// step-down cannot stick across overlay judges.
+  void remember(String identity, ToolChoiceStyle style) {
+    if (style == ToolChoiceStyle.auto) return;
+    _style[identity] = style;
+  }
 
   void reset(String identity) => _style.remove(identity);
 

--- a/test/services/chat/structured_eval_reasoning_salvage_test.dart
+++ b/test/services/chat/structured_eval_reasoning_salvage_test.dart
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// fireStructuredEval must salvage JSON that landed in reasoning_content
+// (empty tool_calls + think-channel JSON) instead of treating that as a
+// failed tools attempt. #230 only looked at message.content.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:front_porch_ai/services/chat/chat.dart';
+import 'package:front_porch_ai/services/services.dart'
+    show LlmToolCall, LlmToolResponse;
+
+void main() {
+  const id = 'Remote API|https://openrouter.ai/api/v1|grok|';
+
+  Future<({String? result, int textCalls})> run({
+    required Future<LlmToolResponse?> Function() toolAnswer,
+  }) async {
+    var textCalls = 0;
+    final result = await fireStructuredEval(
+      probe: ToolTransportProbe(),
+      backendIdentity: id,
+      debugLabel: 'relationship',
+      tools: kRelationshipEvalTools,
+      toolChoice: kRelationshipTool,
+      buildPrompt: ({required bool toolsMode}) => toolsMode ? 'TOOLS' : 'TEXT',
+      callToText: (resp) =>
+          realismToolCallToJson(kRelationshipTool, resp.calls),
+      fireToolEval: (_, _) => toolAnswer(),
+      fireTextEval: (prompt, {onChunk}) async {
+        textCalls++;
+        return 'TEXT-RESULT';
+      },
+    );
+    return (result: result, textCalls: textCalls);
+  }
+
+  test(
+    'JSON only in reasoning_content is salvaged, no text fallback',
+    () async {
+      final r = await run(
+        toolAnswer: () async => const LlmToolResponse(
+          calls: [],
+          text: '',
+          reasoning: '{"relationship_delta":2,"trust_delta":1}',
+        ),
+      );
+      expect(r.result, '{"relationship_delta":2,"trust_delta":1}');
+      expect(r.textCalls, 0);
+    },
+  );
+
+  test('JSON wrapped in think-prose is sliced before schema check', () async {
+    final r = await run(
+      toolAnswer: () async => const LlmToolResponse(
+        calls: [],
+        text: 'thinking...\n{"relationship_delta":8,"trust_delta":0}\n',
+      ),
+    );
+    expect(r.result, '{"relationship_delta":8,"trust_delta":0}');
+    expect(r.textCalls, 0);
+  });
+
+  test('real tool calls still win over leftover reasoning JSON', () async {
+    final r = await run(
+      toolAnswer: () async => const LlmToolResponse(
+        calls: [
+          LlmToolCall(
+            name: kRelationshipTool,
+            arguments: {'relationship_delta': 1, 'trust_delta': 1},
+          ),
+        ],
+        text: '',
+        reasoning: '{"relationship_delta":99,"trust_delta":99}',
+      ),
+    );
+    expect(r.result, '{"relationship_delta":1,"trust_delta":1}');
+    expect(r.textCalls, 0);
+  });
+}

--- a/test/services/open_router_structured_eval_test.dart
+++ b/test/services/open_router_structured_eval_test.dart
@@ -470,7 +470,8 @@ void main() {
         final wiring = File(
           'lib/services/chat/chat_service_wiring_evals.dart',
         ).readAsStringSync();
-        expect(wiring, contains('generateStructuredJson('));
+        expect(wiring, contains('service is OpenRouterService'));
+        expect(wiring, contains('generateStructuredJson'));
         expect(wiring, contains('onChunk: named ? null : spec.onChunk'));
         expect(
           wiring,

--- a/test/services/open_router_structured_eval_test.dart
+++ b/test/services/open_router_structured_eval_test.dart
@@ -1,0 +1,482 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// OpenRouter named evals must use response_format json_schema. PR #230
+// kept forced tool_choice; providers that advertise tools still return
+// empty tool_calls after a think, and require_parameters + reasoning
+// routed only to those endpoints.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:front_porch_ai/services/chat/realism_tools.dart';
+import 'package:front_porch_ai/services/llm_service.dart';
+import 'package:front_porch_ai/services/open_router_service.dart';
+import 'package:front_porch_ai/services/openrouter_structured_eval.dart';
+import 'package:front_porch_ai/services/reasoning_effort.dart';
+
+void main() {
+  setUpAll(() => HttpOverrides.global = null);
+
+  group('isOpenRouterApiUrl', () {
+    test('only the public OpenRouter hosts match', () {
+      expect(isOpenRouterApiUrl('https://openrouter.ai/api/v1'), isTrue);
+      expect(isOpenRouterApiUrl('https://eu.openrouter.ai/api/v1'), isTrue);
+      expect(isOpenRouterApiUrl('https://nano-gpt.com/api/v1'), isFalse);
+      expect(isOpenRouterApiUrl('http://127.0.0.1:1234/v1'), isFalse);
+      expect(isOpenRouterApiUrl('http://192.168.1.10:8080/v1'), isFalse);
+    });
+  });
+
+  group('openRouterEvalJsonSchema', () {
+    test('named judge uses that tool even when the list has three', () {
+      final schema = openRouterEvalJsonSchema(
+        tools: kJudgeEvalTools,
+        toolChoice: kRelationshipTool,
+      )!;
+      expect(schema['name'], kRelationshipTool);
+      expect(schema['strict'], isTrue);
+      final body = schema['schema'] as Map;
+      expect(body['additionalProperties'], isFalse);
+      expect(
+        body['required'],
+        containsAll(['relationship_delta', 'trust_delta']),
+      );
+      expect((body['properties'] as Map).containsKey('emotion'), isFalse);
+    });
+
+    test('Journal-style auto choice does not mint a schema', () {
+      expect(
+        openRouterEvalJsonSchema(
+          tools: kRelationshipEvalTools,
+          toolChoice: null,
+        ),
+        isNull,
+      );
+      expect(
+        openRouterEvalJsonSchema(tools: kRelationshipEvalTools, toolChoice: ''),
+        isNull,
+      );
+    });
+  });
+
+  group('applyOpenRouterStructuredEvalRouting', () {
+    test(
+      'drops tools, samplers, and reasoning so only json_schema is required',
+      () {
+        final payload = applyOpenRouterStructuredEvalRouting(
+          {
+            'max_tokens': 512,
+            'tools': const [],
+            'tool_choice': {
+              'type': 'function',
+              'function': {'name': kRelationshipTool},
+            },
+            'reasoning': {'enabled': false, 'exclude': true},
+            'repetition_penalty': 1.15,
+            'min_p': 0.05,
+            'top_k': 40,
+          },
+          jsonSchema: openRouterEvalJsonSchema(
+            tools: kRelationshipEvalTools,
+            toolChoice: kRelationshipTool,
+          )!,
+          mandatoryReasoning: false,
+        );
+        expect(payload.containsKey('tools'), isFalse);
+        expect(payload.containsKey('tool_choice'), isFalse);
+        expect(payload.containsKey('reasoning'), isFalse);
+        expect(payload.containsKey('min_p'), isFalse);
+        expect(payload['provider'], {'require_parameters': true});
+        expect(payload['max_tokens'], kOpenRouterStructuredEvalMinTokens);
+        expect(payload['response_format']['type'], 'json_schema');
+      },
+    );
+
+    test('mandatory thinking adds the same headroom the text evals use', () {
+      final payload = applyOpenRouterStructuredEvalRouting(
+        {'max_tokens': 512},
+        jsonSchema: const {
+          'name': 'n',
+          'strict': true,
+          'schema': {'type': 'object'},
+        },
+        mandatoryReasoning: true,
+      );
+      expect(
+        payload['max_tokens'],
+        kOpenRouterStructuredEvalMinTokens +
+            kMandatoryReasoningThinkHeadroomTokens,
+      );
+    });
+  });
+
+  group('toolResponseFromStructuredEvalContent', () {
+    test('empty content with JSON in reasoning is a usable call', () {
+      final resp = toolResponseFromStructuredEvalContent(
+        content: '\n',
+        reasoning:
+            'draft 99 then {"relationship_delta":3,"trust_delta":1,"bond_reason":"none","trust_reason":"none"}',
+        toolName: kRelationshipTool,
+      )!;
+      expect(resp.calls.single.name, kRelationshipTool);
+      expect(resp.calls.single.arguments['relationship_delta'], 3);
+      expect(resp.calls.single.arguments['trust_delta'], 1);
+    });
+
+    test('prose without a JSON object is not a success', () {
+      expect(
+        toolResponseFromStructuredEvalContent(
+          content: 'bond went up a bit',
+          reasoning: '',
+          toolName: kRelationshipTool,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('OpenRouterService.generateStructuredJson', () {
+    const tools = [
+      {
+        'type': 'function',
+        'function': {
+          'name': 'report_relationship',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'relationship_delta': {'type': 'integer'},
+              'trust_delta': {'type': 'integer'},
+            },
+            'required': ['relationship_delta', 'trust_delta'],
+          },
+        },
+      },
+    ];
+
+    const named = GenerationParams(
+      prompt: 'score this',
+      maxLength: 512,
+      temperature: 0.1,
+      toolChoice: 'report_relationship',
+      salvageReasoning: true,
+      reasoningEnabled: false,
+      reasoningMaxTokens: 0,
+    );
+
+    test('OpenRouter named eval sends json_schema, not tools', () async {
+      Map<String, dynamic>? payload;
+      var toolPosts = 0;
+      final remote = OpenRouterService(
+        apiUrl: 'https://openrouter.ai/api/v1',
+        apiKey: 'test-key',
+        modelName: 'x-ai/grok-4',
+      );
+      remote.httpClientFactory = () => MockClient((request) async {
+        payload = jsonDecode(request.body) as Map<String, dynamic>;
+        if (payload!.containsKey('tools')) toolPosts++;
+        return http.Response(
+          jsonEncode({
+            'choices': [
+              {
+                'message': {
+                  'content':
+                      '{"relationship_delta":4,"trust_delta":2,"bond_reason":"none","trust_reason":"none"}',
+                },
+              },
+            ],
+          }),
+          200,
+        );
+      });
+
+      final resp = await remote.generateStructuredJson(named, tools);
+      expect(toolPosts, 0);
+      expect(payload!['response_format']['type'], 'json_schema');
+      expect(payload!.containsKey('tools'), isFalse);
+      expect(payload!.containsKey('reasoning'), isFalse);
+      expect(payload!['provider'], {'require_parameters': true});
+      expect(payload!['max_tokens'], kOpenRouterStructuredEvalMinTokens);
+      expect(resp!.calls.single.arguments['relationship_delta'], 4);
+    });
+
+    test(
+      'Nano-GPT named eval keeps tools and never sends json_schema',
+      () async {
+        Map<String, dynamic>? payload;
+        final remote = OpenRouterService(
+          apiUrl: 'https://nano-gpt.com/api/v1',
+          apiKey: 'test-key',
+          modelName: 'same-model',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          payload = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({
+              'choices': [
+                {
+                  'message': {
+                    'tool_calls': [
+                      {
+                        'function': {
+                          'name': 'report_relationship',
+                          'arguments':
+                              '{"relationship_delta":1,"trust_delta":0}',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        });
+
+        final resp = await remote.generateStructuredJson(named, tools);
+        expect(payload!.containsKey('response_format'), isFalse);
+        expect(payload!['tools'], isNotEmpty);
+        expect(payload!.containsKey('provider'), isFalse);
+        expect(resp!.calls.single.arguments['relationship_delta'], 1);
+      },
+    );
+
+    test('OpenRouter Journal (no named tool) stays on tools', () async {
+      Map<String, dynamic>? payload;
+      final remote = OpenRouterService(
+        apiUrl: 'https://openrouter.ai/api/v1',
+        apiKey: 'test-key',
+        modelName: 'openai/gpt-4o',
+      );
+      remote.httpClientFactory = () => MockClient((request) async {
+        payload = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          jsonEncode({
+            'choices': [
+              {
+                'message': {
+                  'tool_calls': [
+                    {
+                      'function': {
+                        'name': 'add_memory',
+                        'arguments': '{"content":"rain"}',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          200,
+        );
+      });
+
+      await remote.generateStructuredJson(
+        const GenerationParams(prompt: 'journal', maxLength: 4000),
+        tools,
+      );
+      expect(payload!.containsKey('response_format'), isFalse);
+      expect(payload!['tools'], isNotEmpty);
+      expect(payload!['provider'], {'require_parameters': true});
+    });
+
+    test('schema 404 falls through to the existing tools door', () async {
+      final payloads = <Map<String, dynamic>>[];
+      final remote = OpenRouterService(
+        apiUrl: 'https://openrouter.ai/api/v1',
+        apiKey: 'test-key',
+        modelName: 'fallback-model',
+      );
+      remote.httpClientFactory = () => MockClient((request) async {
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        payloads.add(body);
+        if (body.containsKey('response_format')) {
+          return http.Response(
+            jsonEncode({
+              'error': {
+                'message': 'No endpoints found that support structured outputs',
+              },
+            }),
+            404,
+          );
+        }
+        return http.Response(
+          jsonEncode({
+            'choices': [
+              {
+                'message': {
+                  'tool_calls': [
+                    {
+                      'function': {
+                        'name': 'report_relationship',
+                        'arguments': '{"relationship_delta":5,"trust_delta":1}',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          200,
+        );
+      });
+
+      final resp = await remote.generateStructuredJson(named, tools);
+      expect(payloads, hasLength(2));
+      expect(payloads.first.containsKey('response_format'), isTrue);
+      expect(payloads.last['tools'], isNotEmpty);
+      expect(resp!.calls.single.arguments['relationship_delta'], 5);
+    });
+
+    test(
+      'Nano-GPT tools door still sends the thinking-off reasoning block',
+      () async {
+        Map<String, dynamic>? payload;
+        final remote = OpenRouterService(
+          apiUrl: 'https://nano-gpt.com/api/v1',
+          apiKey: 'test-key',
+          modelName: 'same-model',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          payload = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({
+              'choices': [
+                {
+                  'message': {
+                    'tool_calls': [
+                      {
+                        'function': {
+                          'name': 'report_relationship',
+                          'arguments': '{}',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        });
+
+        await remote.generateWithTools(
+          const GenerationParams(
+            prompt: 'score',
+            maxLength: 512,
+            reasoningEnabled: false,
+            reasoningMaxTokens: 0,
+            salvageReasoning: true,
+            toolChoice: 'report_relationship',
+          ),
+          tools,
+        );
+        expect(payload!['reasoning'], {'enabled': false, 'max_tokens': 0});
+        expect(payload!.containsKey('provider'), isFalse);
+        expect(payload!['tools'], isNotEmpty);
+      },
+    );
+
+    test(
+      'OpenRouter tools door strips reasoning so require_parameters can route',
+      () async {
+        Map<String, dynamic>? payload;
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'x-ai/grok-4',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          payload = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({
+              'choices': [
+                {
+                  'message': {
+                    'tool_calls': [
+                      {
+                        'function': {
+                          'name': 'report_relationship',
+                          'arguments': '{}',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        });
+
+        await remote.generateWithTools(
+          const GenerationParams(
+            prompt: 'journal or fallback',
+            maxLength: 4000,
+            reasoningEnabled: false,
+            reasoningMaxTokens: 0,
+            salvageReasoning: true,
+          ),
+          tools,
+        );
+        expect(payload!.containsKey('reasoning'), isFalse);
+        expect(payload!['provider'], {'require_parameters': true});
+        expect(payload!['tools'], isNotEmpty);
+      },
+    );
+
+    test(
+      'empty content + reasoning JSON does not take the tools fallback',
+      () async {
+        var posts = 0;
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'thinker',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          posts++;
+          return http.Response(
+            jsonEncode({
+              'choices': [
+                {
+                  'finish_reason': 'length',
+                  'message': {
+                    'content': '',
+                    'reasoning': '{"relationship_delta":7,"trust_delta":0}',
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        });
+
+        final resp = await remote.generateStructuredJson(named, tools);
+        expect(posts, 1);
+        expect(resp!.calls.single.arguments['relationship_delta'], 7);
+      },
+    );
+  });
+
+  group('eval door call site', () {
+    test(
+      'named judges go through generateStructuredJson on a buffered POST',
+      () {
+        final wiring = File(
+          'lib/services/chat/chat_service_wiring_evals.dart',
+        ).readAsStringSync();
+        expect(wiring, contains('generateStructuredJson('));
+        expect(wiring, contains('onChunk: named ? null : spec.onChunk'));
+        expect(
+          wiring,
+          contains('named || spec.maxLength > kScalarToolMaxTokens'),
+        );
+      },
+    );
+  });
+}

--- a/test/services/open_router_structured_eval_test.dart
+++ b/test/services/open_router_structured_eval_test.dart
@@ -18,6 +18,7 @@ import 'package:front_porch_ai/services/llm_service.dart';
 import 'package:front_porch_ai/services/open_router_service.dart';
 import 'package:front_porch_ai/services/openrouter_structured_eval.dart';
 import 'package:front_porch_ai/services/reasoning_effort.dart';
+import 'package:front_porch_ai/services/tool_choice_style_probe.dart';
 
 void main() {
   setUpAll(() => HttpOverrides.global = null);
@@ -107,6 +108,35 @@ void main() {
         },
         mandatoryReasoning: true,
       );
+      expect(
+        payload['max_tokens'],
+        kOpenRouterStructuredEvalMinTokens +
+            kMandatoryReasoningThinkHeadroomTokens,
+      );
+    });
+  });
+
+  group('applyOpenRouterToolRouting', () {
+    test('forces require_parameters and strips OR-hostile samplers', () {
+      final payload = applyOpenRouterToolRouting({
+        'max_tokens': 512,
+        'repetition_penalty': 1.15,
+        'min_p': 0.05,
+        'top_k': 40,
+        'reasoning': {'enabled': false},
+      }, mandatoryReasoning: false);
+      expect(payload.containsKey('min_p'), isFalse);
+      expect(payload.containsKey('top_k'), isFalse);
+      expect(payload.containsKey('repetition_penalty'), isFalse);
+      expect(payload.containsKey('reasoning'), isFalse);
+      expect(payload['provider'], {'require_parameters': true});
+      expect(payload['max_tokens'], kOpenRouterStructuredEvalMinTokens);
+    });
+
+    test('thinking models get the same headroom as text evals', () {
+      final payload = applyOpenRouterToolRouting({
+        'max_tokens': 512,
+      }, mandatoryReasoning: true);
       expect(
         payload['max_tokens'],
         kOpenRouterStructuredEvalMinTokens +
@@ -463,21 +493,171 @@ void main() {
     );
   });
 
-  group('eval door call site', () {
+  group('OpenRouterService.generateWithTools streaming', () {
+    const tools = [
+      {
+        'type': 'function',
+        'function': {
+          'name': 'report_relationship',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'relationship_delta': {'type': 'integer'},
+            },
+          },
+        },
+      },
+    ];
+
+    const sseOk =
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"report_relationship","arguments":"{}"}}]}}]}\n\n'
+        'data: [DONE]\n';
+
+    GenerationParams liveJudge() => GenerationParams(
+      prompt: 'score this',
+      maxLength: 512,
+      temperature: 0.1,
+      minP: 0.05,
+      topK: 40,
+      repeatPenalty: 1.15,
+      toolChoice: 'report_relationship',
+      salvageReasoning: true,
+      reasoningEnabled: false,
+      reasoningMaxTokens: 0,
+      onChunk: (_) {},
+    );
+
+    setUp(ToolChoiceStyleProbe.instance.resetForTest);
+
     test(
-      'named judges go through generateStructuredJson on a buffered POST',
-      () {
-        final wiring = File(
-          'lib/services/chat/chat_service_wiring_evals.dart',
-        ).readAsStringSync();
-        expect(wiring, contains('service is OpenRouterService'));
-        expect(wiring, contains('generateStructuredJson'));
-        expect(wiring, contains('onChunk: named ? null : spec.onChunk'));
-        expect(
-          wiring,
-          contains('named || spec.maxLength > kScalarToolMaxTokens'),
+      'OpenRouter stream forces the named tool, require_parameters, and no OR-hostile samplers',
+      () async {
+        Map<String, dynamic>? payload;
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'x-ai/grok-4',
         );
+        remote.httpClientFactory = () => MockClient((request) async {
+          payload = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(sseOk, 200);
+        });
+
+        await remote.generateWithTools(liveJudge(), tools);
+        expect(payload!['stream'], isTrue);
+        expect(payload!['tool_choice'], {
+          'type': 'function',
+          'function': {'name': 'report_relationship'},
+        });
+        expect(payload!['provider'], {'require_parameters': true});
+        expect(payload!.containsKey('min_p'), isFalse);
+        expect(payload!.containsKey('top_k'), isFalse);
+        expect(payload!.containsKey('repetition_penalty'), isFalse);
+        expect(payload!['max_tokens'], kOpenRouterStructuredEvalMinTokens);
       },
     );
+
+    test(
+      'Nano-GPT stream keeps named tool_choice, samplers, and no provider pin',
+      () async {
+        Map<String, dynamic>? payload;
+        final remote = OpenRouterService(
+          apiUrl: 'https://nano-gpt.com/api/v1',
+          apiKey: 'test-key',
+          modelName: 'same-model',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          payload = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(sseOk, 200);
+        });
+
+        await remote.generateWithTools(liveJudge(), tools);
+        expect(payload!['stream'], isTrue);
+        expect(payload!['tool_choice'], {
+          'type': 'function',
+          'function': {'name': 'report_relationship'},
+        });
+        expect(payload!.containsKey('provider'), isFalse);
+        expect(payload!['min_p'], 0.05);
+        expect(payload!['top_k'], 40);
+        expect(payload!['repetition_penalty'], 1.15);
+        expect(payload!['max_tokens'], 512);
+      },
+    );
+
+    test(
+      'OpenRouter stream raises the think-headroom floor on mandatory models',
+      () async {
+        kMandatoryReasoningModels.add('stream-think-test');
+        addTearDown(
+          () => kMandatoryReasoningModels.remove('stream-think-test'),
+        );
+        Map<String, dynamic>? payload;
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'stream-think-test',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          payload = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(sseOk, 200);
+        });
+
+        await remote.generateWithTools(liveJudge(), tools);
+        expect(
+          payload!['max_tokens'],
+          kOpenRouterStructuredEvalMinTokens +
+              kMandatoryReasoningThinkHeadroomTokens,
+        );
+        expect(payload!['provider'], {'require_parameters': true});
+        expect(payload!['tool_choice'], {
+          'type': 'function',
+          'function': {'name': 'report_relationship'},
+        });
+      },
+    );
+
+    test(
+      'OpenRouter json_schema stream stays off tools when overlay onChunk is set',
+      () async {
+        Map<String, dynamic>? payload;
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'x-ai/grok-4',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          payload = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            'data: {"choices":[{"delta":{"content":"{\\"relationship_delta\\":2,\\"trust_delta\\":1}"}}]}\n\n'
+            'data: [DONE]\n',
+            200,
+          );
+        });
+
+        final resp = await remote.generateStructuredJson(liveJudge(), tools);
+        expect(payload!['stream'], isTrue);
+        expect(payload!['response_format']['type'], 'json_schema');
+        expect(payload!.containsKey('tools'), isFalse);
+        expect(payload!['provider'], {'require_parameters': true});
+        expect(resp!.calls.single.arguments['relationship_delta'], 2);
+      },
+    );
+  });
+
+  group('eval door call site', () {
+    test('named judges go through generateStructuredJson and keep overlay', () {
+      final wiring = File(
+        'lib/services/chat/chat_service_wiring_evals.dart',
+      ).readAsStringSync();
+      expect(wiring, contains('service is OpenRouterService'));
+      expect(wiring, contains('generateStructuredJson'));
+      expect(wiring, contains('onChunk: spec.onChunk'));
+      expect(wiring, isNot(contains('onChunk: named ? null')));
+      expect(
+        wiring,
+        contains('named || spec.maxLength > kScalarToolMaxTokens'),
+      );
+    });
   });
 }

--- a/test/services/open_router_structured_eval_test.dart
+++ b/test/services/open_router_structured_eval_test.dart
@@ -645,6 +645,161 @@ void main() {
     );
   });
 
+  group('tool_choice probe must not persist auto for named judges', () {
+    const tools = [
+      {
+        'type': 'function',
+        'function': {
+          'name': 'report_relationship',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'relationship_delta': {'type': 'integer'},
+            },
+          },
+        },
+      },
+    ];
+
+    const sseOk =
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"report_relationship","arguments":"{}"}}]}}]}\n\n'
+        'data: [DONE]\n';
+
+    const toolChoice400 = '{"error":{"message":"unknown tool_choice value"}}';
+    const postOk =
+        '{"choices":[{"message":{"tool_calls":[{"function":{"name":"report_relationship","arguments":"{}"}}]}}]}';
+
+    final isForcedToolChoice = anyOf('required', {
+      'type': 'function',
+      'function': {'name': 'report_relationship'},
+    });
+
+    GenerationParams named({void Function(String)? onChunk}) =>
+        GenerationParams(
+          prompt: 'score this',
+          maxLength: 512,
+          minP: 0.05,
+          topK: 40,
+          repeatPenalty: 1.15,
+          toolChoice: 'report_relationship',
+          salvageReasoning: true,
+          reasoningEnabled: false,
+          reasoningMaxTokens: 0,
+          onChunk: onChunk,
+        );
+
+    http.Response replyFor(Map<String, dynamic> body, {required bool stream}) {
+      if (body['tool_choice'] == 'auto') {
+        return http.Response(stream ? sseOk : postOk, 200);
+      }
+      return http.Response(toolChoice400, 400);
+    }
+
+    setUp(ToolChoiceStyleProbe.instance.resetForTest);
+
+    test(
+      'stream tool_choice 400 does not leave the next overlay judge on auto',
+      () async {
+        final payloads = <Map<String, dynamic>>[];
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'sticky-auto-stream',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          payloads.add(body);
+          return replyFor(body, stream: true);
+        });
+
+        await remote.generateWithTools(named(onChunk: (_) {}), tools);
+        final afterFirst = payloads.length;
+        expect(payloads.any((p) => p['tool_choice'] == 'auto'), isTrue);
+
+        await remote.generateWithTools(named(onChunk: (_) {}), tools);
+        expect(payloads.length, greaterThan(afterFirst));
+        expect(payloads[afterFirst]['tool_choice'], isForcedToolChoice);
+        expect(payloads[afterFirst]['tool_choice'], isNot('auto'));
+        expect(payloads[afterFirst]['provider'], {'require_parameters': true});
+      },
+    );
+
+    test(
+      'POST tool_choice 400 does not leave the next named judge on auto',
+      () async {
+        final payloads = <Map<String, dynamic>>[];
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'sticky-auto-post',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          payloads.add(body);
+          return replyFor(body, stream: false);
+        });
+
+        await remote.generateWithTools(named(), tools);
+        final afterFirst = payloads.length;
+        expect(payloads.any((p) => p['tool_choice'] == 'auto'), isTrue);
+
+        await remote.generateWithTools(named(), tools);
+        expect(payloads[afterFirst]['tool_choice'], isForcedToolChoice);
+        expect(payloads[afterFirst]['tool_choice'], isNot('auto'));
+      },
+    );
+
+    test(
+      'Journal empty toolChoice still sends auto after a named step-down',
+      () async {
+        final payloads = <Map<String, dynamic>>[];
+        final remote = OpenRouterService(
+          apiUrl: 'https://openrouter.ai/api/v1',
+          apiKey: 'test-key',
+          modelName: 'sticky-auto-journal',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          payloads.add(body);
+          return replyFor(body, stream: true);
+        });
+
+        await remote.generateWithTools(named(onChunk: (_) {}), tools);
+        payloads.clear();
+        await remote.generateWithTools(
+          GenerationParams(prompt: 'journal', maxLength: 4000, onChunk: (_) {}),
+          tools,
+        );
+        expect(payloads, isNotEmpty);
+        expect(payloads.first['tool_choice'], 'auto');
+      },
+    );
+
+    test(
+      'Nano stream after a tool_choice 400 still has no provider pin',
+      () async {
+        final payloads = <Map<String, dynamic>>[];
+        final remote = OpenRouterService(
+          apiUrl: 'https://nano-gpt.com/api/v1',
+          apiKey: 'test-key',
+          modelName: 'sticky-auto-nano',
+        );
+        remote.httpClientFactory = () => MockClient((request) async {
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          payloads.add(body);
+          return replyFor(body, stream: true);
+        });
+
+        await remote.generateWithTools(named(onChunk: (_) {}), tools);
+        final afterFirst = payloads.length;
+        await remote.generateWithTools(named(onChunk: (_) {}), tools);
+        expect(payloads[afterFirst]['tool_choice'], isForcedToolChoice);
+        expect(payloads[afterFirst].containsKey('provider'), isFalse);
+        expect(payloads[afterFirst]['min_p'], 0.05);
+      },
+    );
+  });
+
   group('eval door call site', () {
     test('named judges go through generateStructuredJson and keep overlay', () {
       final wiring = File(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #230 only patched the **non-streaming** OpenRouter tools door. Live realism/Needs judges pass overlay `onChunk`, so `OpenRouterService.generateWithTools` took the streaming branch and:

1. Hardcoded `tool_choice: "auto"` (named `report_*` force ignored — the model can skip)
2. Did not set `provider: { require_parameters: true }`
3. Did not strip `repetition_penalty` / `min_p` / `top_k` on openrouter.ai
4. Kept `max_tokens` at `kScalarToolMaxTokens` (512). Reasoning counts against that budget → `finish_reason=length`, empty `tool_calls`

Nano-GPT / local MLX still worked: same client, no OpenRouter provider roulette.

Hostile follow-up: style retry then **remembered `auto`** after a `tool_choice` 400. The next overlay `report_*` judge on that identity started at auto — #230 again after one bad provider 400. Tests hid it with `resetForTest`.

## What landed

**(1) Unify streaming + non-streaming OR tool requests** — yes

- Both doors use named → required → auto via `attachToolsWithStyleRetry` / `streamOpenAiChatToolsWithStyleRetry`
- `applyOpenRouterToolRouting` on openrouter.ai: `require_parameters: true`, strip hostile samplers + `reasoning`
- Nano / oMLX / LM Studio: no `provider` pin, samplers kept; stream path now forces the named tool too
- Overlay `onChunk` is forwarded again

**(2) Raise judge `max_tokens` / think headroom** — yes

- OpenRouter tool + json_schema evals floor at 4000
- Mandatory-reasoning models add the same 16000 think headroom text evals already add

**(3) `response_format: json_schema` for structured judges** — yes

- Named evals on openrouter.ai still prefer strict `json_schema`
- 404 / unusable JSON falls back to the unified tools door
- Journal / Growth stay on real tools

**(4) Sticky-auto probe** — yes (`c010620d`)

- Probe persists only named/required. Auto is one-shot for this request.
- `styleFor` treats leftover auto as unset so a prior step-down cannot disarm later `report_*` calls
- Stream door also retries mandatory-reasoning 400s (same as POST)

## Tests

`test/services/open_router_structured_eval_test.dart` (does not edit existing tests):

Proven red (`Actual: 'auto'`) then green:

- `stream tool_choice 400 does not leave the next overlay judge on auto`
- `POST tool_choice 400 does not leave the next named judge on auto`
- `Nano stream after a tool_choice 400 still has no provider pin`

Also green both before and after (Journal pin):

- `Journal empty toolChoice still sends auto after a named step-down`

## Poke

1. OpenRouter + a thinking model, Realism + Needs on, send one line in a 1:1 chat.
2. Bond/trust chips should move; Needs should show more than ambient decay.
3. Same turn on Nano-GPT or local MLX — judges still work.
4. If a provider 400s `tool_choice` once, the **next** turn’s relationship/Needs judge must still move (must not stick on auto).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5d4b043-88cd-4bd1-8088-33b2abe25641?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5d4b043-88cd-4bd1-8088-33b2abe25641&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

