### PR TITLE
feat(waifu): live tool chips and a real Tasks checklist

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -76,8 +76,8 @@
 - **Why:** Bug Hunter on #238. `_runTool` had no try/finally around
   settle, so a mid-dispatch throw left a forever-pending spinner.
 - **What:** try/catch/finally after the pending push. Throw → `_reject`
-  fail chip + `_emit`. Leftover pending flips to fail/stopped.
-- **Commit:** (this tip)
+  fail chip + `_emit`.   Leftover pending flips to fail/stopped.
+- **Commit:** 566f190f
 
 ## 2026-09-08 — fix(waifu): “updated the todos” is a todo-receipt claim
 - **Why:** GO wording includes updated todos, not only “todo list”.

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -75,7 +75,7 @@
 ## 2026-09-08 — fix(waifu): “updated the todos” is a todo-receipt claim
 - **Why:** GO wording includes updated todos, not only “todo list”.
 - **What:** Detector treats update/write + todos as a claim. Pin added.
-- **Commit:** (this tip)
+- **Commit:** 58efdd32
 
 ## 2026-09-08 — feat(waifu): todo-claim turn contract (no chip, no receipt)
 - **Why:** Kimi/thinking can narrate todowrite or “I marked it complete”

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,3 +1,17 @@
+## 2026-09-08 — rebase(waifu): #238 onto Rawhide after #237
+- **Why:** #237 squash-merged as `94ff43bd` (and #239 as `cd9bcd49`).
+  PR #238 was CONFLICTING / DIRTY vs Rawhide.
+- **What:** Rebased `cursor/waifu-tool-todo-chrome-e885` onto that tip.
+  Kept #238 live chips + Tasks checklist + todo-claim contract
+  (pending→done, try/finally settle, spoken todo / “updated the todos”
+  / todowrite needs a successful todowrite chip) and Rawhide #239
+  send-order (user+running before await) + plan panel
+  `unawaited(_run)` / try/finally + Epic B verify-after-mutate.
+  Conflict files: `waifu_harness.dart`, `waifu_harness_turn.dart`,
+  `waifu_turn_contract.dart`. Changelog / Rawhide.md auto-merged.
+  No existing Guard tests were edited in the rebase.
+- **Commit:** (this tip)
+
 ## 2026-09-08 — rebase(waifu): Epic B onto #239 Rawhide tip
 - **Why:** #239 squash-merged as `cd9bcd49`. PR #237 could not
   squash-merge (DIRTY / CONFLICTING).

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -82,7 +82,7 @@
   use checkbox / play / checked+strikethrough; content is the label.
   Write() semantics unchanged. Soft spoken-vs-todowrite honesty skipped
   (would fight turn-contract pins).
-- **Commit:** (this tip)
+- **Commit:** 5b68bef5
 
 ## 2026-09-08 — test(waifu): Plan MCP chips are not .single after receipt
 - **Why:** Unit CI red on cb441af6. Plan receipt always-on retries after a

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -72,6 +72,13 @@
   same). `waifuSyncTodosOntoPlan` rolls blocked done todos back to the
   plan step status; todowrite chip output re-reads after that.
 - **Commit:** a48672d9
+## 2026-09-08 — fix(waifu): pending tool chip settles if dispatch throws
+- **Why:** Bug Hunter on #238. `_runTool` had no try/finally around
+  settle, so a mid-dispatch throw left a forever-pending spinner.
+- **What:** try/catch/finally after the pending push. Throw → `_reject`
+  fail chip + `_emit`. Leftover pending flips to fail/stopped.
+- **Commit:** (this tip)
+
 ## 2026-09-08 — fix(waifu): “updated the todos” is a todo-receipt claim
 - **Why:** GO wording includes updated todos, not only “todo list”.
 - **What:** Detector treats update/write + todos as a claim. Pin added.

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -79,7 +79,7 @@
   claims a todo completion / todowrite / todo-list update, with no
   successful todowrite chip this turn, soft-retries then failTodoWrite.
   Thoughts are not receipts. Live chips + Tasks chrome unchanged.
-- **Commit:** (this tip)
+- **Commit:** d1ad6c3b
 
 ## 2026-09-08 — polish(waifu): live tool chips + Tasks checklist chrome
 - **Why:** Tool work was a black box (`_runTool` only `_pushChip` after

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -72,6 +72,11 @@
   same). `waifuSyncTodosOntoPlan` rolls blocked done todos back to the
   plan step status; todowrite chip output re-reads after that.
 - **Commit:** a48672d9
+## 2026-09-08 — fix(waifu): “updated the todos” is a todo-receipt claim
+- **Why:** GO wording includes updated todos, not only “todo list”.
+- **What:** Detector treats update/write + todos as a claim. Pin added.
+- **Commit:** (this tip)
+
 ## 2026-09-08 — feat(waifu): todo-claim turn contract (no chip, no receipt)
 - **Why:** Kimi/thinking can narrate todowrite or “I marked it complete”
   without a real tool call. write() is fine; the spoken line was a lie.

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -10,7 +10,7 @@
   Conflict files: `waifu_harness.dart`, `waifu_harness_turn.dart`,
   `waifu_turn_contract.dart`. Changelog / Rawhide.md auto-merged.
   No existing Guard tests were edited in the rebase.
-- **Commit:** (this tip)
+- **Commit:** 9cc3264e
 
 ## 2026-09-08 — rebase(waifu): Epic B onto #239 Rawhide tip
 - **Why:** #239 squash-merged as `cd9bcd49`. PR #237 could not

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -72,6 +72,17 @@
   same). `waifuSyncTodosOntoPlan` rolls blocked done todos back to the
   plan step status; todowrite chip output re-reads after that.
 - **Commit:** a48672d9
+## 2026-09-08 — polish(waifu): live tool chips + Tasks checklist chrome
+- **Why:** Tool work was a black box (`_runTool` only `_pushChip` after
+  await). Tasks accordion dumped raw `status: content` as a wall of
+  primary text. A hallucinated `todowrite` did not change data — the
+  write path is fine; chrome was the bug.
+- **What:** Pending chip at `noteAttempt` + `_emit`, update-in-place to
+  ok/fail (abort → stopped). Tool log spinner while pending. Tasks rows
+  use checkbox / play / checked+strikethrough; content is the label.
+  Write() semantics unchanged. Soft spoken-vs-todowrite honesty skipped
+  (would fight turn-contract pins).
+- **Commit:** (this tip)
 
 ## 2026-09-08 — test(waifu): Plan MCP chips are not .single after receipt
 - **Why:** Unit CI red on cb441af6. Plan receipt always-on retries after a

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -72,6 +72,15 @@
   same). `waifuSyncTodosOntoPlan` rolls blocked done todos back to the
   plan step status; todowrite chip output re-reads after that.
 - **Commit:** a48672d9
+## 2026-09-08 — feat(waifu): todo-claim turn contract (no chip, no receipt)
+- **Why:** Kimi/thinking can narrate todowrite or “I marked it complete”
+  without a real tool call. write() is fine; the spoken line was a lie.
+- **What:** Same family as sass-without-patches. Visible speech that
+  claims a todo completion / todowrite / todo-list update, with no
+  successful todowrite chip this turn, soft-retries then failTodoWrite.
+  Thoughts are not receipts. Live chips + Tasks chrome unchanged.
+- **Commit:** (this tip)
+
 ## 2026-09-08 — polish(waifu): live tool chips + Tasks checklist chrome
 - **Why:** Tool work was a black box (`_runTool` only `_pushChip` after
   await). Tasks accordion dumped raw `status: content` as a wall of

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -14,13 +14,12 @@ Last shipped nightly: `rawhide.20260906.7059c91`. Everything below is unreleased
 - 📊 **Waifu Coder remembers how full the context bar is** — sit back down on a porch and the meter shows the last turn, not a fake 0. Old sessions still start at 0 until you send once.
 
 - 🎨 **Waifu Coder themes actually paint the bubbles** — Sakura (and the rest) plus your custom bubble/text colors apply in the session instead of writing to the last 1:1 chat and leaving the coworker in default colors.
+
 - 🔧 **Waifu Coder tools show while they run** — a live chip appears the moment they pick up a tool, then flips to ok or fail when it finishes. You are not staring at a black box until the receipt lands.
 
 - 🧾 **A spoken “todo done” needs a real todowrite** — if they claim they marked a todo complete or ran `todowrite` but no successful chip landed this turn, the turn contract asks again, then stops instead of pretending. Thinking out loud does not count.
 
 - ✅ **Waifu Coder Tasks look like a real list** — pending is an empty box, the current job is a play mark, done is checked and struck through. No more raw `in_progress: …` sludge in the sidebar.
-
-- 📋 **Waifu Coder Plan mode now writes a real plan** — in Plan they explore, then save a markdown plan under `.waifu/plans/` (a turn without that file is not done). The Plan panel sits on the main stage: Accept → Build (steps become todos, and they mark those steps on the plan as they go), Revise, or Discard. A draft plan will not silently flip to Build — Accept it, or stay in Plan. They still cannot change project source until you accept. Personality stays the card’s.
 
 - ♾️ **Waifu Coder is not capped at chat Max Output Tokens** — a turn can fill the rest of the context window so a tool call is not cut off mid-file. Chat still uses that slider. One reply bubble per send: reads/writes/bash stack as a quiet log above it, then she speaks. The old 20-step cutoff is a runaway fuse at 80.
 

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -14,6 +14,11 @@ Last shipped nightly: `rawhide.20260906.7059c91`. Everything below is unreleased
 - 📊 **Waifu Coder remembers how full the context bar is** — sit back down on a porch and the meter shows the last turn, not a fake 0. Old sessions still start at 0 until you send once.
 
 - 🎨 **Waifu Coder themes actually paint the bubbles** — Sakura (and the rest) plus your custom bubble/text colors apply in the session instead of writing to the last 1:1 chat and leaving the coworker in default colors.
+- 🔧 **Waifu Coder tools show while they run** — a live chip appears the moment they pick up a tool, then flips to ok or fail when it finishes. You are not staring at a black box until the receipt lands.
+
+- ✅ **Waifu Coder Tasks look like a real list** — pending is an empty box, the current job is a play mark, done is checked and struck through. No more raw `in_progress: …` sludge in the sidebar.
+
+- 📋 **Waifu Coder Plan mode now writes a real plan** — in Plan they explore, then save a markdown plan under `.waifu/plans/` (a turn without that file is not done). The Plan panel sits on the main stage: Accept → Build (steps become todos, and they mark those steps on the plan as they go), Revise, or Discard. A draft plan will not silently flip to Build — Accept it, or stay in Plan. They still cannot change project source until you accept. Personality stays the card’s.
 
 - ♾️ **Waifu Coder is not capped at chat Max Output Tokens** — a turn can fill the rest of the context window so a tool call is not cut off mid-file. Chat still uses that slider. One reply bubble per send: reads/writes/bash stack as a quiet log above it, then she speaks. The old 20-step cutoff is a runaway fuse at 80.
 

--- a/docs/Rawhide.md
+++ b/docs/Rawhide.md
@@ -16,6 +16,8 @@ Last shipped nightly: `rawhide.20260906.7059c91`. Everything below is unreleased
 - 🎨 **Waifu Coder themes actually paint the bubbles** — Sakura (and the rest) plus your custom bubble/text colors apply in the session instead of writing to the last 1:1 chat and leaving the coworker in default colors.
 - 🔧 **Waifu Coder tools show while they run** — a live chip appears the moment they pick up a tool, then flips to ok or fail when it finishes. You are not staring at a black box until the receipt lands.
 
+- 🧾 **A spoken “todo done” needs a real todowrite** — if they claim they marked a todo complete or ran `todowrite` but no successful chip landed this turn, the turn contract asks again, then stops instead of pretending. Thinking out loud does not count.
+
 - ✅ **Waifu Coder Tasks look like a real list** — pending is an empty box, the current job is a play mark, done is checked and struck through. No more raw `in_progress: …` sludge in the sidebar.
 
 - 📋 **Waifu Coder Plan mode now writes a real plan** — in Plan they explore, then save a markdown plan under `.waifu/plans/` (a turn without that file is not done). The Plan panel sits on the main stage: Accept → Build (steps become todos, and they mark those steps on the plan as they go), Revise, or Discard. A draft plan will not silently flip to Build — Accept it, or stay in Plan. They still cannot change project source until you accept. Personality stays the card’s.

--- a/lib/services/waifu/waifu_harness.dart
+++ b/lib/services/waifu/waifu_harness.dart
@@ -235,6 +235,14 @@ class WaifuHarness {
     final kind = waifuSubagentKind(name, work);
     final canon = canonicalWaifuToolName(name);
     _turn.noteAttempt(canon);
+    _pushChip(
+      WaifuToolChip(
+        name: canon,
+        detail: waifuChipDetail(canon, work),
+        ok: false,
+        pending: true,
+      ),
+    );
     final mcpMutates = waifuMcpMutationHint(name, mcpTools);
     if (exploreOnly &&
         !kWaifuExploreToolNames.contains(canon) &&
@@ -276,7 +284,10 @@ class WaifuHarness {
           doomLoop: doom,
         ),
       );
-      if (_aborted) return;
+      if (_aborted) {
+        _pushChip(WaifuToolChip(name: canon, detail: 'stopped', ok: false));
+        return;
+      }
       if (decision == WaifuAskDecision.deny) {
         permissions.record(name: name, args: work);
         _reject(canon, 'denied by user');
@@ -292,7 +303,10 @@ class WaifuHarness {
       kWaifuToolWorkflow => await _runWorkflow(work),
       _ => await _dispatch(canon, work, original: name),
     };
-    if (_aborted) return;
+    if (_aborted) {
+      _pushChip(WaifuToolChip(name: canon, detail: 'stopped', ok: false));
+      return;
+    }
     if (result.write != null) {
       session.lastWrite = result.write;
       undoLog.push(result.write!);
@@ -339,11 +353,22 @@ class WaifuHarness {
 
   void _pushChip(WaifuToolChip chip) {
     final last = _liveAssistant();
+    final chips = List<WaifuToolChip>.from(last.chips);
+    if (!chip.pending) {
+      final i = chips.lastIndexWhere((c) => c.pending && c.name == chip.name);
+      if (i >= 0) {
+        chips[i] = chip;
+      } else {
+        chips.add(chip);
+      }
+    } else {
+      chips.add(chip);
+    }
     _writeLive(
       WaifuMessage(
         isUser: false,
         text: last.text,
-        chips: [...last.chips, chip],
+        chips: chips,
         reasoning: last.reasoning,
         thinkingStartMs: last.thinkingStartMs,
         thinkingMs: last.thinkingMs,

--- a/lib/services/waifu/waifu_harness.dart
+++ b/lib/services/waifu/waifu_harness.dart
@@ -243,85 +243,91 @@ class WaifuHarness {
         pending: true,
       ),
     );
-    final mcpMutates = waifuMcpMutationHint(name, mcpTools);
-    if (exploreOnly &&
-        !kWaifuExploreToolNames.contains(canon) &&
-        canon != kWaifuToolTask) {
-      permissions.record(name: name, args: work);
-      _reject(canon, 'explore is read-only');
-      return;
-    }
-    final block = permissions.hardBlock(
-      name: name,
-      args: work,
-      mutates: mcpMutates,
-    );
-    if (block != null) {
-      permissions.record(name: name, args: work);
-      _reject(canon, block);
-      return;
-    }
-    if (session.mode == WaifuMode.plan &&
-        (canon == kWaifuToolWrite ||
-            canon == kWaifuToolEdit ||
-            canon == kWaifuToolApplyPatch)) {
-      final path = waifuToolPathArg(work);
-      final live = path == null
-          ? 'plan mode can only write under $kWaifuPlansDir'
-          : await waifuPlanWriteLiveBlock(session.folderRoot, path);
-      if (live != null) {
+    try {
+      final mcpMutates = waifuMcpMutationHint(name, mcpTools);
+      if (exploreOnly &&
+          !kWaifuExploreToolNames.contains(canon) &&
+          canon != kWaifuToolTask) {
         permissions.record(name: name, args: work);
-        _reject(canon, live);
+        _reject(canon, 'explore is read-only');
         return;
       }
-    }
-    if (permissions.needsAsk(name: name, args: work, mutates: mcpMutates)) {
-      final doom = permissions.isDoom(name, work);
-      final decision = await _decide(
-        WaifuAskRequest(
-          toolName: canon,
-          summary: permissions.summaryFor(name, work),
-          doomLoop: doom,
-        ),
+      final block = permissions.hardBlock(
+        name: name,
+        args: work,
+        mutates: mcpMutates,
       );
+      if (block != null) {
+        permissions.record(name: name, args: work);
+        _reject(canon, block);
+        return;
+      }
+      if (session.mode == WaifuMode.plan &&
+          (canon == kWaifuToolWrite ||
+              canon == kWaifuToolEdit ||
+              canon == kWaifuToolApplyPatch)) {
+        final path = waifuToolPathArg(work);
+        final live = path == null
+            ? 'plan mode can only write under $kWaifuPlansDir'
+            : await waifuPlanWriteLiveBlock(session.folderRoot, path);
+        if (live != null) {
+          permissions.record(name: name, args: work);
+          _reject(canon, live);
+          return;
+        }
+      }
+      if (permissions.needsAsk(name: name, args: work, mutates: mcpMutates)) {
+        final doom = permissions.isDoom(name, work);
+        final decision = await _decide(
+          WaifuAskRequest(
+            toolName: canon,
+            summary: permissions.summaryFor(name, work),
+            doomLoop: doom,
+          ),
+        );
+        if (_aborted) {
+          _pushChip(WaifuToolChip(name: canon, detail: 'stopped', ok: false));
+          return;
+        }
+        if (decision == WaifuAskDecision.deny) {
+          permissions.record(name: name, args: work);
+          _reject(canon, 'denied by user');
+          return;
+        }
+        if (decision == WaifuAskDecision.allowAlways) {
+          permissions.allowAlways();
+        }
+      }
+      permissions.record(name: name, args: work);
+      final result = switch (canon) {
+        kWaifuToolTask => await _runTask(kind, work),
+        kWaifuToolWorkflow => await _runWorkflow(work),
+        _ => await _dispatch(canon, work, original: name),
+      };
       if (_aborted) {
         _pushChip(WaifuToolChip(name: canon, detail: 'stopped', ok: false));
         return;
       }
-      if (decision == WaifuAskDecision.deny) {
-        permissions.record(name: name, args: work);
-        _reject(canon, 'denied by user');
-        return;
+      if (result.write != null) {
+        session.lastWrite = result.write;
+        undoLog.push(result.write!);
       }
-      if (decision == WaifuAskDecision.allowAlways) {
-        permissions.allowAlways();
+      if (session.mode == WaifuMode.plan &&
+          result.write != null &&
+          waifuRelativeIsPlanArtifact(result.write!.relativePath)) {
+        session.activePlanPath = result.write!.relativePath;
       }
+      _turn.noteResult(canon, result, session.lastWrite, args: work);
+      final detail = result.ok
+          ? waifuChipDetail(canon, work)
+          : waifuClipChipError(result.output);
+      _pushChip(WaifuToolChip(name: canon, detail: detail, ok: result.ok));
+      _trace += '\n[$canon] ${result.ok ? 'ok' : 'error'}\n${result.output}\n';
+    } catch (e) {
+      _reject(canon, '$e');
+    } finally {
+      _settlePendingChip(canon);
     }
-    permissions.record(name: name, args: work);
-    final result = switch (canon) {
-      kWaifuToolTask => await _runTask(kind, work),
-      kWaifuToolWorkflow => await _runWorkflow(work),
-      _ => await _dispatch(canon, work, original: name),
-    };
-    if (_aborted) {
-      _pushChip(WaifuToolChip(name: canon, detail: 'stopped', ok: false));
-      return;
-    }
-    if (result.write != null) {
-      session.lastWrite = result.write;
-      undoLog.push(result.write!);
-    }
-    if (session.mode == WaifuMode.plan &&
-        result.write != null &&
-        waifuRelativeIsPlanArtifact(result.write!.relativePath)) {
-      session.activePlanPath = result.write!.relativePath;
-    }
-    _turn.noteResult(canon, result, session.lastWrite, args: work);
-    final detail = result.ok
-        ? waifuChipDetail(canon, work)
-        : waifuClipChipError(result.output);
-    _pushChip(WaifuToolChip(name: canon, detail: detail, ok: result.ok));
-    _trace += '\n[$canon] ${result.ok ? 'ok' : 'error'}\n${result.output}\n';
   }
 
   Set<String> get _mcpNames => {

--- a/lib/services/waifu/waifu_harness_turn.dart
+++ b/lib/services/waifu/waifu_harness_turn.dart
@@ -74,7 +74,7 @@ extension _WaifuHarnessTurn on WaifuHarness {
       }
 
       if (resp.calls.isEmpty) {
-        switch (_turn.decideFinal(body)) {
+        switch (_turn.decideFinal(body, chips: _liveAssistant().chips)) {
           case WaifuFinalAction.accept:
             _say(body);
             return;
@@ -90,6 +90,9 @@ extension _WaifuHarnessTurn on WaifuHarness {
           case WaifuFinalAction.retryVerify:
             _turn.requestVerify();
             continue;
+          case WaifuFinalAction.retryTodoWrite:
+            _turn.requestTodoWrite();
+            continue;
           case WaifuFinalAction.failMutation:
             _reject('turn', 'no file change landed for a code-change request');
             _say(_turn.failureLine(body));
@@ -103,6 +106,10 @@ extension _WaifuHarnessTurn on WaifuHarness {
             return;
           case WaifuFinalAction.failVerify:
             _reject('turn', 'no verify after a project file change');
+            _say(_turn.failureLine(body));
+            return;
+          case WaifuFinalAction.failTodoWrite:
+            _reject('turn', 'no todowrite receipt for a claimed todo update');
             _say(_turn.failureLine(body));
             return;
         }

--- a/lib/services/waifu/waifu_harness_turn.dart
+++ b/lib/services/waifu/waifu_harness_turn.dart
@@ -129,4 +129,17 @@ extension _WaifuHarnessTurn on WaifuHarness {
     _reject('turn', 'runaway fuse stopped this turn');
     _say(_turn.failureLine(''));
   }
+
+  void _settlePendingChip(String name) {
+    if (!_liveAssistant().chips.any((c) => c.pending && c.name == name)) {
+      return;
+    }
+    _pushChip(
+      WaifuToolChip(
+        name: name,
+        detail: _aborted ? 'stopped' : 'error',
+        ok: false,
+      ),
+    );
+  }
 }

--- a/lib/services/waifu/waifu_session.dart
+++ b/lib/services/waifu/waifu_session.dart
@@ -26,11 +26,15 @@ class WaifuToolChip {
     required this.name,
     required this.detail,
     required this.ok,
+    this.pending = false,
   });
 
   final String name;
   final String detail;
   final bool ok;
+
+  /// Live attempt — [ok] is ignored until the tool settles.
+  final bool pending;
 }
 
 class WaifuWriteRecord {

--- a/lib/services/waifu/waifu_todos.dart
+++ b/lib/services/waifu/waifu_todos.dart
@@ -35,6 +35,22 @@ class WaifuTodo {
   String status;
 }
 
+/// Display kind only. [WaifuTodos.write] still stores the raw status string.
+String waifuTodoMark(String raw) {
+  switch (raw.trim().toLowerCase().replaceAll('-', '_')) {
+    case 'completed':
+    case 'complete':
+    case 'done':
+      return 'completed';
+    case 'in_progress':
+    case 'doing':
+    case 'active':
+      return 'in_progress';
+    default:
+      return 'pending';
+  }
+}
+
 class WaifuTodos {
   final items = <WaifuTodo>[];
 

--- a/lib/services/waifu/waifu_turn_contract.dart
+++ b/lib/services/waifu/waifu_turn_contract.dart
@@ -174,8 +174,8 @@ bool waifuLooksTodoReceiptClaim(String body) {
   final updated = RegExp(
     r'\b(?:updated?|wrote|replaced|rewrote|changed)\b',
   ).hasMatch(lower);
-  if (list && updated) return true;
   final todo = RegExp(r'\b(?:todos?|to-dos?)\b').hasMatch(lower);
+  if ((list || todo) && updated) return true;
   final done = RegExp(
     r'\b(?:completed?|finished|checked\s+off|marked\s+(?:as\s+)?done)\b',
   ).hasMatch(lower);

--- a/lib/services/waifu/waifu_turn_contract.dart
+++ b/lib/services/waifu/waifu_turn_contract.dart
@@ -45,6 +45,8 @@ enum WaifuFinalAction {
   failMutation,
   failSpeech,
   failVerify,
+  retryTodoWrite,
+  failTodoWrite,
 }
 
 String waifuNormalizeVerifyPath(String path) =>
@@ -165,6 +167,29 @@ bool waifuTaskRequestsFileChange(String task) {
   return changeVerb && codeTarget;
 }
 
+bool waifuLooksTodoReceiptClaim(String body) {
+  final lower = body.toLowerCase();
+  if (RegExp(r'\btodowrite\b').hasMatch(lower)) return true;
+  final list = RegExp(r'\b(?:todo|to-do|task) lists?\b').hasMatch(lower);
+  final updated = RegExp(
+    r'\b(?:updated?|wrote|replaced|rewrote|changed)\b',
+  ).hasMatch(lower);
+  if (list && updated) return true;
+  final todo = RegExp(r'\b(?:todos?|to-dos?)\b').hasMatch(lower);
+  final done = RegExp(
+    r'\b(?:completed?|finished|checked\s+off|marked\s+(?:as\s+)?done)\b',
+  ).hasMatch(lower);
+  return todo && done;
+}
+
+bool waifuTurnHasTodoWriteReceipt(Iterable<WaifuToolChip> chips) {
+  for (final chip in chips) {
+    if (chip.pending || !chip.ok) continue;
+    if (canonicalWaifuToolName(chip.name) == kWaifuToolTodoWrite) return true;
+  }
+  return false;
+}
+
 bool waifuLooksGenericCompletion(String body) {
   final normalized = body.trim().toLowerCase().replaceAll(
     RegExp(r'[.!…\s]+$'),
@@ -203,10 +228,13 @@ class WaifuTurnContract {
   bool verifyRequired = false;
   bool verified = false;
   bool successfulTool = false;
+  bool todoWriteSucceeded = false;
+  bool todoWriteRequired = false;
   bool speechOnly = false;
   int mutationCorrectionAttempts = 0;
   int speechCorrectionAttempts = 0;
   int verifyCorrectionAttempts = 0;
+  int todoCorrectionAttempts = 0;
   String rememberedSpeech = '';
   String cue = '';
 
@@ -238,6 +266,11 @@ class WaifuTurnContract {
     Map<String, dynamic>? args,
   }) {
     successfulTool = successfulTool || result.ok;
+    if (toolName == kWaifuToolTodoWrite && result.ok) {
+      todoWriteSucceeded = true;
+      todoWriteRequired = false;
+      cue = '';
+    }
     if (kWaifuReceiptMutationTools.contains(toolName) && result.write != null) {
       if (mode != WaifuMode.plan ||
           waifuRelativeIsPlanArtifact(result.write!.relativePath)) {
@@ -285,6 +318,10 @@ class WaifuTurnContract {
   void absorbChild(WaifuTurnContract child) {
     successfulTool = successfulTool || child.successfulTool;
     mutationAttempted = mutationAttempted || child.mutationAttempted;
+    if (child.todoWriteSucceeded) {
+      todoWriteSucceeded = true;
+      todoWriteRequired = false;
+    }
     if (child.mutationSucceeded) mutationSucceeded = true;
     if (child.verifyRequired) verifyRequired = true;
     if (child.mutatedPaths.isNotEmpty) {
@@ -303,7 +340,10 @@ class WaifuTurnContract {
     }
   }
 
-  WaifuFinalAction decideFinal(String body) {
+  WaifuFinalAction decideFinal(
+    String body, {
+    List<WaifuToolChip> chips = const [],
+  }) {
     final trimmed = body.trim();
     final generic = waifuLooksGenericCompletion(trimmed);
     if (mutationRequired && !mutationSucceeded && !mutationAttempted) {
@@ -330,6 +370,13 @@ class WaifuTurnContract {
                 ? WaifuFinalAction.failMutation
                 : WaifuFinalAction.failSpeech);
     }
+    final todoReceipt =
+        todoWriteSucceeded || waifuTurnHasTodoWriteReceipt(chips);
+    if (waifuLooksTodoReceiptClaim(trimmed) && !todoReceipt) {
+      return todoCorrectionAttempts < kWaifuTurnCorrectionAttempts
+          ? WaifuFinalAction.retryTodoWrite
+          : WaifuFinalAction.failTodoWrite;
+    }
     return WaifuFinalAction.accept;
   }
 
@@ -344,6 +391,17 @@ class WaifuTurnContract {
               'write, edit, or apply_patch receipt landed. Do the real change '
               'with a file tool now; personality without a patch is not '
               'completion.';
+  }
+
+  void requestTodoWrite() {
+    todoCorrectionAttempts++;
+    todoWriteRequired = true;
+    speechOnly = false;
+    cue =
+        'TURN CONTRACT: You claimed a todo update (completed, todowrite, or '
+        'the todo list), but no successful todowrite landed this turn. Call '
+        'todowrite for real, or stop claiming the list changed. Thoughts are '
+        'not a receipt.';
   }
 
   void requestSpeech() {
@@ -365,6 +423,10 @@ class WaifuTurnContract {
   }
 
   String failureLine(String body) {
+    if (todoWriteRequired && !todoWriteSucceeded) {
+      return 'I did not actually update the todo list, so I stopped instead of '
+          'pretending I did.';
+    }
     if (mutationRequired && !mutationSucceeded) {
       if (mode == WaifuMode.plan) {
         return 'I could not write a plan file under $kWaifuPlansDir, so I '

--- a/lib/ui/waifu/waifu_todo_list.dart
+++ b/lib/ui/waifu/waifu_todo_list.dart
@@ -29,40 +29,82 @@ class WaifuTodoList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (todos.items.isEmpty) return const SizedBox.shrink();
-    return Container(
+    return Padding(
       key: const Key('waifu-todos'),
-      width: double.infinity,
-      margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: AppColors.cardOf(context),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: AppColors.porchAmberOf(context).withValues(alpha: 0.35),
-        ),
-      ),
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [for (final t in todos.items) _WaifuTodoRow(todo: t)],
+      ),
+    );
+  }
+}
+
+class _WaifuTodoRow extends StatelessWidget {
+  const _WaifuTodoRow({required this.todo});
+
+  final WaifuTodo todo;
+
+  @override
+  Widget build(BuildContext context) {
+    final mark = waifuTodoMark(todo.status);
+    final amber = AppColors.porchAmberOf(context);
+    final done = mark == 'completed';
+    final doing = mark == 'in_progress';
+    final color = done
+        ? AppColors.textTertiary(context)
+        : doing
+        ? amber
+        : AppColors.textSecondary(context);
+    return Padding(
+      key: Key('waifu-todo-row-${todo.id}'),
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Todos',
-            style: TextStyle(
-              color: AppColors.porchAmberOf(context),
-              fontWeight: FontWeight.w600,
-              fontSize: 13,
-            ),
+          Padding(
+            padding: const EdgeInsets.only(top: 1),
+            child: Semantics(label: mark, child: _markIcon(mark, amber, color)),
           ),
-          const SizedBox(height: 6),
-          for (final t in todos.items)
-            Text(
-              '${t.status}: ${t.content}',
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              todo.content,
               style: TextStyle(
-                color: AppColors.textPrimary(context),
+                color: color,
                 fontSize: 13,
+                height: 1.3,
+                fontWeight: doing ? FontWeight.w600 : FontWeight.w400,
+                decoration: done ? TextDecoration.lineThrough : null,
+                decorationColor: color,
               ),
             ),
+          ),
         ],
       ),
     );
+  }
+
+  Widget _markIcon(String mark, Color amber, Color color) {
+    return switch (mark) {
+      'completed' => Icon(
+        Icons.check_box,
+        key: Key('waifu-todo-mark-${todo.id}'),
+        size: 18,
+        color: color,
+      ),
+      'in_progress' => Icon(
+        Icons.play_circle_fill,
+        key: Key('waifu-todo-mark-${todo.id}'),
+        size: 18,
+        color: amber,
+      ),
+      _ => Icon(
+        Icons.check_box_outline_blank,
+        key: Key('waifu-todo-mark-${todo.id}'),
+        size: 18,
+        color: color,
+      ),
+    };
   }
 }

--- a/lib/ui/waifu/waifu_tool_log.dart
+++ b/lib/ui/waifu/waifu_tool_log.dart
@@ -30,8 +30,6 @@ class WaifuToolLog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (chips.isEmpty) return const SizedBox.shrink();
-    final amber = AppColors.porchAmberOf(context);
-    final fail = AppColors.negativeAccentOf(context);
     return Padding(
       key: const Key('waifu-tool-log'),
       padding: const EdgeInsets.fromLTRB(16, 4, 16, 6),
@@ -42,41 +40,62 @@ class WaifuToolLog extends StatelessWidget {
             Padding(
               key: Key('waifu-tool-row-$i'),
               padding: const EdgeInsets.only(top: 2),
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.circle,
-                    size: 6,
-                    color: chips[i].ok ? amber : fail,
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    chips[i].name,
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.textSecondary(context),
-                    ),
-                  ),
-                  if (chips[i].detail.trim().isNotEmpty) ...[
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        chips[i].detail,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: AppColors.textTertiary(context),
-                        ),
-                      ),
-                    ),
-                  ],
-                ],
-              ),
+              child: _WaifuToolRow(chip: chips[i], index: i),
             ),
         ],
       ),
+    );
+  }
+}
+
+class _WaifuToolRow extends StatelessWidget {
+  const _WaifuToolRow({required this.chip, required this.index});
+
+  final WaifuToolChip chip;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final amber = AppColors.porchAmberOf(context);
+    final fail = AppColors.negativeAccentOf(context);
+    final pending = chip.pending;
+    final mark = pending
+        ? SizedBox(
+            key: Key('waifu-tool-pending-$index'),
+            width: 10,
+            height: 10,
+            child: CircularProgressIndicator(strokeWidth: 1.6, color: amber),
+          )
+        : Icon(Icons.circle, size: 6, color: chip.ok ? amber : fail);
+    return Row(
+      children: [
+        SizedBox(width: 10, height: 10, child: Center(child: mark)),
+        const SizedBox(width: 8),
+        Text(
+          chip.name,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            fontStyle: pending ? FontStyle.italic : FontStyle.normal,
+            color: pending ? amber : AppColors.textSecondary(context),
+          ),
+        ),
+        if (chip.detail.trim().isNotEmpty) ...[
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              chip.detail,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                fontStyle: pending ? FontStyle.italic : FontStyle.normal,
+                color: AppColors.textTertiary(context),
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 }

--- a/test/services/waifu/waifu_live_chips_test.dart
+++ b/test/services/waifu/waifu_live_chips_test.dart
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/services.dart';
+import 'package:front_porch_ai/services/waifu/waifu.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory root;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('waifu_live_chips_');
+    await File(p.join(root.path, 'notes.txt')).writeAsString('old notes');
+  });
+
+  tearDown(() async {
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  test('tool attempt emits a pending chip before the tool settles', () async {
+    final session = WaifuSession(
+      folderRoot: root.path,
+      coworker: CharacterCard(name: 'Mira', personality: 'tsundere'),
+    );
+    final llm = ScriptedWaifuLlm([
+      const LlmToolResponse(
+        calls: [
+          LlmToolCall(name: 'read', arguments: {'path': 'notes.txt'}),
+        ],
+        text: '',
+      ),
+      const LlmToolResponse(calls: [], text: 'Hmph. I read it.'),
+    ]);
+    final harness = WaifuHarness(session: session, llm: llm);
+    var sawPending = false;
+    var sawOk = false;
+    harness.onChanged = () {
+      for (final c in session.toolChips) {
+        if (c.name != 'read') continue;
+        if (c.pending) sawPending = true;
+        if (!c.pending && c.ok) sawOk = true;
+      }
+    };
+
+    await harness.send('read the notes');
+
+    expect(sawPending, isTrue);
+    expect(sawOk, isTrue);
+    expect(session.toolChips, hasLength(1));
+    expect(session.toolChips.single.pending, isFalse);
+    expect(session.toolChips.single.ok, isTrue);
+    expect(session.toolChips.single.detail, 'notes.txt');
+  });
+
+  test('failed tool flips the same pending chip to fail', () async {
+    final session = WaifuSession(
+      folderRoot: root.path,
+      coworker: CharacterCard(name: 'Mira', personality: 'tsundere'),
+    );
+    final llm = ScriptedWaifuLlm([
+      const LlmToolResponse(
+        calls: [
+          LlmToolCall(name: 'read', arguments: {'path': 'missing.txt'}),
+        ],
+        text: '',
+      ),
+      const LlmToolResponse(calls: [], text: 'Gone.'),
+    ]);
+    final harness = WaifuHarness(session: session, llm: llm);
+    var sawPending = false;
+    var sawFail = false;
+    harness.onChanged = () {
+      for (final c in session.toolChips) {
+        if (c.name != 'read') continue;
+        if (c.pending) sawPending = true;
+        if (!c.pending && !c.ok) sawFail = true;
+      }
+    };
+
+    await harness.send('read missing');
+
+    expect(sawPending, isTrue);
+    expect(sawFail, isTrue);
+    expect(session.toolChips, hasLength(1));
+    expect(session.toolChips.single.pending, isFalse);
+    expect(session.toolChips.single.ok, isFalse);
+  });
+}

--- a/test/services/waifu/waifu_live_chips_test.dart
+++ b/test/services/waifu/waifu_live_chips_test.dart
@@ -89,4 +89,46 @@ void main() {
     expect(session.toolChips.single.pending, isFalse);
     expect(session.toolChips.single.ok, isFalse);
   });
+
+  test('dispatch throw flips the pending chip to fail', () async {
+    final session = WaifuSession(
+      folderRoot: root.path,
+      coworker: CharacterCard(name: 'Mira', personality: 'tsundere'),
+      mode: WaifuMode.yolo,
+    );
+    final llm = ScriptedWaifuLlm([
+      const LlmToolResponse(
+        calls: [
+          LlmToolCall(name: 'read', arguments: {'path': 'notes.txt'}),
+        ],
+        text: '',
+      ),
+      const LlmToolResponse(calls: [], text: 'Hmph. It blew up.'),
+    ]);
+    final harness = WaifuHarness(
+      session: session,
+      llm: llm,
+      fs: _ThrowingFs(root.path),
+    );
+
+    await harness.send('read the notes');
+
+    expect(session.toolChips, hasLength(1));
+    expect(session.toolChips.single.name, 'read');
+    expect(session.toolChips.single.pending, isFalse);
+    expect(session.toolChips.single.ok, isFalse);
+    expect(session.toolChips.single.detail, contains('exploded'));
+  });
+}
+
+class _ThrowingFs extends WaifuFs {
+  _ThrowingFs(super.root);
+
+  @override
+  Future<WaifuToolResult> dispatch(
+    String name,
+    Map<String, dynamic> args,
+  ) async {
+    throw StateError('dispatch exploded');
+  }
 }

--- a/test/services/waifu/waifu_todo_contract_test.dart
+++ b/test/services/waifu/waifu_todo_contract_test.dart
@@ -26,6 +26,7 @@ void main() {
     expect(waifuLooksTodoReceiptClaim('I marked the todo completed.'), isTrue);
     expect(waifuLooksTodoReceiptClaim('Hmph. I ran todowrite.'), isTrue);
     expect(waifuLooksTodoReceiptClaim('I updated the todo list.'), isTrue);
+    expect(waifuLooksTodoReceiptClaim('I updated the todos.'), isTrue);
     expect(waifuLooksTodoReceiptClaim('Hmph. Consider it fixed.'), isFalse);
     expect(waifuLooksTodoReceiptClaim('I completed the login page.'), isFalse);
     expect(waifuLooksTodoReceiptClaim('Done.'), isFalse);

--- a/test/services/waifu/waifu_todo_contract_test.dart
+++ b/test/services/waifu/waifu_todo_contract_test.dart
@@ -1,0 +1,186 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/services.dart';
+import 'package:front_porch_ai/services/waifu/waifu.dart';
+
+void main() {
+  late Directory root;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('waifu_todo_contract_');
+  });
+
+  tearDown(() async {
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  CharacterCard iris() =>
+      CharacterCard(name: 'Iris', personality: 'proud, sharp, and teasing');
+
+  test('todo-receipt detector wants a real todo claim, not generic done', () {
+    expect(waifuLooksTodoReceiptClaim('I marked the todo completed.'), isTrue);
+    expect(waifuLooksTodoReceiptClaim('Hmph. I ran todowrite.'), isTrue);
+    expect(waifuLooksTodoReceiptClaim('I updated the todo list.'), isTrue);
+    expect(waifuLooksTodoReceiptClaim('Hmph. Consider it fixed.'), isFalse);
+    expect(waifuLooksTodoReceiptClaim('I completed the login page.'), isFalse);
+    expect(waifuLooksTodoReceiptClaim('Done.'), isFalse);
+  });
+
+  test('decideFinal: todo claim without a todowrite chip is a soft fail', () {
+    final turn = WaifuTurnContract.start('track the work', null);
+    const claim = 'Hmph. I marked the todo completed.';
+    expect(turn.decideFinal(claim), WaifuFinalAction.retryTodoWrite);
+    turn.requestTodoWrite();
+    expect(turn.decideFinal(claim), WaifuFinalAction.retryTodoWrite);
+    turn.requestTodoWrite();
+    expect(turn.decideFinal(claim), WaifuFinalAction.failTodoWrite);
+    expect(turn.failureLine(claim), contains('did not actually update'));
+  });
+
+  test('decideFinal: todo claim with a successful todowrite chip passes', () {
+    final turn = WaifuTurnContract.start('track the work', null);
+    expect(
+      turn.decideFinal(
+        'Hmph. I marked the todo completed.',
+        chips: const [
+          WaifuToolChip(name: kWaifuToolTodoWrite, detail: '1 item', ok: true),
+        ],
+      ),
+      WaifuFinalAction.accept,
+    );
+  });
+
+  test('failed or pending todowrite chips are not receipts', () {
+    final turn = WaifuTurnContract.start('track the work', null);
+    const claim = 'Hmph. I marked the todo completed.';
+    expect(
+      turn.decideFinal(
+        claim,
+        chips: const [
+          WaifuToolChip(
+            name: kWaifuToolTodoWrite,
+            detail: 'stopped',
+            ok: false,
+            pending: true,
+          ),
+        ],
+      ),
+      WaifuFinalAction.retryTodoWrite,
+    );
+    expect(
+      turn.decideFinal(
+        claim,
+        chips: const [
+          WaifuToolChip(name: kWaifuToolTodoWrite, detail: 'denied', ok: false),
+        ],
+      ),
+      WaifuFinalAction.retryTodoWrite,
+    );
+  });
+
+  test(
+    'spoken todo-complete claim without todowrite is a red failure',
+    () async {
+      final llm = ScriptedWaifuLlm([
+        for (var i = 0; i < 3; i++)
+          const LlmToolResponse(
+            calls: [],
+            text: 'Hmph. I marked the todo completed.',
+          ),
+      ]);
+      final session = WaifuSession(
+        folderRoot: root.path,
+        coworker: iris(),
+        mode: WaifuMode.yolo,
+      );
+      final harness = WaifuHarness(session: session, llm: llm);
+
+      await harness.send('track the work');
+
+      expect(harness.todos.items, isEmpty);
+      final reply = session.transcript.where((m) => !m.isUser).single;
+      expect(reply.chips.last.ok, isFalse);
+      expect(reply.chips.last.detail, contains('no todowrite receipt'));
+      expect(reply.text, contains('did not actually update the todo list'));
+      expect(reply.text, isNot(contains('marked the todo completed')));
+      expect(
+        llm.calls.skip(1).every((c) => c.prompt.contains('todowrite')),
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'spoken todo-complete claim with a successful todowrite chip passes',
+    () async {
+      final llm = ScriptedWaifuLlm([
+        const LlmToolResponse(
+          calls: [
+            LlmToolCall(
+              name: 'todowrite',
+              arguments: {
+                'todos': [
+                  {'id': '1', 'content': 'add helper', 'status': 'completed'},
+                ],
+              },
+            ),
+          ],
+          text: '',
+        ),
+        const LlmToolResponse(
+          calls: [],
+          text: 'Hmph. I marked the todo completed.',
+        ),
+      ]);
+      final session = WaifuSession(
+        folderRoot: root.path,
+        coworker: iris(),
+        mode: WaifuMode.yolo,
+      );
+      final harness = WaifuHarness(session: session, llm: llm);
+
+      await harness.send('track the work');
+
+      expect(harness.todos.items, hasLength(1));
+      expect(harness.todos.items.single.status, 'completed');
+      final reply = session.transcript.where((m) => !m.isUser).single;
+      expect(
+        reply.chips.any((c) => c.name == kWaifuToolTodoWrite && c.ok),
+        isTrue,
+      );
+      expect(
+        reply.chips.any((c) => c.detail.contains('no todowrite')),
+        isFalse,
+      );
+      expect(reply.text, 'Hmph. I marked the todo completed.');
+    },
+  );
+
+  test('think-block todowrite narration is not a spoken receipt', () async {
+    final llm = ScriptedWaifuLlm([
+      const LlmToolResponse(
+        calls: [],
+        text:
+            '<think>I called todowrite and marked it complete</think>\n'
+            'Hmph. I will look around first.',
+        reasoning: 'I called todowrite and marked it complete',
+      ),
+    ]);
+    final session = WaifuSession(
+      folderRoot: root.path,
+      coworker: iris(),
+      mode: WaifuMode.yolo,
+    );
+
+    await WaifuHarness(session: session, llm: llm).send('look around');
+
+    final reply = session.transcript.where((m) => !m.isUser).single;
+    expect(reply.text, contains('look around first'));
+    expect(reply.chips.any((c) => c.detail.contains('no todowrite')), isFalse);
+  });
+}

--- a/test/ui/waifu/waifu_pending_chip_test.dart
+++ b/test/ui/waifu/waifu_pending_chip_test.dart
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/services/waifu/waifu.dart';
+import 'package:front_porch_ai/ui/waifu/waifu.dart';
+
+void main() {
+  testWidgets('pending tool row shows a spinner, not a fail dot', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: WaifuToolLog(
+            chips: [
+              WaifuToolChip(
+                name: 'read',
+                detail: 'notes.txt',
+                ok: false,
+                pending: true,
+              ),
+              WaifuToolChip(name: 'bash', detail: 'ls -la', ok: true),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('waifu-tool-log')), findsOneWidget);
+    expect(find.byKey(const Key('waifu-tool-pending-0')), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('read'), findsOneWidget);
+    expect(find.text('notes.txt'), findsOneWidget);
+    expect(find.text('bash'), findsOneWidget);
+  });
+}

--- a/test/ui/waifu/waifu_todo_chrome_test.dart
+++ b/test/ui/waifu/waifu_todo_chrome_test.dart
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/services/waifu/waifu.dart';
+import 'package:front_porch_ai/ui/waifu/waifu.dart';
+
+void main() {
+  testWidgets('todo list uses marks, not a status: content dump', (
+    tester,
+  ) async {
+    final todos = WaifuTodos()
+      ..write([
+        {'id': '1', 'content': 'Debug the particle', 'status': 'in_progress'},
+        {'id': '2', 'content': 'Write the note', 'status': 'pending'},
+        {'id': '3', 'content': 'Ship the porch', 'status': 'completed'},
+      ]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: WaifuTodoList(todos: todos)),
+      ),
+    );
+
+    expect(find.byKey(const Key('waifu-todos')), findsOneWidget);
+    expect(find.text('Debug the particle'), findsOneWidget);
+    expect(find.text('Write the note'), findsOneWidget);
+    expect(find.text('Ship the porch'), findsOneWidget);
+    expect(find.textContaining('in_progress:'), findsNothing);
+    expect(find.textContaining('pending:'), findsNothing);
+    expect(find.textContaining('completed:'), findsNothing);
+    expect(find.text('in_progress: Debug the particle'), findsNothing);
+
+    expect(find.byIcon(Icons.play_circle_fill), findsOneWidget);
+    expect(find.byIcon(Icons.check_box_outline_blank), findsOneWidget);
+    expect(find.byIcon(Icons.check_box), findsOneWidget);
+
+    final done = tester.widget<Text>(find.text('Ship the porch'));
+    expect(done.style?.decoration, TextDecoration.lineThrough);
+    final doing = tester.widget<Text>(find.text('Debug the particle'));
+    expect(doing.style?.decoration, isNot(TextDecoration.lineThrough));
+    expect(doing.style?.fontWeight, FontWeight.w600);
+  });
+
+  testWidgets('empty todo list stays hidden', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: WaifuTodoList(todos: WaifuTodos())),
+      ),
+    );
+    expect(find.byKey(const Key('waifu-todos')), findsNothing);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Waifu Coder tool/todo **chrome** plus a claim-vs-chip turn contract. The todo **data path is correct** — a hallucinated `todowrite` does not change status because no real tool ran. Do not “fix” `write()`.

Rebased onto current Rawhide `94ff43bd` (#237 Epic B squash, which already includes #239 unit unblock). Kept both sides:

- **#238:** live pending→done chips, try/finally settle, real Tasks checklist, spoken todo / “updated the todos” / todowrite claim needs a successful todowrite chip
- **Rawhide:** `send()` user+running before any await, Plan panel `unawaited(_run)` + try/finally, Epic B verify-after-mutate

Conflict files: `waifu_harness.dart`, `waifu_harness_turn.dart`, `waifu_turn_contract.dart`. Changelog / Rawhide.md auto-merged (duplicate Plan bullet dropped). **No existing Guard tests were edited.**

The problems were:

1. **Black-box tools.** `_runTool` only `_pushChip` after `await`. `noteAttempt` did not emit UI. You saw nothing until the postmortem amber/fail chips.
2. **Tasks sludge.** The sidebar printed raw `in_progress: …` / `pending: …` as a wall of same-weight primary text.
3. **Spoken todo lies.** Thinking/Kimi can narrate “I marked it complete”, `todowrite`, or “I updated the todos” with no successful chip. Same family as sass-without-patches.
4. **Forever-pending spinner.** A mid-dispatch throw never flipped the pending chip (Bug Hunter on tip 37bb3572).

## What changed

- Pending/running chip at attempt + `_emit` immediately; that chip flips in place to ok/fail (or `stopped` on abort).
- `_runTool` wraps settle in try/catch/finally: any throw rejects the pending chip and emits; leftover pending becomes fail/stopped.
- `WaifuToolLog` shows a spinner + italic amber name while pending, then the existing amber/fail dots.
- Tasks accordion is still hidden when empty. Rows are a real list: empty checkbox (pending), amber play (in_progress), checked + strikethrough (completed). Content is the label — not `status: content`.
- Turn contract: visible speech that claims a todo completion / `todowrite` / **updated todos** (or todo list), with **no successful `todowrite` chip this turn**, soft-retries (same 2-attempt cue path) then `failTodoWrite`. Think blocks are not receipts. Pending or failed chips do not count.
- Tests: live pending→ok/fail chips; dispatch throw flips pending to fail; Tasks UI does not dump `in_progress:`; speech claim + no chip → soft reject; speech claim + successful chip → pass; “I updated the todos” is a claim.

Write replace semantics unchanged. Detector heuristic nit left as-is (not a blocker).

**Leave draft** for CoS squash. Do not squash-merge from this agent.

## Target branch

- [x] This PR targets Rawhide

## Type of change

- [x] Bug fix (chrome / visibility / pending settle)
- [x] New feature (live pending chips + todo-claim contract)

## How was this tested?

Tested on: Linux sandbox (no Flutter SDK / no display — cannot launch the desktop app or run `flutter test` here)

- [ ] Targeted waifu chrome/todo/plan/shell tests — **rely on CI** on this tip
- [ ] Ran the app by hand — **no**: headless sandbox without Flutter

## Parity

- [x] Not applicable / desktop-only Waifu Coder surface

## Checklist

- [x] New files carry the AGPL header
- [x] New/refactored UI uses `AppColors`
- [x] I did not run `dart format` over the whole tree
- [x] I did not edit `pubspec.yaml`
- [x] No merge requested
- [x] No existing Guard-protected tests edited (no `approved-test-change` needed for this rebase)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad8cdf49-28ec-4c97-b25f-7621ba1ee885?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad8cdf49-28ec-4c97-b25f-7621ba1ee885&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

