### PR TITLE
fix(waifu): unblock unit CI after Plan P0 Accept hang and missing thoughts

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,3 +1,15 @@
+## 2026-09-08 — fix(waifu): unit CI hang after Plan P0 + mid-stream thoughts
+- **Why:** After #236, `Tests (unit + integration)` was deterministically
+  red. `waifu_plan_panel_test` Accept→Build hung 10 minutes (`tester.tap`
+  + async `onPressed` + dart:io vs FakeAsync). Thought-token chrome
+  missed mid-stream text because `send()` awaited `_refreshPlanBlock()`
+  before recording the user line / `running`.
+- **What:** Record user message + `running` before any await. Accept
+  buttons use `unawaited(_run(…))`. Widget test drives
+  `acceptActivePlan(editedBody:)` inside `runAsync` (no tap). Sync-prefix
+  + encode/parse pins. Existing tests under Guard were edited.
+- **Commit:** (this tip)
+
 ## 2026-09-08 — test(waifu): Plan MCP chips are not .single after receipt
 - **Why:** Unit CI red on cb441af6. Plan receipt always-on retries after a
   blocked mutating MCP call, so `toolChips.single` threw Too many elements.

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,3 +1,12 @@
+## 2026-09-08 — fix(waifu): Plan panel _run clears busy after throw
+- **Why:** Senior Dev residual on #239. Accept/Revise/Discard now
+  `unawaited(_run(…))`. If `fn()` or `_reload()` threw, `_busy` stayed
+  true and the buttons died.
+- **What:** `try/finally` clears `_busy` when still mounted. Flash/ok
+  only on success. Did not widen `send()` (pre-gen I/O still sits
+  after `running=true`, outside that try).
+- **Commit:** (this tip)
+
 ## 2026-09-08 — fix(waifu): unit CI hang after Plan P0 + mid-stream thoughts
 - **Why:** After #236, `Tests (unit + integration)` was deterministically
   red. `waifu_plan_panel_test` Accept→Build hung 10 minutes (`tester.tap`

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -5,9 +5,10 @@
   missed mid-stream text because `send()` awaited `_refreshPlanBlock()`
   before recording the user line / `running`.
 - **What:** Record user message + `running` before any await. Accept
-  buttons use `unawaited(_run(…))`. Widget test drives
-  `acceptActivePlan(editedBody:)` inside `runAsync` (no tap). Sync-prefix
-  + encode/parse pins. Existing tests under Guard were edited.
+  buttons use `unawaited(_run(…))`. Accept product pin is a plain
+  `test()` (FakeAsync + dart:io still hung even inside `runAsync`).
+  Widget test only mounts the button. Sync-prefix + encode/parse pins.
+  Existing tests under Guard were edited.
 - **Commit:** (this tip)
 
 ## 2026-09-08 — test(waifu): Plan MCP chips are not .single after receipt

--- a/lib/services/waifu/waifu_harness.dart
+++ b/lib/services/waifu/waifu_harness.dart
@@ -164,12 +164,15 @@ class WaifuHarness {
       mode: session.mode,
       exploreOnly: exploreOnly,
     );
-    await _refreshPlanBlock();
+    // Record the send before any await. Plan-file I/O used to sit here
+    // first (#236), so a kicked-off send left transcript empty and
+    // mid-stream thought chrome never painted.
     session.running = true;
     session.transcript.add(
       WaifuMessage(isUser: true, text: text, imagePath: imagePath),
     );
     if (session.title.isEmpty) session.title = waifuTitleFrom(text);
+    await _refreshPlanBlock();
     _mentionBlock = await waifuExpandMentions(text, session.folderRoot);
     waifuRewriteSlashUser(session.transcript, text);
     await skills.refreshLocal();

--- a/lib/ui/waifu/waifu_plan_panel.dart
+++ b/lib/ui/waifu/waifu_plan_panel.dart
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Front Porch AI. If not, see <https://www.gnu.org/licenses/>.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:front_porch_ai/services/waifu/waifu.dart';
@@ -173,11 +175,15 @@ class _WaifuPlanPanelState extends State<WaifuPlanPanel> {
                   key: const Key('waifu-plan-accept'),
                   onPressed: _busy
                       ? null
-                      : () => _run(() async {
-                          await widget.harness?.acceptActivePlan(
-                            editedBody: _body.text,
+                      : () {
+                          unawaited(
+                            _run(() async {
+                              await widget.harness?.acceptActivePlan(
+                                editedBody: _body.text,
+                              );
+                            }, 'Accepted — Build'),
                           );
-                        }, 'Accepted — Build'),
+                        },
                   style: FilledButton.styleFrom(
                     backgroundColor: amber,
                     foregroundColor: AppColors.onChaosAccent,
@@ -189,20 +195,28 @@ class _WaifuPlanPanelState extends State<WaifuPlanPanel> {
                   key: const Key('waifu-plan-revise'),
                   onPressed: _busy
                       ? null
-                      : () => _run(() async {
-                          await widget.harness?.reviseActivePlan(
-                            editedBody: _body.text,
+                      : () {
+                          unawaited(
+                            _run(() async {
+                              await widget.harness?.reviseActivePlan(
+                                editedBody: _body.text,
+                              );
+                            }, 'Back to Plan'),
                           );
-                        }, 'Back to Plan'),
+                        },
                   child: const Text('Revise'),
                 ),
                 TextButton(
                   key: const Key('waifu-plan-discard'),
                   onPressed: _busy
                       ? null
-                      : () => _run(() async {
-                          await widget.harness?.discardActivePlan();
-                        }, 'Pin cleared'),
+                      : () {
+                          unawaited(
+                            _run(() async {
+                              await widget.harness?.discardActivePlan();
+                            }, 'Pin cleared'),
+                          );
+                        },
                   child: const Text('Discard'),
                 ),
               ],

--- a/lib/ui/waifu/waifu_plan_panel.dart
+++ b/lib/ui/waifu/waifu_plan_panel.dart
@@ -95,15 +95,22 @@ class _WaifuPlanPanelState extends State<WaifuPlanPanel> {
       _busy = true;
       _flash = '';
     });
-    await fn();
-    if (!mounted) return;
-    await _reload();
-    if (!mounted) return;
-    setState(() {
-      _busy = false;
-      _flash = ok;
-    });
-    widget.onChanged?.call();
+    var succeeded = false;
+    try {
+      await fn();
+      if (!mounted) return;
+      await _reload();
+      if (!mounted) return;
+      succeeded = true;
+      widget.onChanged?.call();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _busy = false;
+          if (succeeded) _flash = ok;
+        });
+      }
+    }
   }
 
   @override

--- a/test/services/waifu/waifu_plan_encode_parse_test.dart
+++ b/test/services/waifu/waifu_plan_encode_parse_test.dart
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/services/waifu/waifu.dart';
+
+const _widgetFixture = '''
+---
+id: empty-email
+slug: empty-email
+title: Empty email fix
+goal: Make the empty-email test pass
+status: draft
+steps:
+- id: s1
+  title: Add failing test
+  status: pending
+---
+
+# Empty email fix
+''';
+
+void main() {
+  test('encode then parse of the Accept panel fixture', () {
+    const rel = '.waifu/plans/empty-email.md';
+    final seeded = waifuPlanParse(_widgetFixture, relativePath: rel);
+    final encoded = waifuPlanEncode(seeded);
+    final again = waifuPlanParse(encoded, relativePath: rel);
+    expect(again.id, seeded.id);
+    expect(again.steps, hasLength(1));
+    expect(again.steps.single.id, 's1');
+    expect(again.status, WaifuPlanStatus.draft);
+    final accepted = waifuPlanEncode(
+      again.copyWith(status: WaifuPlanStatus.accepted),
+    );
+    expect(
+      waifuPlanParse(accepted, relativePath: rel).status,
+      WaifuPlanStatus.accepted,
+    );
+  }, timeout: const Timeout(Duration(seconds: 3)));
+}

--- a/test/services/waifu/waifu_send_sync_prefix_test.dart
+++ b/test/services/waifu/waifu_send_sync_prefix_test.dart
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Front Porch AI
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:front_porch_ai/models/models.dart';
+import 'package:front_porch_ai/services/llm_service.dart';
+import 'package:front_porch_ai/services/waifu/waifu.dart';
+
+void main() {
+  test('send records the user line before any await', () async {
+    final root = await Directory.systemTemp.createTemp('waifu_send_sync_');
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+    final session = WaifuSession(
+      folderRoot: root.path,
+      coworker: CharacterCard(name: 'Mira'),
+    );
+    final harness = WaifuHarness(
+      session: session,
+      llm: ScriptedWaifuLlm(const [LlmToolResponse(calls: [], text: 'Hmph.')]),
+    );
+    final done = harness.send('count');
+    expect(session.running, isTrue);
+    expect(session.transcript, isNotEmpty);
+    expect(session.transcript.first.isUser, isTrue);
+    expect(session.transcript.first.text, 'count');
+    await done;
+  });
+}

--- a/test/ui/waifu/waifu_chat_shell_test.dart
+++ b/test/ui/waifu/waifu_chat_shell_test.dart
@@ -91,11 +91,20 @@ void main() {
     late Future<void> done;
     await tester.runAsync(() async {
       done = harness.send('count');
-      for (var i = 0; i < 40 && s.transcript.last.reasoning.isEmpty; i++) {
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+      for (var i = 0; i < 100; i++) {
+        if (s.transcript.any((m) => !m.isUser && m.reasoning.isNotEmpty)) {
+          break;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 20));
       }
     });
     await tester.pump();
+    expect(
+      s.transcript.any(
+        (m) => !m.isUser && m.reasoning.contains('one two three'),
+      ),
+      isTrue,
+    );
     expect(find.textContaining('one two three'), findsWidgets);
     expect(find.textContaining('Thinking'), findsWidgets);
 

--- a/test/ui/waifu/waifu_plan_panel_test.dart
+++ b/test/ui/waifu/waifu_plan_panel_test.dart
@@ -113,6 +113,7 @@ void main() {
     ).readAsStringSync();
     expect(panelSrc, contains('acceptActivePlan'));
     expect(panelSrc, contains("'Accepted — Build'"));
+    expect(panelSrc, contains('finally'));
   }, timeout: const Timeout(Duration(seconds: 10)));
 
   test('draft plan blocks Build; freeform Build does not', () async {

--- a/test/ui/waifu/waifu_plan_panel_test.dart
+++ b/test/ui/waifu/waifu_plan_panel_test.dart
@@ -115,9 +115,7 @@ void main() {
     expect(panelSrc, contains("'Accepted — Build'"));
   }, timeout: const Timeout(Duration(seconds: 10)));
 
-  testWidgets('draft plan blocks the Build chip; freeform Build does not', (
-    tester,
-  ) async {
+  test('draft plan blocks Build; freeform Build does not', () async {
     final root = await Directory.systemTemp.createTemp('waifu_plan_gate_');
     addTearDown(() async {
       if (await root.exists()) await root.delete(recursive: true);
@@ -131,31 +129,10 @@ void main() {
       mode: WaifuMode.plan,
       activePlanPath: rel,
     );
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: StatefulBuilder(
-            builder: (context, setState) {
-              return WaifuModeBar(
-                mode: draft.mode,
-                onChanged: (next) {
-                  waifuTrySetMode(session: draft, next: next).then((_) {
-                    setState(() {});
-                  });
-                },
-              );
-            },
-          ),
-        ),
-      ),
+    expect(
+      await waifuTrySetMode(session: draft, next: WaifuMode.build),
+      WaifuModeApply.blockedDraft,
     );
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('waifu-mode-build')));
-    await tester.pump();
-    await tester.runAsync(
-      () => Future<void>.delayed(const Duration(milliseconds: 80)),
-    );
-    await tester.pump();
     expect(draft.mode, WaifuMode.plan);
 
     final freeRoot = await Directory.systemTemp.createTemp('waifu_plan_free_');
@@ -167,31 +144,22 @@ void main() {
       coworker: CharacterCard(name: 'Mira'),
       mode: WaifuMode.plan,
     );
+    expect(
+      await waifuTrySetMode(session: free, next: WaifuMode.build),
+      WaifuModeApply.applied,
+    );
+    expect(free.mode, WaifuMode.build);
+  });
+
+  testWidgets('Build chip is on the mode bar', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: StatefulBuilder(
-            builder: (context, setState) {
-              return WaifuModeBar(
-                mode: free.mode,
-                onChanged: (next) {
-                  waifuTrySetMode(session: free, next: next).then((_) {
-                    setState(() {});
-                  });
-                },
-              );
-            },
-          ),
+          body: WaifuModeBar(mode: WaifuMode.plan, onChanged: (_) {}),
         ),
       ),
     );
     await tester.pump();
-    await tester.tap(find.byKey(const Key('waifu-mode-build')));
-    await tester.pump();
-    await tester.runAsync(
-      () => Future<void>.delayed(const Duration(milliseconds: 80)),
-    );
-    await tester.pump();
-    expect(free.mode, WaifuMode.build);
-  }, timeout: const Timeout(Duration(seconds: 15)));
+    expect(find.byKey(const Key('waifu-mode-build')), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 10)));
 }

--- a/test/ui/waifu/waifu_plan_panel_test.dart
+++ b/test/ui/waifu/waifu_plan_panel_test.dart
@@ -37,10 +37,8 @@ void main() {
     expect(sidebar, isNot(contains("id: 'waifu_plan'")));
   });
 
-  testWidgets('main-stage Accept → Build flips the session mode', (
-    tester,
-  ) async {
-    final root = await Directory.systemTemp.createTemp('waifu_plan_ui_');
+  test('Accept → Build flips mode and writes accepted status', () async {
+    final root = await Directory.systemTemp.createTemp('waifu_plan_accept_');
     addTearDown(() async {
       if (await root.exists()) await root.delete(recursive: true);
     });
@@ -59,7 +57,26 @@ void main() {
       llm: ScriptedWaifuLlm(const []),
     );
     final seeded = waifuPlanParse(_planMd, relativePath: rel);
+    await harness.acceptActivePlan(editedBody: waifuPlanEncode(seeded));
+    expect(session.mode, WaifuMode.build);
+    expect(session.activePlanPath, rel);
+    expect(
+      waifuPlanParse(await file.readAsString()).status,
+      WaifuPlanStatus.accepted,
+    );
+  });
 
+  testWidgets('main-stage Accept button is bound', (tester) async {
+    final session = WaifuSession(
+      folderRoot: Directory.systemTemp.path,
+      coworker: CharacterCard(name: 'Mira'),
+      mode: WaifuMode.plan,
+      activePlanPath: '.waifu/plans/empty-email.md',
+    );
+    final seeded = waifuPlanParse(
+      _planMd,
+      relativePath: session.activePlanPath!,
+    );
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -68,7 +85,10 @@ void main() {
               key: const Key('waifu-plan-stage'),
               child: WaifuPlanPanel(
                 session: session,
-                harness: harness,
+                harness: WaifuHarness(
+                  session: session,
+                  llm: ScriptedWaifuLlm(const []),
+                ),
                 initialPlan: seeded,
               ),
             ),
@@ -88,25 +108,12 @@ void main() {
       isNotNull,
     );
     expect(session.mode, WaifuMode.plan);
-
-    // tester.tap + async onPressed + dart:io deadlocks FakeAsync (CI
-    // 10-minute hang). Call the same method the Accept button uses.
-    late String acceptedRaw;
-    await tester.runAsync(() async {
-      await harness.acceptActivePlan(editedBody: waifuPlanEncode(seeded));
-      acceptedRaw = await file.readAsString();
-    });
-    await tester.pump();
-
-    expect(session.mode, WaifuMode.build);
-    expect(session.activePlanPath, rel);
-    expect(waifuPlanParse(acceptedRaw).status, WaifuPlanStatus.accepted);
     final panelSrc = File(
       'lib/ui/waifu/waifu_plan_panel.dart',
     ).readAsStringSync();
     expect(panelSrc, contains('acceptActivePlan'));
     expect(panelSrc, contains("'Accepted — Build'"));
-  }, timeout: const Timeout(Duration(seconds: 30)));
+  }, timeout: const Timeout(Duration(seconds: 10)));
 
   testWidgets('draft plan blocks the Build chip; freeform Build does not', (
     tester,
@@ -186,5 +193,5 @@ void main() {
     );
     await tester.pump();
     expect(free.mode, WaifuMode.build);
-  });
+  }, timeout: const Timeout(Duration(seconds: 15)));
 }

--- a/test/ui/waifu/waifu_plan_panel_test.dart
+++ b/test/ui/waifu/waifu_plan_panel_test.dart
@@ -81,26 +81,32 @@ void main() {
     expect(find.byKey(const Key('waifu-plan-stage')), findsOneWidget);
     expect(find.byKey(const Key('waifu-plan-panel')), findsOneWidget);
     expect(find.byKey(const Key('waifu-plan-accept')), findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const Key('waifu-plan-accept')))
+          .onPressed,
+      isNotNull,
+    );
     expect(session.mode, WaifuMode.plan);
 
+    // tester.tap + async onPressed + dart:io deadlocks FakeAsync (CI
+    // 10-minute hang). Call the same method the Accept button uses.
+    late String acceptedRaw;
     await tester.runAsync(() async {
-      await tester.tap(find.byKey(const Key('waifu-plan-accept')));
-      final deadline = DateTime.now().add(const Duration(seconds: 2));
-      while (session.mode != WaifuMode.build &&
-          DateTime.now().isBefore(deadline)) {
-        await Future<void>.delayed(const Duration(milliseconds: 20));
-      }
+      await harness.acceptActivePlan(editedBody: waifuPlanEncode(seeded));
+      acceptedRaw = await file.readAsString();
     });
     await tester.pump();
 
     expect(session.mode, WaifuMode.build);
     expect(session.activePlanPath, rel);
-    expect(
-      waifuPlanParse(await file.readAsString()).status,
-      WaifuPlanStatus.accepted,
-    );
-    expect(find.text('Accepted — Build'), findsOneWidget);
-  });
+    expect(waifuPlanParse(acceptedRaw).status, WaifuPlanStatus.accepted);
+    final panelSrc = File(
+      'lib/ui/waifu/waifu_plan_panel.dart',
+    ).readAsStringSync();
+    expect(panelSrc, contains('acceptActivePlan'));
+    expect(panelSrc, contains("'Accepted — Build'"));
+  }, timeout: const Timeout(Duration(seconds: 30)));
 
   testWidgets('draft plan blocks the Build chip; freeform Build does not', (
     tester,
@@ -137,10 +143,11 @@ void main() {
       ),
     );
     await tester.pump();
-    await tester.runAsync(() async {
-      await tester.tap(find.byKey(const Key('waifu-mode-build')));
-      await Future<void>.delayed(const Duration(milliseconds: 80));
-    });
+    await tester.tap(find.byKey(const Key('waifu-mode-build')));
+    await tester.pump();
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 80)),
+    );
     await tester.pump();
     expect(draft.mode, WaifuMode.plan);
 
@@ -172,10 +179,11 @@ void main() {
       ),
     );
     await tester.pump();
-    await tester.runAsync(() async {
-      await tester.tap(find.byKey(const Key('waifu-mode-build')));
-      await Future<void>.delayed(const Duration(milliseconds: 80));
-    });
+    await tester.tap(find.byKey(const Key('waifu-mode-build')));
+    await tester.pump();
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 80)),
+    );
     await tester.pump();
     expect(free.mode, WaifuMode.build);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Rawhide unit CI went deterministically red after Plan P0 (#236). Analyze, goldens, and E2E stayed green; `Tests (unit + integration)` hung or failed. Same two failures blocked stacked PRs #237/#238. Requeue does not help.

**Root cause (two independent #236 regressions):**

1. **Accept hang** — `waifu_plan_panel_test` tapped `Key('waifu-plan-accept')` inside `tester.runAsync` while `onPressed` returned a Future that does dart:io (`acceptActivePlan` → write/reload plan). `TestAsyncUtils.guard` + FakeAsync never drain that I/O, so the test sat until Flutter’s 10-minute timeout and then killed the 20-minute job. **`await harness.acceptActivePlan(...)` inside `runAsync` also hung 30s** on this runner — same class. Chip-tap draft-gate hung the same way (15s). Product Accept/gate are fine in plain (non-widget) tests. Encode→parse of the panel fixture is **not** an infinite loop.
2. **Thought tokens** — `#236` inserted `await _refreshPlanBlock()` **before** recording the user line / `running`. The shell test immediately inspects `transcript` mid-`send()`. Empty list / no assistant reasoning → 0 widgets for `one two three` / Thinking. Mid-stream thought chrome is intentional.

**Senior Dev residual (this tip):** After `unawaited(_run(…))`, a throw from `fn()` or `_reload()` left `_busy` true forever and killed Accept/Revise/Discard. `_run` now uses `try/finally` so `_busy` clears when still mounted; flash/ok stay success-only. Did **not** widen `send()` — `_refreshPlanBlock` / mentions / skills still sit after `running=true` outside that try (pre-existing; not a one-liner).

## What changed

- `send()` records the user message and `running` **before any await**. Plan I/O still happens before `_loop()`.
- Accept/Revise/Discard `onPressed` is a `VoidCallback` via `unawaited(_run(…))`.
- `_run` wraps work in `try/finally` and always clears `_busy` if mounted.
- Accept + draft-gate **product pins are plain `test()`** (outside FakeAsync). Widget tests only mount the Accept button / Build chip and source-pin the panel (including `finally`).
- Thought-token wait no longer uses `.last` on an empty transcript.
- New pins: `waifu_send_sync_prefix_test.dart`, `waifu_plan_encode_parse_test.dart`.

## Guard

**Existing tests under Guard were edited** so CoS can label `approved-test-change`:

- `test/ui/waifu/waifu_plan_panel_test.dart`
- `test/ui/waifu/waifu_chat_shell_test.dart`

New test files are additive (no Guard issue).

## Target branch

- [x] This PR targets Rawhide. **Do not merge** until CoS/CI review.

## Type of change

- [x] Bug fix

## How was this tested?

Tested on: Linux (sandbox). Could not launch the desktop app (no display).

- [x] `flutter analyze` on touched paths — clean
- [x] `flutter test test/ui/waifu/waifu_plan_panel_test.dart test/ui/waifu/waifu_chat_shell_test.dart` — **7 passed in ~7s** after `_run` finally
- [ ] Did **not** run the app by hand in this sandbox

## Residual

- `#237` `waifu_loop_chrome_test` speech misses are **not** in this PR.
- Widget tests no longer physically tap Accept / Build. Product paths are the same methods the chrome calls (`acceptActivePlan`, `waifuTrySetMode`).
- `send()` pre-gen I/O after `running=true` still sits outside that method’s `try` (left as noted).

## Parity

- [x] Not applicable — Waifu Coder desktop-only; no web_ui Plan panel / thought chrome twin. Not ChatService Realism/Needs.

## Checklist

- [x] New files carry the AGPL header
- [x] No `dart format .` (per-file only)
- [x] Did not edit `pubspec.yaml`
- [x] Public identity only: Sosuke Aizen / linux4life1

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4a1f49c-3c3e-4480-a345-b1f1e7f6f255?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4a1f49c-3c3e-4480-a345-b1f1e7f6f255&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

