### PR TITLE
fix(waifu): restore Rawhide tip unit green after overnight sit-down

### DIFF
--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -1,3 +1,19 @@
+## 2026-09-09 — fix(waifu): restore tip unit green after overnight sit-down
+- **Why:** Rawhide tip `e29dff59` went red on six Waifu unit tests after
+  the sit-down / verify-before-speech / compact overnight. Sit-down
+  Confirm never fired `onSatDown` because `waifuLoadTodos` awaited disk
+  on the widget-test clock. `/init` still expected a Build ask after
+  in-porch writes stopped asking. Chrome and `turnVerifyPaths` still
+  treated re-read-only as a finished turn.
+- **What:** Confirm hands off the session before any disk read.
+  `/init` + work-strip + loop-chrome scripts match the shipped contract
+  (porch writes do not ask; wrap-up needs re-read AND test/analyze).
+  `/build` slash blurb no longer claims she asks on the first write.
+- **Files:** `waifu_wizard_page.dart`, `waifu_slash.dart`,
+  `waifu_slice_e_test.dart`, `waifu_tools_fail_closed_test.dart`,
+  `waifu_loop_chrome_test.dart`
+- **Commit:** (this commit)
+
 ## 2026-09-09 — fix(waifu): real context meter + OpenCode-style compact
 - **Why:** The sidebar bar was chars÷4 of the user prompt, so system and
   tool schemas were invisible, and every send folded the transcript at

--- a/.claude/changelog.md
+++ b/.claude/changelog.md
@@ -12,7 +12,7 @@
 - **Files:** `waifu_wizard_page.dart`, `waifu_slash.dart`,
   `waifu_slice_e_test.dart`, `waifu_tools_fail_closed_test.dart`,
   `waifu_loop_chrome_test.dart`
-- **Commit:** (this commit)
+- **Commit:** c140247f
 
 ## 2026-09-09 — fix(waifu): real context meter + OpenCode-style compact
 - **Why:** The sidebar bar was chars÷4 of the user prompt, so system and

--- a/lib/services/waifu/waifu_slash.dart
+++ b/lib/services/waifu/waifu_slash.dart
@@ -80,7 +80,9 @@ const kWaifuSlashCommands = <WaifuSlashCommand>[
   WaifuSlashCommand(
     name: 'build',
     hint: '/build',
-    blurb: 'Switch to Build — asks on the first write, then goes.',
+    blurb:
+        'Switch to Build — in-folder writes just happen; mutating bash '
+        'and off-porch paths still ask.',
   ),
   WaifuSlashCommand(
     name: 'yolo',

--- a/lib/ui/waifu/waifu_wizard_page.dart
+++ b/lib/ui/waifu/waifu_wizard_page.dart
@@ -129,12 +129,12 @@ class _WaifuWizardPageState extends State<WaifuWizardPage> {
       pathMode: _pathMode,
       toolsSupported: widget.toolsSupported,
     );
-    await waifuLoadTodos(_path, session.todos);
     final onSat = widget.onSatDown;
     if (onSat != null) {
       onSat(session);
       return;
     }
+    await waifuLoadTodos(_path, session.todos);
     await waifuPrepareLangs(session);
     if (!mounted) return;
     Navigator.of(context).pushReplacement(

--- a/test/services/waifu/waifu_slice_e_test.dart
+++ b/test/services/waifu/waifu_slice_e_test.dart
@@ -147,17 +147,22 @@ void main() {
     expect(llm.calls.last.prompt, contains('Be terse.'));
   });
 
-  test('/init does not write AGENTS.md when Build denies', () async {
+  test('/init writes AGENTS.md in Build without asking', () async {
+    var asked = 0;
     final llm = ScriptedWaifuLlm([
       const LlmToolResponse(calls: [], text: 'idle'),
     ]);
     final harness = WaifuHarness(
       session: _session(root.path, WaifuMode.build),
       llm: llm,
-      onAsk: (req) async => WaifuAskDecision.deny,
+      onAsk: (req) async {
+        asked++;
+        return WaifuAskDecision.deny;
+      },
     );
     await harness.send('/init');
-    expect(File(p.join(root.path, 'AGENTS.md')).existsSync(), isFalse);
+    expect(asked, 0);
+    expect(File(p.join(root.path, 'AGENTS.md')).existsSync(), isTrue);
   });
 
   test('/init writes AGENTS.md in Yolo', () async {

--- a/test/services/waifu/waifu_tools_fail_closed_test.dart
+++ b/test/services/waifu/waifu_tools_fail_closed_test.dart
@@ -24,6 +24,8 @@ import 'package:front_porch_ai/services/llm_service.dart';
 import 'package:front_porch_ai/services/waifu/waifu.dart';
 import 'package:path/path.dart' as p;
 
+import 'waifu_analyze_bash.dart';
+
 void main() {
   test('resolve + can-use fail closed on unsupported or paused', () {
     expect(
@@ -61,10 +63,10 @@ void main() {
     final llm = ScriptedWaifuLlm([
       const LlmToolResponse(
         calls: [
-          LlmToolCall(name: 'write', arguments: {
-            'path': 'hello.txt',
-            'contents': 'nope',
-          }),
+          LlmToolCall(
+            name: 'write',
+            arguments: {'path': 'hello.txt', 'contents': 'nope'},
+          ),
         ],
         text: '',
       ),
@@ -108,6 +110,7 @@ void main() {
         ],
         text: '',
       ),
+      const LlmToolResponse(calls: [kWaifuAnalyzeCall], text: ''),
       const LlmToolResponse(calls: [], text: 'Both files are down.'),
     ]);
     final session = WaifuSession(
@@ -115,41 +118,45 @@ void main() {
       coworker: CharacterCard(name: 'Mira', personality: 'dry'),
       mode: WaifuMode.yolo,
     );
-    await WaifuHarness(session: session, llm: llm).send('add a.txt and b.txt');
+    await WaifuHarness(
+      session: session,
+      llm: llm,
+      bash: WaifuAnalyzeBash(root.path),
+    ).send('add a.txt and b.txt');
 
-    expect(
-      session.turnWrites.map((w) => w.relativePath).toList(),
-      ['a.txt', 'b.txt'],
-    );
+    expect(session.turnWrites.map((w) => w.relativePath).toList(), [
+      'a.txt',
+      'b.txt',
+    ]);
     expect(session.lastWrite?.relativePath, 'b.txt');
     expect(waifuTurnReceiptHeadline(session.turnWrites), '2 files this turn');
     expect(session.turnVerifyPaths, containsAll(['a.txt', 'b.txt']));
   });
 
-  test('send does not loop when the LLM door is toolsSupported false', () async {
-    final root = await Directory.systemTemp.createTemp('waifu_tools_llm_');
-    addTearDown(() async {
-      if (await root.exists()) await root.delete(recursive: true);
-    });
-    final llm = ScriptedWaifuLlm(
-      [
+  test(
+    'send does not loop when the LLM door is toolsSupported false',
+    () async {
+      final root = await Directory.systemTemp.createTemp('waifu_tools_llm_');
+      addTearDown(() async {
+        if (await root.exists()) await root.delete(recursive: true);
+      });
+      final llm = ScriptedWaifuLlm([
         const LlmToolResponse(calls: [], text: 'I can code just fine.'),
-      ],
-      toolsSupported: false,
-    );
-    final session = WaifuSession(
-      folderRoot: root.path,
-      coworker: CharacterCard(name: 'Mira', personality: 'dry'),
-    );
-    await WaifuHarness(session: session, llm: llm).send('fix the test');
+      ], toolsSupported: false);
+      final session = WaifuSession(
+        folderRoot: root.path,
+        coworker: CharacterCard(name: 'Mira', personality: 'dry'),
+      );
+      await WaifuHarness(session: session, llm: llm).send('fix the test');
 
-    expect(llm.calls, isEmpty);
-    expect(session.transcript.last.text, kWaifuToolsUnsupported);
-    expect(
-      session.transcript.any((m) => m.text.contains('I can code just fine')),
-      isFalse,
-    );
-  });
+      expect(llm.calls, isEmpty);
+      expect(session.transcript.last.text, kWaifuToolsUnsupported);
+      expect(
+        session.transcript.any((m) => m.text.contains('I can code just fine')),
+        isFalse,
+      );
+    },
+  );
 
   test('store round-trips toolsSupported false', () async {
     final dir = await Directory.systemTemp.createTemp('waifu_tools_store_');

--- a/test/ui/waifu/waifu_loop_chrome_test.dart
+++ b/test/ui/waifu/waifu_loop_chrome_test.dart
@@ -27,6 +27,8 @@ import 'package:front_porch_ai/services/llm_service.dart';
 import 'package:front_porch_ai/ui/waifu/waifu_page.dart';
 import 'package:path/path.dart' as p;
 
+import '../../services/waifu/waifu_analyze_bash.dart';
+
 void main() {
   late Directory root;
 
@@ -60,10 +62,15 @@ void main() {
         ],
         text: '',
       ),
+      const LlmToolResponse(calls: [kWaifuAnalyzeCall], text: ''),
       const LlmToolResponse(calls: [], text: 'Hmph. There. hello.txt.'),
     ]);
     final s = session();
-    final harness = WaifuHarness(session: s, llm: llm);
+    final harness = WaifuHarness(
+      session: s,
+      llm: llm,
+      bash: WaifuAnalyzeBash(root.path),
+    );
     await tester.pumpWidget(
       MaterialApp(
         home: WaifuPage(session: s, harness: harness),
@@ -118,13 +125,18 @@ void main() {
           ],
           text: '',
         ),
+        const LlmToolResponse(calls: [kWaifuAnalyzeCall], text: ''),
         const LlmToolResponse(
           calls: [],
           text: 'Hmph. Your parser is fixed. Try to keep up.',
         ),
       ]);
       final s = session()..mode = WaifuMode.yolo;
-      final harness = WaifuHarness(session: s, llm: llm);
+      final harness = WaifuHarness(
+        session: s,
+        llm: llm,
+        bash: WaifuAnalyzeBash(root.path),
+      );
       await tester.pumpWidget(
         MaterialApp(
           home: WaifuPage(session: s, harness: harness),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Rawhide tip `e29dff59` is unit+integration red: https://github.com/linux4life1/front-porch-AI/actions/runs/34325655907

Last green tip was `66913ac`. Overnight Waifu sit-down / verify-before-speech / compact landed four real mismatches:

1. **Sit-down Confirm** (`waifu_wizard_test`) — `await waifuLoadTodos` ran *before* `onSatDown`. Widget-test FakeAsync never completes `exists()`/`read`, so Confirm looked tapped and `sat` stayed null (line 119). Product fix: hand off the session first; production still loads todos before opening the page.

2. **`/init` + Build deny** (`waifu_slice_e_test`) — sit-down already consented to the folder. In-porch `write` (including `/init` → `AGENTS.md`) no longer asks. The deny pin was stale. Test now asserts Build does not ask and still writes.

3. **`turnVerifyPaths` empty** (`waifu_tools_fail_closed_test`) — writes *did* land (`turnWrites` was `a.txt, b.txt`). CI line 126 failed because verify is now re-read **and** a real test/analyze. Script was re-read-only.

4. **Missing “Hmph. There” / parser speech** (`waifu_loop_chrome_test`) — same contract: wrap-up is rejected until analyze/test passes, so the failure line replaced the in-character bubble.

`/build` slash blurb no longer claims she asks on the first write.

**approved-test-change:** three existing test files updated to the shipped contract. Do not treat this as watering down — the overnight product is keep; the scripts were behind it.

## Target branch

- [x] This PR targets Rawhide

## Type of change

- [x] Bug fix

## How was this tested?

Tested on: Linux cloud agent, Flutter 3.47.0 / Dart 3.13.0. Cannot launch the desktop app (no display).

- [x] `flutter analyze --no-fatal-warnings --no-fatal-infos` on touched paths: **No issues found**
- [x] `dart fix --dry-run` on `waifu_wizard_page.dart`: **Nothing to fix**
- [x] The six previously red cases + siblings (`waifu_bash_ask`, `waifu_sit_down`, `waifu_checkin`): **29 passed**
- [x] Red-green: putting `waifuLoadTodos` back before `onSatDown` fails Confirm (`sat` null, line 119); restore green. Removing the analyze step from the chrome script fails `Hmph. There`; restore green.
- [ ] Ran the app by hand — **no**: headless sandbox

## Parity

- [x] Not applicable / Waifu Coder is desktop-only; no web sit-down or `/init` surface. Realism/Needs untouched.

## Checklist

- [x] No new files (existing AGPL headers stay)
- [x] No new UI chrome / AppColors
- [x] Per-file `dart format` only
- [x] Did not edit `pubspec.yaml`
- [x] Needs maintainer `approved-test-change` for the three existing test files

## Tip SHA + root cause

- Tip: `e29dff5933e30c89fc9891f2b70231f42e1bfa5a`
- Last green: `66913ac`
- Breakers: `16f668df` (porch writes skip ask; todos load on Confirm), `582b11ea` (verify = re-read AND test/analyze)

Do not merge. Draft only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d58dfc1-d291-47b7-8790-933c749b9925?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d58dfc1-d291-47b7-8790-933c749b9925&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

